### PR TITLE
Install dependencies in one go.

### DIFF
--- a/asv/environment.py
+++ b/asv/environment.py
@@ -181,12 +181,6 @@ class Environment(object):
         """
         raise NotImplementedError()
 
-    def upgrade(self, package):
-        """
-        Upgrade a package into the environment.
-        """
-        raise NotImplementedError()
-
     def uninstall(self, package):
         """
         Uninstall a package into the environment.

--- a/asv/plugins/conda.py
+++ b/asv/plugins/conda.py
@@ -143,12 +143,6 @@ class Conda(environment.Environment):
         args.append(package)
         self._run_executable('pip', args)
 
-    def upgrade(self, package):
-        log.info("Upgrading {0} in {1}".format(package, self.name))
-        self._run_executable(
-            'conda',
-            ['install', '-p', self._path, '--yes', package])
-
     def uninstall(self, package):
         log.info("Uninstalling {0} from {1}".format(package, self.name))
         self._run_executable('pip', ['uninstall', '-y', package],

--- a/asv/plugins/conda.py
+++ b/asv/plugins/conda.py
@@ -116,11 +116,16 @@ class Conda(environment.Environment):
 
         self.setup()
 
+        # Install all the dependencies with a single conda command.
+        # This ensures we get the versions requested, or an error
+        # otherwise. It's also quicker than doing it one by one.
+        args = ['install', '-p', self._path, '--yes']
         for key, val in six.iteritems(self._requirements):
             if val is not None:
-                self.upgrade("{0}={1}".format(key, val))
+                args.append("{0}={1}".format(key, val))
             else:
-                self.upgrade(key)
+                args.append(key)
+        self._run_executable('conda', args)
 
         self._requirements_installed = True
 

--- a/asv/plugins/conda.py
+++ b/asv/plugins/conda.py
@@ -116,16 +116,17 @@ class Conda(environment.Environment):
 
         self.setup()
 
-        # Install all the dependencies with a single conda command.
-        # This ensures we get the versions requested, or an error
-        # otherwise. It's also quicker than doing it one by one.
-        args = ['install', '-p', self._path, '--yes']
-        for key, val in six.iteritems(self._requirements):
-            if val is not None:
-                args.append("{0}={1}".format(key, val))
-            else:
-                args.append(key)
-        self._run_executable('conda', args)
+        if self._requirements:
+            # Install all the dependencies with a single conda command.
+            # This ensures we get the versions requested, or an error
+            # otherwise. It's also quicker than doing it one by one.
+            args = ['install', '-p', self._path, '--yes']
+            for key, val in six.iteritems(self._requirements):
+                if val is not None:
+                    args.append("{0}={1}".format(key, val))
+                else:
+                    args.append(key)
+            self._run_executable('conda', args)
 
         self._requirements_installed = True
 

--- a/asv/plugins/virtualenv.py
+++ b/asv/plugins/virtualenv.py
@@ -124,13 +124,13 @@ class Virtualenv(environment.Environment):
 
         self.setup()
 
-        self.upgrade('setuptools==3.8')
+        self._upgrade('setuptools==3.8')
 
         for key, val in six.iteritems(self._requirements):
             if val is not None:
-                self.upgrade("{0}=={1}".format(key, val))
+                self._upgrade("{0}=={1}".format(key, val))
             else:
-                self.upgrade(key)
+                self._upgrade(key)
 
         self._requirements_installed = True
 
@@ -147,7 +147,7 @@ class Virtualenv(environment.Environment):
         args.append(package)
         self._run_executable('pip', args)
 
-    def upgrade(self, package):
+    def _upgrade(self, package):
         log.info("Upgrading {0} in {1}".format(package, self.name))
         self._run_executable('pip', ['install', '--upgrade', package])
 

--- a/asv/plugins/virtualenv.py
+++ b/asv/plugins/virtualenv.py
@@ -124,13 +124,17 @@ class Virtualenv(environment.Environment):
 
         self.setup()
 
-        self._upgrade('setuptools==3.8')
+        self._run_executable('pip', ['install', '--upgrade',
+                                     'setuptools==3.8'])
 
-        for key, val in six.iteritems(self._requirements):
-            if val is not None:
-                self._upgrade("{0}=={1}".format(key, val))
-            else:
-                self._upgrade(key)
+        if self._requirements:
+            args = ['install', '--upgrade']
+            for key, val in six.iteritems(self._requirements):
+                if val is not None:
+                    args.append("{0}=={1}".format(key, val))
+                else:
+                    args.append(key)
+            self._run_executable('pip', args)
 
         self._requirements_installed = True
 
@@ -146,10 +150,6 @@ class Virtualenv(environment.Environment):
             args.append('-e')
         args.append(package)
         self._run_executable('pip', args)
-
-    def _upgrade(self, package):
-        log.info("Upgrading {0} in {1}".format(package, self.name))
-        self._run_executable('pip', ['install', '--upgrade', package])
 
     def uninstall(self, package):
         log.info("Uninstalling {0} from {1}".format(package, self.name))


### PR DESCRIPTION
This PR avoids the "version bouncing" of secondary dependencies than can occur when upgrading conda packages one-by-one. It also makes it faster. Win - win! :smile:

For example, assume a project has two dependencies: "numpy" at version 1.7, and "wibble", where "wibble" has only been built against numpy 1.8. First, asv installs numpy 1.7. Then it installs wibble, which drags numpy up to 1.8.