### PR TITLE
Add ccache plugin

### DIFF
--- a/asv/ext/__init__.py
+++ b/asv/ext/__init__.py
@@ -1,0 +1,3 @@
+"""
+This directory contains plugins that are not enabled by default.
+"""

--- a/asv/ext/ccache.py
+++ b/asv/ext/ccache.py
@@ -1,0 +1,31 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+# -*- coding: utf-8 -*-
+
+from __future__ import absolute_import, division, unicode_literals, print_function
+
+"""
+This plugin makes ccache more effective by making it sloppier and
+removing debugging information from the generated files.
+"""
+
+# Contributed by @pv
+
+import os
+import sysconfig
+
+
+def drop_g_flag(flags):
+    """
+    Drop -g from command line flags
+    """
+    if not flags:
+        return flags
+    return " ".join(
+        x for x in flags.split() if x not in ('-g', '-g1', '-g2', '-g3'))
+
+
+os.environ['CCACHE_SLOPPINESS'] = 'file_macro,time_macros'
+os.environ['CCACHE_UNIFY'] = '1'
+os.environ['CFLAGS'] = drop_g_flag(sysconfig.get_config_var('CFLAGS'))
+os.environ['OPT'] = drop_g_flag(sysconfig.get_config_var('OPT'))
+os.environ['LDSHARED'] = drop_g_flag(sysconfig.get_config_var('LDSHARED'))

--- a/asv/template/asv.conf.json
+++ b/asv/template/asv.conf.json
@@ -54,4 +54,8 @@
 
     // The number of characters to retain in the commit hashes.
     // "hash_length": 8
+
+    // A list of plugins to load into asv.  Each entry is a Python module
+    // on the Python path.
+    // "plugins": []
 }

--- a/docs/source/asv.conf.json.rst
+++ b/docs/source/asv.conf.json.rst
@@ -134,4 +134,4 @@ results, where the full commit hash is always retained.
 
 ``plugins``
 -----------
-A list of modules to import containing asv plugins.
+A list of modules to import that contain ``asv`` plugins.

--- a/docs/source/ext.rst
+++ b/docs/source/ext.rst
@@ -1,0 +1,17 @@
+Plugins
+=======
+
+``asv`` has some optional features that may be enabled by adding them
+to the ``plugins`` list in ``asv.conf.json``.  For example, to enable
+the ``asv.ext.ccache`` plugin, add the following to your
+``asv.conf.json``::
+
+   "plugins": ["asv.ext.ccache"]
+
+asv.ext.ccache
+--------------
+
+Normally, when using ``asv`` with ``ccache`` it is not very effective
+because the location of the build products is randomized.  This plugin
+makes ``ccache`` more amenable to that, resulting in more cache hits
+and faster compilation.

--- a/docs/source/reference.rst
+++ b/docs/source/reference.rst
@@ -4,3 +4,4 @@ Reference
 .. toctree::
    asv.conf.json.rst
    commands.rst
+   ext.rst

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,8 @@ setup(
     packages=['asv',
               'asv.commands',
               'asv.plugins',
-              'asv.extern'],
+              'asv.extern',
+              'asv.ext'],
     entry_points={
         'console_scripts': [
             'asv = asv.main:main'


### PR DESCRIPTION
This is an attempt to address #201.

This adds an optional `ccache` plugin that can be turned on by adding `"plugins": ["asv.ext.ccache"]` to `asv.conf.json`.  That way we don't need to add this hacky stuff for everyone, just for those who opt-in.

Unfortunately, however, it doesn't seem to work, and I'm getting all cache misses when enabling these environment variables (even though I've confirmed they are being applied).  @pv since you reported the technique itself as working, do you have any thoughts?