### PR TITLE
Use `setup.py` directly rather than `pip install`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,5 +30,5 @@ install:
     fi
 
 script:
-    - pip install virtualenv==1.10
+    - pip install virtualenv
     - python setup.py test

--- a/asv/benchmarks.py
+++ b/asv/benchmarks.py
@@ -178,7 +178,7 @@ class Benchmarks(dict):
 
         cls.check_tree(root)
 
-        environments = list(get_environments(conf, repo))
+        environments = list(get_environments(conf))
         if len(environments) == 0:
             raise util.UserError("No available environments")
 

--- a/asv/benchmarks.py
+++ b/asv/benchmarks.py
@@ -174,10 +174,11 @@ class Benchmarks(dict):
         Discover all benchmarks in a directory tree.
         """
         root = conf.benchmark_dir
+        repo = get_repo(conf)
 
         cls.check_tree(root)
 
-        environments = list(get_environments(conf))
+        environments = list(get_environments(conf, repo))
         if len(environments) == 0:
             raise util.UserError("No available environments")
 
@@ -194,9 +195,7 @@ class Benchmarks(dict):
 
         log.info("Discovering benchmarks")
         with log.indent():
-            repo = get_repo(conf)
-            repo.checkout()
-
+            env.repo.checkout()
             env.install_project(conf)
 
             output = env.run(

--- a/asv/benchmarks.py
+++ b/asv/benchmarks.py
@@ -195,8 +195,7 @@ class Benchmarks(dict):
 
         log.info("Discovering benchmarks")
         with log.indent():
-            env.repo.checkout()
-            env.install_project(conf)
+            env.install_project(conf, repo.get_hash_from_head())
 
             output = env.run(
                 [BENCHMARK_RUN_SCRIPT, 'discover', root],

--- a/asv/benchmarks.py
+++ b/asv/benchmarks.py
@@ -15,7 +15,6 @@ import six
 
 from .console import log, truncate_left
 from .environment import get_environments
-from .repo import get_repo
 from . import util
 
 
@@ -174,7 +173,6 @@ class Benchmarks(dict):
         Discover all benchmarks in a directory tree.
         """
         root = conf.benchmark_dir
-        repo = get_repo(conf)
 
         cls.check_tree(root)
 
@@ -195,7 +193,8 @@ class Benchmarks(dict):
 
         log.info("Discovering benchmarks")
         with log.indent():
-            env.install_project(conf, repo.get_hash_from_head())
+            env.create()
+            env.install_project(conf)
 
             output = env.run(
                 [BENCHMARK_RUN_SCRIPT, 'discover', root],

--- a/asv/commands/find.py
+++ b/asv/commands/find.py
@@ -126,8 +126,7 @@ class Find(Command):
                 "For {0} commit hash {1}:".format(
                     conf.project, commit_hash[:8]))
 
-            env.repo.checkout(commit_hash)
-            env.install_project(conf)
+            env.install_project(conf, commit_hash)
             x = benchmarks.run_benchmarks(
                 env, show_stderr=show_stderr)
             results[i] = list(x.values())[0]['result']

--- a/asv/commands/find.py
+++ b/asv/commands/find.py
@@ -126,7 +126,7 @@ class Find(Command):
                 "For {0} commit hash {1}:".format(
                     conf.project, commit_hash[:8]))
 
-            repo.checkout(commit_hash)
+            env.repo.checkout(commit_hash)
             env.install_project(conf)
             x = benchmarks.run_benchmarks(
                 env, show_stderr=show_stderr)

--- a/asv/commands/profiling.py
+++ b/asv/commands/profiling.py
@@ -163,7 +163,7 @@ class Profile(Command):
                             break
 
         if profile_data is None:
-            environments = list(get_environments(conf))
+            environments = list(get_environments(conf, repo))
 
             if len(environments) == 0:
                 log.error("No environments selected")
@@ -203,7 +203,7 @@ class Profile(Command):
             else:
                 log.info("Running profiler")
             with log.indent():
