### PR TITLE
Use shorter environment directory names

### DIFF
--- a/asv/environment.py
+++ b/asv/environment.py
@@ -9,6 +9,7 @@ of dependencies.
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
+import hashlib
 import os
 import sys
 
@@ -158,6 +159,13 @@ class Environment(object):
         return get_env_name(self._python, self._requirements)
 
     @property
+    def hashname(self):
+        """
+        Get a hash to uniquely identify this environment.
+        """
+        return hashlib.md5(self.name.encode('utf-8')).hexdigest()
+
+    @property
     def requirements(self):
         return self._requirements
 
@@ -210,6 +218,18 @@ class Environment(object):
         can be installed into this environment.
         """
         return True
+
+    def save_info_file(self, path):
+        """
+        Save a file with information about the environment into
+        directory `path`.
+        """
+        path = os.path.join(path, 'asv-env-info.json')
+        content = {
+            'python': self._python,
+            'requirements': self._requirements
+        }
+        util.write_json(path, content)
 
 
 class ExistingEnvironment(Environment):

--- a/asv/plugins/conda.py
+++ b/asv/plugins/conda.py
@@ -40,7 +40,7 @@ class Conda(environment.Environment):
         self._python = python
         self._requirements = requirements
         self._path = os.path.join(
-            self._env_dir, self.name)
+            self._env_dir, self.hashname)
 
         self._is_setup = False
         self._requirements_installed = False
@@ -107,6 +107,8 @@ class Conda(environment.Environment):
             if os.path.exists(self._path):
                 shutil.rmtree(self._path)
             raise
+
+        self.save_info_file(self._path)
 
         self._is_setup = True
 

--- a/asv/plugins/virtualenv.py
+++ b/asv/plugins/virtualenv.py
@@ -41,7 +41,7 @@ class Virtualenv(environment.Environment):
         self._python = python
         self._requirements = requirements
         self._path = os.path.join(
-            self._env_dir, self.name)
+            self._env_dir, self.hashname)
 
         try:
             import virtualenv
@@ -115,6 +115,8 @@ class Virtualenv(environment.Environment):
             if os.path.exists(self._path):
                 shutil.rmtree(self._path)
             raise
+
+        self.save_info_file(self._path)
 
         self._is_setup = True
 

--- a/test/test_environment.py
+++ b/test/test_environment.py
@@ -58,3 +58,27 @@ def test_matrix_environments(tmpdir):
         output = env.run(
             ['-c', 'import psutil, sys; sys.stdout.write(psutil.__version__)'])
         assert output.startswith(six.text_type(env._requirements['psutil']))
+
+
+@pytest.mark.xfail(not HAS_PYTHON_27,
+                   reason="Requires Python 2.7")
+def test_large_environment_matrix(tmpdir):
+    # As seen in issue #169, conda can't handle using really long
+    # directory names in its environment.  This creates an environment
+    # with many dependencies in order to ensure it still works.
+
+    conf = config.Config()
+
+    conf.env_dir = six.text_type(tmpdir.join("env"))
+    conf.pythons = ["2.7"]
+    for i in range(25):
+        conf.matrix['foo{0}'.format(i)] = []
+
+    environments = list(environment.get_environments(conf))
+
+    for env in environments:
+        # Since *actually* installing all the dependencies would make
+        # this test run a long time, we only set up the environment,
+        # but don't actually install dependencies into it.  This is
+        # enough to trigger the bug in #169.
+        env.setup()


### PR DESCRIPTION
This is a possible fix for #169 and an alternative to #176.

It uses an md5 hexdigest for the directory name, and then puts information about the environment in a file `asv-env-info.json` within the environment directory (though this isn't currently used for anything).