### PR TITLE
Add options to run command to run only missing benchmarks

### DIFF
--- a/asv/benchmarks.py
+++ b/asv/benchmarks.py
@@ -422,7 +422,8 @@ class Benchmarks(dict):
 
         return cls(conf, benchmarks=d)
 
-    def run_benchmarks(self, env, show_stderr=False, quick=False, profile=False):
+    def run_benchmarks(self, env, show_stderr=False, quick=False, profile=False,
+                       skip=None):
         """
         Run all of the benchmarks in the given `Environment`.
 
@@ -443,6 +444,9 @@ class Benchmarks(dict):
         profile : bool, optional
             When `True`, run the benchmark through the `cProfile`
             profiler.
+
+        skip : set, optional
+            Benchmark names to skip.
 
         Returns
         -------
@@ -471,6 +475,8 @@ class Benchmarks(dict):
             times = {}
             benchmarks = sorted(list(six.iteritems(self)))
             for name, benchmark in benchmarks:
+                if skip and name in skip:
+                    continue
                 times[name] = run_benchmark(
                     benchmark, self._benchmark_dir, env, show_stderr=show_stderr,
                     quick=quick, profile=profile)
@@ -478,7 +484,7 @@ class Benchmarks(dict):
 
     def skip_benchmarks(self, env):
         """
-        Mark all of the benchmarks as skipped.
+        Mark benchmarks as skipped.
         """
         log.warn("Skipping {0}".format(env.name))
         with log.indent():

--- a/asv/results.py
+++ b/asv/results.py
@@ -51,8 +51,8 @@ def iter_results_for_machine_and_hash(results, machine_name, commit):
     for (root, filename) in iter_results_paths(
             os.path.join(results, machine_name)):
         results_commit = filename.split('-')[0]
-        max_len = max(len(commit), len(results_commit))
-        if results_commit[:max_len] == commit[:max_len]:
+        cmp_len = min(len(commit), len(results_commit))
+        if results_commit[:cmp_len] == commit[:cmp_len]:
             yield Results.load(os.path.join(root, filename))
 
 

--- a/test/test_workflow.py
+++ b/test/test_workflow.py
@@ -9,6 +9,7 @@ import sys
 from os.path import abspath, dirname, exists, join, isfile
 import shutil
 import glob
+from io import StringIO
 
 import six
 import json
@@ -81,6 +82,20 @@ def test_run_publish(basic_conf):
         assert isinstance(data[0][1][0], float)
         assert isinstance(data[0][1][1], float)
         assert data[0][1][2] is None
+
+    # Check that the skip options work
+    s = StringIO()
+    stdout = sys.stdout
+    try:
+        sys.stdout = s
+        Run.run(conf, range_spec="6b1fb9b04f..2927a27ec", steps=2,
+                _machine_file=join(tmpdir, 'asv-machine.json'), quick=True,
+                skip_successful=True, skip_failed=True)
+    finally:
+        sys.stdout = stdout
+    s.seek(0)
+    text = s.read()
+    assert 'Running benchmarks.' not in text
 
     # Check EXISTING works
     Run.run(conf, range_spec="EXISTING",

--- a/test/test_workflow.py
+++ b/test/test_workflow.py
@@ -91,6 +91,9 @@ def test_run_publish(basic_conf):
         Run.run(conf, range_spec="6b1fb9b04f..2927a27ec", steps=2,
                 _machine_file=join(tmpdir, 'asv-machine.json'), quick=True,
                 skip_successful=True, skip_failed=True)
+        Run.run(conf, range_spec="6b1fb9b04f..2927a27ec", steps=2,
+                _machine_file=join(tmpdir, 'asv-machine.json'), quick=True,
+                skip_existing_commits=True)
     finally:
         sys.stdout = stdout
     s.seek(0)


### PR DESCRIPTION
Add options to `asv run` to skip benchmarks based on whether there are existing results or not.
This operates on a finer-grained level than the `MISSING` range_spec option.

I assume the intent in the hash comparison code in iter_results_for_machine_and_hash was to allow matching on the shortest initial part, and not require full match always?