### PR TITLE
For python=same, do not clone repository or print no-op actions

### DIFF
--- a/asv/commands/dev.py
+++ b/asv/commands/dev.py
@@ -46,6 +46,10 @@ class Dev(Run):
 
     @classmethod
     def run_from_conf_args(cls, conf, args):
-        return cls.run(
-            conf=conf, bench=args.bench, show_stderr=True, quick=True,
-            python=args.python, machine=args.machine, dry_run=True)
+        return cls.run(conf, bench=args.bench, machine=args.machine, python=args.python)
+
+    @classmethod
+    def run(cls, conf, bench=None, python="same", machine=None, _machine_file=None):
+        return super(cls, Dev).run(conf=conf, bench=bench, show_stderr=True, quick=True,
+                                   python=python, machine=machine, dry_run=True,
+                                   _machine_file=_machine_file)

--- a/asv/commands/profiling.py
+++ b/asv/commands/profiling.py
@@ -128,6 +128,9 @@ class Profile(Command):
             raise util.UserError(
                 "Must specify benchmark to run")
 
+        if python == "same":
+            conf.dvcs = "none"
+
         repo = get_repo(conf)
 
         if python is not None:
@@ -152,7 +155,7 @@ class Profile(Command):
 
         # First, we see if we already have the profile in the results
         # database
-        if not force:
+        if not force and commit_hash:
             for result in iter_results_for_machine(
                     conf.results_dir, machine_name):
                 if hash_equal(commit_hash, result.commit_hash):
@@ -169,7 +172,7 @@ class Profile(Command):
                 log.error("No environments selected")
                 return
 
