### PR TITLE
Ignore "error" from a commit with changes.

### DIFF
--- a/asv/benchmarks.py
+++ b/asv/benchmarks.py
@@ -86,7 +86,7 @@ def run_benchmark(benchmark, root, env, show_stderr=False, quick=False,
                  profile_path],
                 dots=False, timeout=benchmark['timeout'],
                 display_error=False, return_stderr=True,
-                error=False)
+                valid_return_codes=None)
             if errcode:
                 log.add(" failed".format(name))
             else:

--- a/asv/plugins/conda.py
+++ b/asv/plugins/conda.py
@@ -145,7 +145,8 @@ class Conda(environment.Environment):
 
     def uninstall(self, package):
         log.info("Uninstalling {0} from {1}".format(package, self.name))
-        self._run_executable('pip', ['uninstall', '-y', package], error=False)
+        self._run_executable('pip', ['uninstall', '-y', package],
+                             valid_return_codes=None)
 
     def run(self, args, **kwargs):
         log.debug("Running '{0}' in {1}".format(' '.join(args), self.name))

--- a/asv/plugins/git.py
+++ b/asv/plugins/git.py
@@ -75,7 +75,7 @@ class Git(Repo):
         # TODO: This works on Linux, but should be extended for other platforms
         return int(self._run_git(
             ['show', hash, '--quiet', '--format=format:%ct'],
-            dots=False).strip().split()[0]) * 1000
+            valid_return_codes=(0, 1), dots=False).strip().split()[0]) * 1000
 
     def get_hashes_from_range(self, range_spec):
         if range_spec == 'master':
@@ -83,7 +83,8 @@ class Git(Repo):
         args = ['log', '--quiet', '--first-parent', '--format=format:%H']
         if range_spec != "":
             args += [range_spec]
-        return self._run_git(args, dots=False).strip().split()
+        output = self._run_git(args, valid_return_codes=(0, 1), dots=False)
+        return output.strip().split()
 
     def get_hash_from_tag(self, tag):
         return self._run_git(

--- a/asv/plugins/github.py
+++ b/asv/plugins/github.py
@@ -50,7 +50,7 @@ class GithubPages(Command):
         # Create a new "orphaned" branch -- we don't need history for
         # the built products
         util.check_call([git, 'branch', '-D', 'gh-pages'],
-                        error=False, display_error=False)
+                        valid_return_codes=None, display_error=False)
         util.check_call([git, 'checkout', '--orphan', 'gh-pages'])
 
         # We need to tell github this is not a Jekyll document

--- a/asv/plugins/virtualenv.py
+++ b/asv/plugins/virtualenv.py
@@ -153,7 +153,8 @@ class Virtualenv(environment.Environment):
 
     def uninstall(self, package):
         log.info("Uninstalling {0} from {1}".format(package, self.name))
-        self._run_executable('pip', ['uninstall', '-y', package], error=False)
+        self._run_executable('pip', ['uninstall', '-y', package],
+                             valid_return_codes=None)
 
     def run(self, args, **kwargs):
         log.debug("Running '{0}' in {1}".format(' '.join(args), self.name))

--- a/asv/util.py
+++ b/asv/util.py
@@ -206,8 +206,8 @@ class ProcessError(subprocess.CalledProcessError):
             ' '.join(self.args), self.retcode)
 
 
-def check_call(args, error=True, timeout=60, dots=True, display_error=True,
-               shell=False, env=None):
+def check_call(args, valid_return_codes=(0,), timeout=60, dots=True,
+               display_error=True, shell=False, env=None):
     """
     Runs the given command in a subprocess, raising ProcessError if it
     fails.
@@ -215,21 +215,22 @@ def check_call(args, error=True, timeout=60, dots=True, display_error=True,
     See `check_output` for parameters.
     """
     check_output(
-        args, error=error, timeout=timeout, dots=dots,
-        display_error=display_error, shell=shell, env=env)
+        args, valid_return_codes=valid_return_codes, timeout=timeout,
+        dots=dots, display_error=display_error, shell=shell, env=env)
 
 
-def check_output(args, error=True, timeout=120, dots=True, display_error=True,
-                 shell=False, return_stderr=False, env=None):
+def check_output(args, valid_return_codes=(0,), timeout=120, dots=True,
+                 display_error=True, shell=False, return_stderr=False,
+                 env=None):
     """
     Runs the given command in a subprocess, raising ProcessError if it
     fails.  Returns stdout as a string on success.
 
     Parameters
     ----------
-    error : bool, optional
-        When `True` (default) raise a ProcessError if the subprocess
-        returns an error code.
+    valid_return_codes : list, optional
+        A list of return codes to ignore. Defaults to only ignoring zero.
+        Setting to None ignores all return codes.
 
     timeout : number, optional
         Kill the process if it lasts longer than `timeout` seconds.
@@ -319,7 +320,7 @@ def check_output(args, error=True, timeout=120, dots=True, display_error=True,
     stderr = b''.join(stderr_chunks).decode('utf-8', 'replace')
 
     retcode = proc.wait()
-    if retcode and error:
+    if valid_return_codes is not None and retcode not in valid_return_codes:
         header = 'Error running {0}'.format(' '.join(args))
         if display_error:
             log.error(get_content(header))


### PR DESCRIPTION
Running `git show --quiet ...` on a commit that includes changes (i.e. not a merge commit) gives an exit code of 1. This makes asv think there has been error when in reality everything is fine.

The same applies to `git log ...` as used to determine a range of commits.

Perhaps it would be worth making a more specific change so that only 1 is ignored? E.g. a 128 exit code from not being in a git repo still counts as an error.