### PR TITLE
Cache build results in Python wheels for faster installation

### DIFF
--- a/asv/benchmarks.py
+++ b/asv/benchmarks.py
@@ -197,7 +197,7 @@ class Benchmarks(dict):
             repo = get_repo(conf)
             repo.checkout()
 
-            env.install_project(conf)
+            env.install_project(conf, repo.get_hash_from_head())
 
             output = env.run(
                 [BENCHMARK_RUN_SCRIPT, 'discover', root],

--- a/asv/commands/find.py
+++ b/asv/commands/find.py
@@ -127,7 +127,7 @@ class Find(Command):
                     conf.project, commit_hash[:8]))
 
             repo.checkout(commit_hash)
-            env.install_project(conf)
+            env.install_project(conf, commit_hash)
             x = benchmarks.run_benchmarks(
                 env, show_stderr=show_stderr)
             results[i] = list(x.values())[0]['result']

--- a/asv/commands/profiling.py
+++ b/asv/commands/profiling.py
@@ -204,7 +204,7 @@ class Profile(Command):
                 log.info("Running profiler")
             with log.indent():
                 repo.checkout(commit_hash)
-                env.install_project(conf)
+                env.install_project(conf, commit_hash)
 
                 results = benchmarks.run_benchmarks(
                     env, show_stderr=True, quick=False, profile=True)

--- a/asv/commands/run.py
+++ b/asv/commands/run.py
@@ -18,9 +18,9 @@ from .setup import Setup
 
 
 def _do_build(args):
-    env, conf = args
+    env, conf, commit_hash = args
     try:
-        env.install_project(conf)
+        env.install_project(conf, commit_hash)
     except util.ProcessError:
         return False
     return True
@@ -228,7 +228,7 @@ class Run(Command):
                     log.info("Building for {0}".format(
                         ', '.join([x.name for x in subenv])))
                     with log.indent():
-                        args = [(env, conf) for env in subenv]
+                        args = [(env, conf, commit_hash) for env in subenv]
                         if parallel != 1:
                             pool = multiprocessing.Pool(parallel)
                             successes = pool.map(_do_build_multiprocess, args)

--- a/asv/environment.py
+++ b/asv/environment.py
@@ -241,7 +241,7 @@ class Environment(object):
         """
         raise NotImplementedError()
 
-    def install_project(self, conf):
+    def install_project(self, conf, commit_hash):
         """
         Install a working copy of the benchmarked project into the
         environment.  Uninstalls any installed copy of the project
@@ -313,7 +313,7 @@ class ExistingEnvironment(Environment):
     def install_requirements(self):
         pass
 
-    def install_project(self, conf):
+    def install_project(self, conf, commit_hash):
         pass
 
     def can_install_project(self):

--- a/asv/plugins/conda.py
+++ b/asv/plugins/conda.py
@@ -141,7 +141,7 @@ class Conda(environment.Environment):
         return util.check_output([
             os.path.join(self._path, 'bin', executable)] + args, **kwargs)
 
-    def install(self, package, editable=False):
+    def install(self, package, editable=False, commit_hash=None):
         rel = os.path.relpath(package, os.getcwd())
         log.info("Installing {0} into {1}".format(rel, self.name))
         args = ['install']


### PR DESCRIPTION
This may be useful when manually running `asv`. Quite often, you don't get the command line switches right the first time, and some benchmark fails e.g with timeout, so cutting down time spent waiting on rebuilds becomes useful. (For Scipy, the build time is 2 min (with ccache+f90cache) which is already annoying to wait for, whereas wheel install time is 2 seconds.)

Now, one question is how well `pip wheel` works with various Python projects. I'd believe it works almost for everything, but not 100% sure.