### PR TITLE
Only include pinned versions in environment name.

### DIFF
--- a/asv/environment.py
+++ b/asv/environment.py
@@ -55,8 +55,6 @@ def get_env_name(python, requirements):
     for key, val in reqs:
         if val is not None:
             name.append(''.join([key, val]))
-        else:
-            name.append(key)
     return '-'.join(name)
 
 


### PR DESCRIPTION
re: #169.

For a dependency matrix such as...
```
"matrix": {
    "a": [],
    "b": ["5"],
    "c": ["2.24", "2.26"]
}
```
... this PR changes the resulting environment names from:
 - py2.7-a-b5-c2.24
 - py2.7-a-b5-c2.26

to:
 - py2.7-b5-c2.24
 - py2.7-b5-c2.26

NB.
 - As mentioned on #169, this affects both the name of the testing environment and the name of the result files.
 - This PR does *not* change the circumstances under which result file names will change (e.g. going from an unpinned version to a pinned version). The obvious exception to this is the initial transition from the current naming scheme to the scheme proposed in this PR.