-                repo.checkout(commit_hash)
+                env.repo.checkout(commit_hash)
                 env.install_project(conf)
 
                 results = benchmarks.run_benchmarks(

--- a/asv/commands/profiling.py
+++ b/asv/commands/profiling.py
@@ -163,7 +163,7 @@ class Profile(Command):
                             break
 
         if profile_data is None:
-            environments = list(get_environments(conf, repo))
+            environments = list(get_environments(conf))
 
             if len(environments) == 0:
                 log.error("No environments selected")

--- a/asv/commands/profiling.py
+++ b/asv/commands/profiling.py
@@ -203,8 +203,7 @@ class Profile(Command):
             else:
                 log.info("Running profiler")
             with log.indent():
-                env.repo.checkout(commit_hash)
-                env.install_project(conf)
+                env.install_project(conf, commit_hash)
 
                 results = benchmarks.run_benchmarks(
                     env, show_stderr=True, quick=False, profile=True)

--- a/asv/commands/run.py
+++ b/asv/commands/run.py
@@ -23,8 +23,7 @@ def _do_build(args):
     env, conf, commit_hash = args
     try:
         with log.set_level(logging.WARN):
-            env.repo.checkout(commit_hash)
-            env.install_project(conf, silent=True)
+            env.install_project(conf, commit_hash)
     except util.ProcessError:
         return False
     return True

--- a/asv/commands/run.py
+++ b/asv/commands/run.py
@@ -6,6 +6,8 @@ from __future__ import (absolute_import, division, print_function,
 
 import six
 
+import logging
+
 from . import Command
 from ..benchmarks import Benchmarks
 from ..console import log
@@ -18,9 +20,11 @@ from .setup import Setup
 
 
 def _do_build(args):
-    env, conf = args
+    env, conf, commit_hash = args
     try:
-        env.install_project(conf)
+        with log.set_level(logging.WARN):
+            env.repo.checkout(commit_hash)
+            env.install_project(conf, silent=True)
     except util.ProcessError:
         return False
     return True
@@ -78,9 +82,7 @@ class Run(Command):
             "--parallel", "-j", nargs='?', type=int, default=1, const=-1,
             help="""Build (but don't benchmark) in parallel.  The
             value is the number of CPUs to use, or if no number
-            provided, use the number of cores on this machine.  NOTE:
-            parallel building is still experimental and may not work
-            in all cases.""")
+            provided, use the number of cores on this machine.""")
         parser.add_argument(
             "--show-stderr", "-e", action="store_true",
             help="""Display the stderr output from the benchmarks.""")
@@ -222,13 +224,11 @@ class Run(Command):
                 "For {0} commit hash {1}:".format(
                     conf.project, commit_hash[:8]))
             with log.indent():
-                repo.checkout(commit_hash)
-
                 for subenv in util.iter_chunks(environments, parallel):
                     log.info("Building for {0}".format(
                         ', '.join([x.name for x in subenv])))
                     with log.indent():
-                        args = [(env, conf) for env in subenv]
+                        args = [(env, conf, commit_hash) for env in subenv]
                         if parallel != 1:
                             pool = multiprocessing.Pool(parallel)
                             successes = pool.map(_do_build_multiprocess, args)

--- a/asv/commands/setup.py
+++ b/asv/commands/setup.py
@@ -59,9 +59,7 @@ class Setup(Command):
 
     @classmethod
     def run(cls, conf, parallel=-1):
-        repo = get_repo(conf)
-
-        environments = list(environment.get_environments(conf, repo))
+        environments = list(environment.get_environments(conf))
 
         parallel, multiprocessing = util.get_multiprocessing(parallel)
 

--- a/asv/console.py
+++ b/asv/console.py
@@ -308,8 +308,10 @@ class Log(object):
     def set_level(self, level):
         orig_level = self._logger.level
         self._logger.setLevel(level)
-        yield
-        self._logger.setLevel(orig_level)
+        try:
+            yield
+        finally:
+            self._logger.setLevel(orig_level)
 
     def is_debug_enabled(self):
         return self._logger.getEffectiveLevel() <= logging.DEBUG

--- a/asv/console.py
+++ b/asv/console.py
@@ -304,6 +304,13 @@ class Log(object):
         else:
             self._logger.setLevel(logging.INFO)
 
+    @contextlib.contextmanager
+    def set_level(self, level):
+        orig_level = self._logger.level
+        self._logger.setLevel(level)
+        yield
+        self._logger.setLevel(orig_level)
+
     def is_debug_enabled(self):
         return self._logger.getEffectiveLevel() <= logging.DEBUG
 

--- a/asv/environment.py
+++ b/asv/environment.py
@@ -296,12 +296,15 @@ class Environment(object):
         self.run(['setup.py', 'build'], cwd=build_root)
         return build_root
 
-    def install_project(self, conf, commit_hash):
+    def install_project(self, conf, commit_hash=None):
         """
         Install a working copy of the benchmarked project into the
         environment.  Uninstalls any installed copy of the project
         first.
         """
+        if commit_hash is None:
+            commit_hash = self.repo.get_hash_from_head()
+
         self.install_requirements()
         self.uninstall(conf.project)
 

--- a/asv/environment.py
+++ b/asv/environment.py
@@ -289,7 +289,7 @@ class Environment(object):
         """
         raise NotImplementedError()
 
-    def install_project(self, conf, silent=False):
+    def install_project(self, conf, commit_hash):
         """
         Install a working copy of the benchmarked project into the
         environment.  Uninstalls any installed copy of the project
@@ -298,6 +298,7 @@ class Environment(object):
         self.install_requirements()
         self.uninstall(conf.project)
         log.info("Building {0} for {1}".format(conf.project, self.name))
+        self.repo.checkout(commit_hash)
         self.run(['setup.py', 'build'], cwd=os.path.abspath(self.repo.path))
         self.install(self.repo.path)
 
@@ -363,7 +364,7 @@ class ExistingEnvironment(Environment):
     def install_requirements(self):
         pass
 
-    def install_project(self, conf):
+    def install_project(self, conf, commit_hash):
         pass
 
     def can_install_project(self):

--- a/asv/environment.py
+++ b/asv/environment.py
@@ -242,15 +242,13 @@ class Environment(object):
             os.makedirs(self._env_dir)
 
         if not os.path.exists(self._path):
-            os.makedirs(self._path)
-
-        try:
-            self.setup()
-        except:
-            log.error("Failure creating environment for {0}".format(self.name))
-            if os.path.exists(self._path):
-                shutil.rmtree(self._path)
-            raise
+            try:
+                self.setup()
+            except:
+                log.error("Failure creating environment for {0}".format(self.name))
+                if os.path.exists(self._path):
+                    shutil.rmtree(self._path)
+                raise
 
         self.save_info_file(self._path)
         if self._source_repo is not None:  # For testing only

--- a/asv/environment.py
+++ b/asv/environment.py
@@ -338,8 +338,6 @@ class ExistingEnvironment(Environment):
     tool_name = "existing"
 
     def __init__(self, conf, executable):
-        super(ExistingEnvironment, self).__init__(conf)
-
         self._executable = executable
         self._python = util.check_output(
             [executable,
@@ -348,6 +346,8 @@ class ExistingEnvironment(Environment):
              'print(str(sys.version_info[0]) + "." + str(sys.version_info[1]))'
          ]).strip()
         self._requirements = {}
+
+        super(ExistingEnvironment, self).__init__(conf)
 
     @classmethod
     def get_environments(cls, conf, python):
@@ -378,7 +378,7 @@ class ExistingEnvironment(Environment):
     def install_requirements(self):
         pass
 
-    def install_project(self, conf, commit_hash):
+    def install_project(self, conf, commit_hash=None):
         pass
 
     def can_install_project(self):

--- a/asv/environment.py
+++ b/asv/environment.py
@@ -250,12 +250,7 @@ class Environment(object):
         self.install_requirements()
         self.uninstall(conf.project)
         log.info("Building {0} for {1}".format(conf.project, self.name))
-        orig_path = os.getcwd()
-        os.chdir(conf.project)
-        try:
-            self.run(['setup.py', 'build'])
-        finally:
-            os.chdir(orig_path)
+        self.run(['setup.py', 'build'], cwd=os.path.abspath(conf.project))
         self.install(os.path.abspath(conf.project))
 
     def can_install_project(self):

--- a/asv/environment.py
+++ b/asv/environment.py
@@ -249,13 +249,14 @@ class Environment(object):
         """
         self.install_requirements()
         self.uninstall(conf.project)
-        log.info("Installing {0} into {1}".format(conf.project, self.name))
+        log.info("Building {0} for {1}".format(conf.project, self.name))
         orig_path = os.getcwd()
         os.chdir(conf.project)
         try:
-            self.run(['setup.py', 'install'])
+            self.run(['setup.py', 'build'])
         finally:
             os.chdir(orig_path)
+        self.install(os.path.abspath(conf.project))
 
     def can_install_project(self):
         """

--- a/asv/environment.py
+++ b/asv/environment.py
@@ -249,7 +249,13 @@ class Environment(object):
         """
         self.install_requirements()
         self.uninstall(conf.project)
-        self.install(os.path.abspath(conf.project))
+        log.info("Installing {0} into {1}".format(conf.project, self.name))
+        orig_path = os.getcwd()
+        os.chdir(conf.project)
+        try:
+            self.run(['setup.py', 'install'])
+        finally:
+            os.chdir(orig_path)
 
     def can_install_project(self):
         """

--- a/asv/plugins/conda.py
+++ b/asv/plugins/conda.py
@@ -123,8 +123,8 @@ class Conda(environment.Environment):
         return util.check_output([
             os.path.join(self._path, 'bin', executable)] + args, **kwargs)
 
-    def install(self, package):
-        log.info("Installing {0} into {1}".format(self.name))
+    def install(self, package, commit_hash=None):
+        log.info("Installing {0} into {1}".format(rel, self.name))
         self._run_executable('pip', ['install', package])
 
     def uninstall(self, package):

--- a/asv/plugins/conda.py
+++ b/asv/plugins/conda.py
@@ -94,11 +94,13 @@ class Conda(environment.Environment):
 
         self.create()
 
+        self.install('wheel')
+
         if self._requirements:
             # Install all the dependencies with a single conda command.
             # This ensures we get the versions requested, or an error
             # otherwise. It's also quicker than doing it one by one.
-            args = ['install', '-p', self._path, '--yes', 'wheel']
+            args = ['install', '-p', self._path, '--yes']
             for key, val in six.iteritems(self._requirements):
                 if val is not None:
                     args.append("{0}={1}".format(key, val))
@@ -113,11 +115,11 @@ class Conda(environment.Environment):
             os.path.join(self._path, 'bin', executable)] + args, **kwargs)
 
     def install(self, package):
-        log.info("Installing {0} into {1}".format(rel, self.name))
+        log.info("Installing into {0}".format(self.name))
         self._run_executable('pip', ['install', package])
 
     def uninstall(self, package):
-        log.info("Uninstalling {0} from {1}".format(package, self.name))
+        log.info("Uninstalling from {0}".format(self.name))
         self._run_executable('pip', ['uninstall', '-y', package],
                              valid_return_codes=None)
 

--- a/asv/plugins/conda.py
+++ b/asv/plugins/conda.py
@@ -4,7 +4,6 @@
 from __future__ import absolute_import, division, unicode_literals, print_function
 
 import os
-import shutil
 import tempfile
 
 import six
@@ -36,9 +35,6 @@ class Conda(environment.Environment):
         requirements : dict
             Dictionary mapping a PyPI package name to a version
             identifier string.
-
-        source_repo : Repo instance
-            The source repo to use to install the project
         """
         self._python = python
         self._requirements = requirements
@@ -71,7 +67,7 @@ class Conda(environment.Environment):
                 return True
 
     @classmethod
-    def get_environments(cls, conf, python, repo):
+    def get_environments(cls, conf, python):
         for configuration in environment.iter_configuration_matrix(conf.matrix):
             yield cls(conf, python, configuration)
 

--- a/asv/plugins/conda.py
+++ b/asv/plugins/conda.py
@@ -24,7 +24,7 @@ class Conda(environment.Environment):
     """
     tool_name = "conda"
 
-    def __init__(self, env_dir, python, requirements):
+    def __init__(self, env_dir, python, requirements, source_repo):
         """
         Parameters
         ----------
@@ -37,12 +37,16 @@ class Conda(environment.Environment):
         requirements : dict
             Dictionary mapping a PyPI package name to a version
             identifier string.
+
+        source_repo : Repo instance
+            The source repo to use to install the project
         """
         self._env_dir = env_dir
         self._python = python
         self._requirements = requirements
         self._path = os.path.abspath(os.path.join(
             self._env_dir, self.hashname))
+        self._source_repo = source_repo
 
         self._is_setup = False
         self._requirements_installed = False
@@ -74,54 +78,32 @@ class Conda(environment.Environment):
                 return True
 
     @classmethod
-    def get_environments(cls, conf, python):
+    def get_environments(cls, conf, python, repo):
         for configuration in environment.iter_configuration_matrix(conf.matrix):
-            yield cls(conf.env_dir, python, configuration)
+            yield cls(conf.env_dir, python, configuration, repo)
 
     def setup(self):
-        if self._is_setup:
-            return
-
-        if not os.path.exists(self._env_dir):
-            os.makedirs(self._env_dir)
-
-        # We start with a clean conda environment everytime, since
-        # they are so quick to create.
-        if os.path.exists(self._path):
-            shutil.rmtree(self._path)
-
         try:
             conda = util.which('conda')
         except IOError as e:
             raise util.UserError(str(e))
 
         log.info("Creating conda environment for {0}".format(self.name))
-        try:
-            util.check_call([
-                conda,
-                'create',
-                '--yes',
-                '-p',
-                self._path,
-                '--use-index-cache',
-                'python={0}'.format(self._python),
-                'pip'])
-        except util.ProcessError:
-            log.error("Failure creating conda environment for {0}".format(
-                self.name))
-            if os.path.exists(self._path):
-                shutil.rmtree(self._path)
-            raise
-
-        self.save_info_file(self._path)
-
-        self._is_setup = True
+        util.check_call([
+            conda,
+            'create',
+            '--yes',
+            '-p',
+            self._path,
+            '--use-index-cache',
+            'python={0}'.format(self._python),
+            'pip'])
 
     def install_requirements(self):
         if self._requirements_installed:
             return
 
-        self.setup()
+        self.create()
 
         if self._requirements:
             # Install all the dependencies with a single conda command.
@@ -141,14 +123,9 @@ class Conda(environment.Environment):
         return util.check_output([
             os.path.join(self._path, 'bin', executable)] + args, **kwargs)
 
-    def install(self, package, editable=False):
-        rel = os.path.relpath(package, os.getcwd())
-        log.info("Installing {0} into {1}".format(rel, self.name))
-        args = ['install']
-        if editable:
-            args.append('-e')
-        args.append(package)
-        self._run_executable('pip', args)
+    def install(self, package):
+        log.info("Installing {0} into {1}".format(self.name))
+        self._run_executable('pip', ['install', package])
 
     def uninstall(self, package):
         log.info("Uninstalling {0} from {1}".format(package, self.name))

--- a/asv/plugins/conda.py
+++ b/asv/plugins/conda.py
@@ -41,8 +41,8 @@ class Conda(environment.Environment):
         self._env_dir = env_dir
         self._python = python
         self._requirements = requirements
-        self._path = os.path.join(
-            self._env_dir, self.hashname)
+        self._path = os.path.abspath(os.path.join(
+            self._env_dir, self.hashname))
 
         self._is_setup = False
         self._requirements_installed = False

--- a/asv/plugins/git.py
+++ b/asv/plugins/git.py
@@ -50,14 +50,12 @@ class Git(Repo):
 
     def _run_git(self, args, chdir=True, **kwargs):
         if chdir:
-            orig_dir = os.getcwd()
-            os.chdir(self._path)
-        try:
-            return util.check_output(
-                [self._git] + args, **kwargs)
-        finally:
-            if chdir:
-                os.chdir(orig_dir)
+            cwd = self._path
+        else:
+            cwd = None
+        kwargs['cwd'] = cwd
+        return util.check_output(
+            [self._git] + args, **kwargs)
 
     def pull(self):
         # We assume the remote isn't updated during the run of asv

--- a/asv/plugins/git.py
+++ b/asv/plugins/git.py
@@ -19,14 +19,18 @@ from .. import util
 class Git(Repo):
     dvcs = "git"
 
-    def __init__(self, url, path):
+    def __init__(self, url, path, shared=False):
         self._git = util.which("git")
         self._path = os.path.abspath(path)
         self._pulled = False
 
         if not os.path.isdir(self._path):
             log.info("Cloning project")
-            self._run_git(['clone', url, self._path], chdir=False)
+            args = ['clone']
+            if shared:
+                args.append('--shared')
+            args.extend([url, self._path])
+            self._run_git(args, chdir=False)
 
     @property
     def path(self):

--- a/asv/plugins/virtualenv.py
+++ b/asv/plugins/virtualenv.py
@@ -128,7 +128,7 @@ class Virtualenv(environment.Environment):
         self._run_executable('pip', ['install', package])
 
     def uninstall(self, package):
-        log.info("Uninstalling {0} from {1}".format(package, self.name))
+        log.info("Uninstalling from {0}".format(self.name))
         self._run_executable('pip', ['uninstall', '-y', package],
                              valid_return_codes=None)
 

--- a/asv/plugins/virtualenv.py
+++ b/asv/plugins/virtualenv.py
@@ -35,9 +35,6 @@ class Virtualenv(environment.Environment):
         requirements : dict
             Dictionary mapping a PyPI package name to a version
             identifier string.
-
-        source_repo : Repo instance
-            The source repo to use to install the project
         """
         self._executable = executable
         self._python = python

--- a/asv/plugins/virtualenv.py
+++ b/asv/plugins/virtualenv.py
@@ -42,8 +42,8 @@ class Virtualenv(environment.Environment):
         self._env_dir = env_dir
         self._python = python
         self._requirements = requirements
-        self._path = os.path.join(
-            self._env_dir, self.hashname)
+        self._path = os.path.abspath(os.path.join(
+            self._env_dir, self.hashname))
 
         try:
             import virtualenv

--- a/asv/repo.py
+++ b/asv/repo.py
@@ -108,6 +108,9 @@ def get_repo(conf):
     type, it will attempt to automatically determine one from the
     ``conf.repo`` URL.
     """
+    if conf.repo is None:
+        return None
+
     if conf.dvcs is not None:
         for cls in util.iter_subclasses(Repo):
             if getattr(cls, 'dvcs') == conf.dvcs:

--- a/asv/repo.py
+++ b/asv/repo.py
@@ -12,7 +12,7 @@ class Repo(object):
     """
     Base class for repository handlers.
     """
-    def __init__(self, url, path):
+    def __init__(self, url, path, shared=False):
         """
         Parameters
         ----------
@@ -21,6 +21,10 @@ class Repo(object):
 
         path : str
             The local path to clone into
+
+        shared : bool, optional.
+            When `True`, share the repository history with the source
+            repo's history.
         """
         raise NotImplementedError()
 

--- a/asv/template/asv.conf.json
+++ b/asv/template/asv.conf.json
@@ -59,5 +59,10 @@
     // "html_dir": "html",
 
     // The number of characters to retain in the commit hashes.
-    // "hash_length": 8
+    // "hash_length": 8,
+
+    // `asv` will cache wheels of the recent builds in each
+    // environment, making them faster to install next time.  This is
+    // number of builds to keep, per environment.
+    // "wheel_cache_size": 0
 }

--- a/asv/util.py
+++ b/asv/util.py
@@ -207,7 +207,7 @@ class ProcessError(subprocess.CalledProcessError):
 
 
 def check_call(args, valid_return_codes=(0,), timeout=60, dots=True,
-               display_error=True, shell=False, env=None):
+               display_error=True, shell=False, env=None, cwd=None):
     """
     Runs the given command in a subprocess, raising ProcessError if it
     fails.
@@ -216,12 +216,13 @@ def check_call(args, valid_return_codes=(0,), timeout=60, dots=True,
     """
     check_output(
         args, valid_return_codes=valid_return_codes, timeout=timeout,
-        dots=dots, display_error=display_error, shell=shell, env=env)
+        dots=dots, display_error=display_error, shell=shell, env=env,
+        cwd=cwd)
 
 
 def check_output(args, valid_return_codes=(0,), timeout=120, dots=True,
                  display_error=True, shell=False, return_stderr=False,
-                 env=None):
+                 env=None, cwd=None):
     """
     Runs the given command in a subprocess, raising ProcessError if it
     fails.  Returns stdout as a string on success.
@@ -255,6 +256,10 @@ def check_output(args, valid_return_codes=(0,), timeout=120, dots=True,
 
     env : dict, optional
         Specify environment variables for the subprocess.
+
+    cwd : str, optional
+        Specify the current working directory to use when running the
+        process.
     """
     def get_content(header=None):
         content = []
@@ -280,7 +285,8 @@ def check_output(args, valid_return_codes=(0,), timeout=120, dots=True,
         env=env,
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
-        shell=shell)
+        shell=shell,
+        cwd=cwd)
 
     last_dot_time = time.time()
     stdout_chunks = []

--- a/asv/wheel_cache.py
+++ b/asv/wheel_cache.py
@@ -1,0 +1,95 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+# -*- coding: utf-8 -*-
+
+from __future__ import absolute_import, division, unicode_literals, print_function
+
+
+import os
+import shutil
+
+from . import util
+
+
+class WheelCache(object):
+    def __init__(self, conf, root):
+        self._root = root
+        self._path = os.path.join(root, 'wheels')
+        self._wheel_cache_size = getattr(conf, 'wheel_cache_size', 0)
+
+    def _get_wheel_cache_path(self, commit_hash):
+        """
+        Get the wheel cache path corresponding to a given commit hash.
+        """
+        return os.path.join(self._path, commit_hash)
+
+    def _create_wheel_cache_path(self, commit_hash):
+        """
+        Create the directory for the wheel cache corresponding to the given commit hash.
+        """
+        path = self._get_wheel_cache_path(commit_hash)
+        stamp = os.path.join(path, 'timestamp')
+        if not os.path.isdir(path):
+            os.makedirs(path)
+        with open(stamp, 'wb'):
+            pass
+        return path
+
+    def _get_wheel(self, commit_hash):
+        cache_path = self._get_wheel_cache_path(commit_hash)
+
+        for fn in os.listdir(cache_path):
+            if fn.endswith('.whl'):
+                return os.path.join(cache_path, fn)
+        return None
+
+    def _cleanup_wheel_cache(self):
+        if not os.path.isdir(self._path):
+            return
+
+        def sort_key(name):
+            path = os.path.join(self._path, name, 'timestamp')
+            try:
+                return os.stat(path).st_mtime
+            except OSError:
+                return 0
+
+        names = os.listdir(self._path)
+        if len(names) < self._wheel_cache_size:
+            return
+
+        names.sort(key=sort_key, reverse=True)
+
+        for name in names[self._wheel_cache_size:]:
+            path = os.path.join(self._path, name)
+            if os.path.isdir(path):
+                shutil.rmtree(path)
+
+    def build_project_cached(self, env, package, commit_hash):
+        if self._wheel_cache_size == 0:
+            return None
+
+        if not os.path.isdir(self._path):
+            return
+
+        if commit_hash is None:
+            commit_hash = env.repo.get_hash_from_head()
+
+        wheel = self._get_wheel(commit_hash)
+        if wheel:
+            return wheel
+
+        self._cleanup_wheel_cache()
+
+        build_root = env.build_project(commit_hash)
+        cache_path = self._create_wheel_cache_path(commit_hash)
+
+        try:
+            env._run_executable(
+                'pip', ['wheel', '--wheel-dir', cache_path,
+                        '--no-deps', '--no-index', build_root])
+        except util.ProcessError:
+            # failed -- clean up
+            shutil.rmtree(cache_path)
+            raise
+
+        return self._get_wheel(commit_hash)

--- a/asv/wheel_cache.py
+++ b/asv/wheel_cache.py
@@ -37,6 +37,9 @@ class WheelCache(object):
     def _get_wheel(self, commit_hash):
         cache_path = self._get_wheel_cache_path(commit_hash)
 
+        if not os.path.isdir(cache_path):
+            return None
+
         for fn in os.listdir(cache_path):
             if fn.endswith('.whl'):
                 return os.path.join(cache_path, fn)

--- a/asv/wheel_cache.py
+++ b/asv/wheel_cache.py
@@ -68,9 +68,6 @@ class WheelCache(object):
         if self._wheel_cache_size == 0:
             return None
 
-        if not os.path.isdir(self._path):
-            return
-
         wheel = self._get_wheel(commit_hash)
         if wheel:
             return wheel

--- a/asv/wheel_cache.py
+++ b/asv/wheel_cache.py
@@ -71,9 +71,6 @@ class WheelCache(object):
         if not os.path.isdir(self._path):
             return
 
-        if commit_hash is None:
-            commit_hash = env.repo.get_hash_from_head()
-
         wheel = self._get_wheel(commit_hash)
         if wheel:
             return wheel

--- a/docs/source/asv.conf.json.rst
+++ b/docs/source/asv.conf.json.rst
@@ -113,7 +113,7 @@ by looking for tools on the ``PATH`` environment variable.
 -----------
 The directory, relative to the current directory, to cache the Python
 environments in.  If not provided, defaults to ``"env"``.
-
+`
 ``results_dir``
 ---------------
 The directory, relative to the current directory, that the raw results
@@ -135,3 +135,7 @@ results, where the full commit hash is always retained.
 ``plugins``
 -----------
 A list of modules to import containing asv plugins.
+
+``wheel_cache_size``
+--------------------
+The number of wheels (builds) to cache for each environment.

--- a/docs/source/dev.rst
+++ b/docs/source/dev.rst
@@ -1,0 +1,135 @@
+Developer Docs
+==============
+
+This section describes some things that may be of interest to
+developers of ``asv``.
+
+Benchmark suite layout
+----------------------
+
+A benchmark suite directory has the following layout.  The
+``$``-prefixed variables refer to values in the ``asv.conf.json`` file.
+
+- ``asv.conf.json``: The configuration file.
+
+- ``$benchmark_dir``: Contains the benchmark code, created by the
+  user.  Each subdirectory needs an ``__init__.py``.
+
+- ``$project/``: A clone of the project being benchmarked.
+  Information about the history is grabbed from here, but the actual
+  building happens in the environment-specific clones described below.
+
+- ``$env_dir/``: Contains the environments used for building and
+  benchmarking.  There is one environment in here for each specific
+  combination of Python version and library dependency.  Generally,
+  the dependencies are only installed once, and then reused on
+  subsequent runs of ``asv``, but the project itself needs to be
+  rebuilt for each commit being benchmarked.
+
+  - ``$ENVIRONMENT_HASH/``: The directory name of each environment is
+    the md5hash of the list of dependencies and the Python version.
+    This is not very user friendly, but this keeps the filename within
+    reasonable limits.
+
+    - ``asv-env-info.json``: Contains information about the
+      environment, mainly the Python version and dependencies used.
+
+    - ``project/``: An environment-specific clone of the project
+      repository.  Each environment has its own clone so that builds
+      can be run in parallel without fear of clobbering (particularly
+      for projects that generate source files outside of the
+      ``build/`` directory.  These clones are created from the main
+      ``$project/`` directory using the ``--shared`` option to ``git
+      clone`` so that the repository history is stored in one place to
+      save on disk space.
+
+      The project is built in this directory with the standard
+      ``distutils`` ``python setup.py build`` command.  This means
+      repeated builds happen in the same place and `ccache
+      <https://ccache.samba.org>`__ is able to cache and reuse many of
+      the build products.
+
+    - ``wheels/``: If ``wheel_cache_size`` in ``asv.conf.json`` is set
+      to something other than 0, this contains `Wheels
+      <https://pypi.python.org/pypi/wheel>`__ of the last N project
+      builds for this environment.  In this way, if a build for a
+      particular commit has already been performed and cached, it can
+      be restored much more quickly.  Each subdirectory is a commit
+      hash, containing one ``.whl`` file and a timestamp.
+
+    - ``usr/``, ``lib/``, ``bin/`` etc.: These are the virtualenv or
+      Conda environment directories that we install the project into
+      and then run benchmarks from.
+
+- ``$results_dir/``: This is the "database" of results from benchmark
+  runs.
+
+  - ``benchmarks.json``: Contains metadata about all of the
+    benchmarks in the suite.  It is a dictionary from benchmark
+    names (a fully-qualified dot-separated path) to dictionaries
+    containing information about that benchmark.  Useful keys
+    include:
+
+    - ``code``: The Python code of the benchmark
+
+    Other keys are specific to the kind of benchmark, and correspond
+    to :ref:`benchmark-attributes`.
+
+  - ``MACHINE/``: Within the results directory is a directory for each
+    machine.  Putting results from different machines in separate
+    directories makes the results trivial to merge, which is useful
+    when benchmarking across different platforms or architectures.
+
+    - ``HASH-pythonX.X-depA-depB.json``: Each JSON file within a
+      particular machine represents a run of benchmarks for a
+      particular project commit in a particular environment.  Useful
+      keys include:
+
+      - ``commit_hash``: The project commit that the benchmarks were
+        run on.
+
+      - ``date``: A Javascript date stamp of the date of the commit
+        (not when the benchmarks were run).
+
+      - ``params``: Information about the machine the benchmarks were
+        run on.
+
+      - ``results``: A dictionary from benchmark names to benchmark
+        results.
+
+- ``$html_dir/``: The output of ``asv publish``, that turns the raw
+  results in ``$results_dir/`` into something viewable in a web
+  browser.  It is an important feature of ``asv`` that the results can
+  be shared on a static web server, so there is no server side
+  component, and the result data is accessed through AJAX calls from
+  Javascript.  Most of the files at the root of ``$html_dir/`` are
+  completely static and are just copied verbatim from ``asv/www/`` in
+  the source tree.
+
+  - ``index.json``: Contains an index into the benchmark data,
+    describing what is available.  Important keys include:
+
+    - ``benchmarks``: A dictionary of benchmarks.  At the moment, this
+      is identical to the content in ``$results_dir/benchmarks.json``.
+
+    - ``date_to_hash``: A dictionary mapping Javascript date stamps to
+      commit hashes.  This allows the x-scale of a plot to be scaled
+      by date.
+
+    - ``machines``: Describes the machines used for testing.
+
+    - ``params``: A dictionary of parameters against which benchmark
+      results can be selected.  Each entry is a list of valid values
+      for that parameter.
+
+    - ``tags``: A dictionary of git tags and their dates, so this
+      information can be displayed in the plot.
+
+  - ``graphs/``: This is a nested tree of directories where each level
+    is a parameter from the ``params`` dictionary, in asciibetical
+    order.  The web interface, given a set of parameters that are set,
+    get easily grab the associated graph.
+
+    - ``BENCHMARK_NAME.json``: At the leaves of this tree are the
+      actual benchmark graphs.  It contains a list of pairs, where
+      each pair is of the form ``(timestamp, result_value)``.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -29,3 +29,4 @@ License: `BSD three-clause license
    using.rst
    writing_benchmarks.rst
    reference.rst
+   dev.rst

--- a/docs/source/writing_benchmarks.rst
+++ b/docs/source/writing_benchmarks.rst
@@ -105,6 +105,8 @@ clean up any changes made to the filesystem.  Generally, however, it
 is not required: each benchmark runs in its own process, so any
 tearing down of in-memory state happens automatically.
 
+.. _benchmark-attributes:
+
 Benchmark attributes
 --------------------
 

--- a/test/asv.conf.json
+++ b/test/asv.conf.json
@@ -26,4 +26,6 @@
     "plugins": [".example_plugin"],
 
     "benchmark_dir": "benchmark",
+
+    "wheel_cache_size": 10
 }

--- a/test/test_benchmarks.py
+++ b/test/test_benchmarks.py
@@ -13,7 +13,6 @@ import six
 from asv import benchmarks
 from asv import config
 from asv import environment
-from asv.repo import get_repo
 from asv import util
 
 BENCHMARK_DIR = os.path.join(os.path.dirname(__file__), 'benchmark')
@@ -36,7 +35,6 @@ def test_find_benchmarks(tmpdir):
     d.update(ASV_CONF_JSON)
     d['env_dir'] = os.path.join(tmpdir, "env")
     conf = config.Config.from_json(d)
-    repo = get_repo(conf)
 
     b = benchmarks.Benchmarks(conf, regex='secondary')
     assert len(b) == 3
@@ -50,7 +48,7 @@ def test_find_benchmarks(tmpdir):
     b = benchmarks.Benchmarks(conf)
     assert len(b) == 10
 
-    envs = list(environment.get_environments(conf, repo))
+    envs = list(environment.get_environments(conf))
     b = benchmarks.Benchmarks(conf)
     times = b.run_benchmarks(envs[0], profile=True, show_stderr=True)
 

--- a/test/test_benchmarks.py
+++ b/test/test_benchmarks.py
@@ -13,6 +13,7 @@ import six
 from asv import benchmarks
 from asv import config
 from asv import environment
+from asv.repo import get_repo
 from asv import util
 
 BENCHMARK_DIR = os.path.join(os.path.dirname(__file__), 'benchmark')
@@ -35,6 +36,7 @@ def test_find_benchmarks(tmpdir):
     d.update(ASV_CONF_JSON)
     d['env_dir'] = os.path.join(tmpdir, "env")
     conf = config.Config.from_json(d)
+    repo = get_repo(conf)
 
     b = benchmarks.Benchmarks(conf, regex='secondary')
     assert len(b) == 3
@@ -48,7 +50,7 @@ def test_find_benchmarks(tmpdir):
     b = benchmarks.Benchmarks(conf)
     assert len(b) == 10
 
-    envs = list(environment.get_environments(conf))
+    envs = list(environment.get_environments(conf, repo))
     b = benchmarks.Benchmarks(conf)
     times = b.run_benchmarks(envs[0], profile=True, show_stderr=True)
 

--- a/test/test_environment.py
+++ b/test/test_environment.py
@@ -12,7 +12,6 @@ from asv import environment
 from asv import util
 
 
-
 try:
     util.which('python2.7')
     HAS_PYTHON_27 = True
@@ -39,8 +38,7 @@ def test_matrix_environments(tmpdir):
         "six": ["1.4", None],
         "psutil": ["1.2", "2.1"]
     }
-
-    environments = list(environment.get_environments(conf))
+    environments = list(environment.get_environments(conf, None))
 
     assert len(environments) == 2 * 2 * 2
 
@@ -74,7 +72,7 @@ def test_large_environment_matrix(tmpdir):
     for i in range(25):
         conf.matrix['foo{0}'.format(i)] = []
 
-    environments = list(environment.get_environments(conf))
+    environments = list(environment.get_environments(conf, None))
 
     for env in environments:
         # Since *actually* installing all the dependencies would make

--- a/test/test_environment.py
+++ b/test/test_environment.py
@@ -38,7 +38,7 @@ def test_matrix_environments(tmpdir):
         "six": ["1.4", None],
         "psutil": ["1.2", "2.1"]
     }
-    environments = list(environment.get_environments(conf, None))
+    environments = list(environment.get_environments(conf))
 
     assert len(environments) == 2 * 2 * 2
 
@@ -72,7 +72,7 @@ def test_large_environment_matrix(tmpdir):
     for i in range(25):
         conf.matrix['foo{0}'.format(i)] = []
 
-    environments = list(environment.get_environments(conf, None))
+    environments = list(environment.get_environments(conf))
 
     for env in environments:
         # Since *actually* installing all the dependencies would make


### PR DESCRIPTION
This results in building the project in the same directory every time, giving ccache a better chance of doing its thing.  An alternate solution to #201.

`pip install /some/local/path` has been used in asv to install the benchmarked project on the assumption that `pip` knows better about the details of how to install a Python package beyond just the usual `setup.py install`.  However, I wonder if that's really the case...

Note that I tried to use the `--build` flag for `pip install` to force it to build in a specific directory.  This seems to work for remote packages, but it's ignored when given a local path...

Attn: @pv 