-            if revision is not None:
+            if revision != "master":
                 for env in environments:
                     if not env.can_install_project():
                         raise util.UserError(

--- a/asv/commands/profiling.py
+++ b/asv/commands/profiling.py
@@ -223,5 +223,5 @@ class Profile(Command):
         else:
             with temp_profile(profile_data) as profile_path:
                 stats = pstats.Stats(profile_path)
-                stats.sort_stats('cumtime')
+                stats.sort_stats('cumulative')
                 stats.print_stats()

--- a/asv/commands/run.py
+++ b/asv/commands/run.py
@@ -143,6 +143,11 @@ class Run(Command):
         params.update(machine_params.__dict__)
         machine_params.save(conf.results_dir)
 
+        if python == "same":
+            conf.dvcs = "none"
+            conf.repo = ""
+            dry_run = True
+
         repo = get_repo(conf)
 
         if python is not None:
@@ -219,9 +224,10 @@ class Run(Command):
         _returns['machine_params'] = machine_params.__dict__
 
         for commit_hash in commit_hashes:
-            log.info(
-                "For {0} commit hash {1}:".format(
-                    conf.project, commit_hash[:8]))
+            if commit_hash:
+                log.info(
+                    "For {0} commit hash {1}:".format(
+                        conf.project, commit_hash[:8]))
             with log.indent():
                 for subenv in util.iter_chunks(environments, parallel):
                     log.info("Building for {0}".format(

--- a/asv/commands/setup.py
+++ b/asv/commands/setup.py
@@ -61,6 +61,10 @@ class Setup(Command):
     def run(cls, conf, parallel=-1):
         environments = list(environment.get_environments(conf))
 
+        if all(isinstance(env, environment.ExistingEnvironment) for env in environments):
+            # Nothing to do, so don't print anything
+            return environments
+
         parallel, multiprocessing = util.get_multiprocessing(parallel)
 
         log.info("Creating environments")

--- a/asv/environment.py
+++ b/asv/environment.py
@@ -372,6 +372,9 @@ class ExistingEnvironment(Environment):
     def name(self):
         return self._executable
 
+    def create(self):
+        pass
+
     def setup(self):
         pass
 
@@ -382,7 +385,7 @@ class ExistingEnvironment(Environment):
         pass
 
     def can_install_project(self):
-        return True
+        return False
 
     def run(self, args, **kwargs):
         log.debug("Running '{0}' in {1}".format(' '.join(args), self.name))

--- a/asv/repo.py
+++ b/asv/repo.py
@@ -100,6 +100,60 @@ class Repo(object):
         raise NotImplementedError()
 
 
+class NoRepository(Repo):
+    """
+    Project installed in the current environment
+    """
+
+    dvcs = "none"
+
+    def __init__(self, url=None, path=None, shared=False):
+        self.url = None
+        self.path = None
+
+    def _raise_error(self):
+        raise ValueError("Using the currently installed project version: "
+                         "operations requiring repository are not possible")
+
+    def _check_branch(self, branch):
+        if branch is not None:
+            self._raise_error()
+
+    @classmethod
+    def url_match(cls, url):
+        return False
+
+    def checkout(self, branch):
+        self._check_branch(branch)
+
+    def clean(self, branch):
+        self._check_branch(branch)
+
+    def get_date(self, hash):
+        self._raise_error()
+
+    def get_hashes_from_range(self, range):
+        return [None]
+
+    def get_hash_from_head(self):
+        return None
+
+    def get_hash_from_tag(self, range):
+        return None
+
+    def get_tags(self):
+        return []
+
+    def get_date_from_tag(self, tag):
+        self._raise_error()
+
+    def checkout_remote_branch(self, remote, branch):
+        self._raise_error()
+
+    def checkout_parent(self):
+        self._raise_error()
+
+
 def get_repo(conf):
     """
     Get a Repo subclass for the given configuration.

--- a/test/test_dev.py
+++ b/test/test_dev.py
@@ -1,0 +1,127 @@
+# -*- coding: utf-8 -*-
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+
+from __future__ import (absolute_import, division, print_function,
+                        unicode_literals)
+
+import os
+import sys
+import re
+from os.path import abspath, dirname, exists, join, isfile
+import shutil
+import pytest
+from io import StringIO
+
+import six
+
+from asv import config
+from asv.commands.dev import Dev
+from asv.commands.profiling import Profile
+from asv.commands.run import Run
+
+
+@pytest.fixture
+def basic_conf(tmpdir):
+    tmpdir = six.text_type(tmpdir)
+    local = abspath(dirname(__file__))
+    os.chdir(tmpdir)
+
+    shutil.copyfile(join(local, 'asv-machine.json'),
+                    join(tmpdir, 'asv-machine.json'))
+
+    conf = config.Config.from_json({
+        'env_dir': join(tmpdir, 'env'),
+        'benchmark_dir': join(local, 'benchmark'),
+        'results_dir': join(tmpdir, 'results_workflow'),
+        'html_dir': join(tmpdir, 'html'),
+        'repo': 'https://github.com/spacetelescope/asv.git',
+        'project': 'asv',
+        'matrix': {
+            "six": [None],
+            "psutil": ["1.2", "2.1"]
+        }
+    })
+
+    return tmpdir, local, conf
+
+
+def test_dev(basic_conf):
+    tmpdir, local, conf = basic_conf
+
+    # Test Dev runs
+    s = StringIO()
+    stdout = sys.stdout
+    try:
+        sys.stdout = s
+        Dev.run(conf, _machine_file=join(tmpdir, 'asv-machine.json'))
+    finally:
+        sys.stdout = stdout
+
+    s.seek(0)
+    text = s.read()
+
+    # time_with_warnings failure case
+    assert re.search("File.*time_exception.*RuntimeError", text, re.S)
+    assert re.search(r"Running time_secondary.track_value\s+42.0", text)
+
+    # Check that it did not clone or install
+    assert "Cloning" not in text
+    assert "Installing" not in text
+
+
+def test_run_python_same(basic_conf):
+    tmpdir, local, conf = basic_conf
+
+    # Test Run runs with python=same
+    s = StringIO()
+    stdout = sys.stdout
+    try:
+        sys.stdout = s
+        Run.run(conf, _machine_file=join(tmpdir, 'asv-machine.json'), python="same")
+    finally:
+        sys.stdout = stdout
+
+    s.seek(0)
+    text = s.read()
+
+    assert re.search("time_exception.*failed", text, re.S)
+    assert re.search(r"Running time_secondary.track_value\s+42.0", text)
+
+    # Check that it did not clone or install
+    assert "Cloning" not in text
+    assert "Installing" not in text
+
+
+def test_profile_python_same(basic_conf):
+    tmpdir, local, conf = basic_conf
+
+    if sys.version_info[0] == 2:
+        # pstats.Profile prints stuff to stdout as bytes
+        from StringIO import StringIO as StringIO_py2
+        s = StringIO_py2()
+    else:
+        s = StringIO()
+
+    # Test Profile can run with python=same
+    stdout = sys.stdout
+    try:
+        sys.stdout = s
+        Profile.run(conf, "time_secondary.track_value",
+                    _machine_file=join(tmpdir, 'asv-machine.json'),
+                    python="same")
+    finally:
+        sys.stdout = stdout
+
+    s.seek(0)
+    text = s.read()
+
+    # time_with_warnings failure case
+    assert re.search(r"^\s+1\s+.*time_secondary.*\(track_value\)", text, re.M)
+
+    # Check that it did not clone or install
+    assert "Cloning" not in text
+    assert "Installing" not in text
+
+
+if __name__ == '__main__':
+    test_dev('/tmp')


### PR DESCRIPTION
The `asv dev` / `asv run --python=same` commands assume the project is already installed in the current overall Python environment. Therefore, we can skip all operations on the repository. Also, skip printing unnecessary things to stdout, and add a test checking `asv dev` works.

The use case I have in mind is to be able to use asv simply as a benchmark runner, without needing its repository/environment management features.