### PR TITLE
Incremental benchmarking

### DIFF
--- a/asv/benchmarks.py
+++ b/asv/benchmarks.py
@@ -261,8 +261,8 @@ class Benchmarks(dict):
         metadata about the discovered benchmarks, in the results dir.
         """
         path = self.get_benchmark_file_path(self._conf.results_dir)
-        util.write_json(path, self, self.api_version)
-        del self['version']
+        util.write_json(path, self._all_benchmarks, self.api_version)
+        del self._all_benchmarks['version']
 
     @classmethod
     def load(cls, conf, regex=None):

--- a/asv/benchmarks.py
+++ b/asv/benchmarks.py
@@ -265,7 +265,7 @@ class Benchmarks(dict):
         del self._all_benchmarks['version']
 
     @classmethod
-    def load(cls, conf, regex=None):
+    def load(cls, conf):
         """
         Load the benchmark descriptions from the `benchmarks.json` file.
         If the file is not found, one of the given `environments` will
@@ -276,17 +276,12 @@ class Benchmarks(dict):
         conf : Config object
             The project's configuration
 
-        regex : str or list of str, optional
-            `regex` is a list of regular expressions matching the
-            benchmarks to run.  If none are provided, all benchmarks
-            are run.
-
         Returns
         -------
         benchmarks : Benchmarks object
         """
         def regenerate():
-            self = cls(conf, regex=regex)
+            self = cls(conf)
             self.save()
             return self
 
@@ -302,7 +297,7 @@ class Benchmarks(dict):
             # version
             return regenerate()
 
-        return cls(conf, benchmarks=d, regex=regex)
+        return cls(conf, benchmarks=d)
 
     def run_benchmarks(self, env, show_stderr=False, quick=False, profile=False):
         """

--- a/asv/results.py
+++ b/asv/results.py
@@ -8,6 +8,8 @@ import base64
 import os
 import zlib
 
+import six
+
 from . import environment
 from .console import log
 from . import util
@@ -213,6 +215,10 @@ class Results(object):
         """
         path = os.path.join(result_dir, self._filename)
 
+        if os.path.exists(path):
+            old_results = self.load(path)
+            self.add_existing_results(old_results)
+
         util.write_json(path, {
             'results': self._results,
             'params': self._params,
@@ -247,6 +253,18 @@ class Results(object):
             obj._profiles = d['profiles']
         obj._filename = os.path.join(*path.split(os.path.sep)[-2:])
         return obj
+
+    def add_existing_results(self, old):
+        """
+        Add any existing old results that aren't overridden by the
+        current results.
+        """
+        for key, val in six.iteritems(old.results):
+            if key not in self._results:
+                self._results[key] = val
+        for key, val in six.iteritems(old._profiles):
+            if key not in self._profiles:
+                self._profiles[key] = val
 
     def rm(self, result_dir):
         path = os.path.join(result_dir, self._filename)


### PR DESCRIPTION
Extends the patch supplied in #175 to ensure the `results/benchmarks.json` always contains *all* the benchmark definitions, instead of just the benchmarks selected in the last invocation.

(It also removes the apparently unused `regex` argument from `Benchmarks.load()`. This isn't necessary for the PR to work so I'm happy to drop that commit, but the existence of the `regex` argument did slow down the process of finding the right bit of code to modify.)

If this looks to be a sensible change them I'm happy to look at testing.