### PR TITLE
CSS fix: prevent benchmark tree view carets from ending up at different lines than the labels

### DIFF
--- a/asv/www/asv.css
+++ b/asv/www/asv.css
@@ -86,3 +86,11 @@
 .nav>li>a {
     padding: 0;
 }
+
+.nav-list>li {
+    overflow-x: hidden;
+}
+
+.nav-list>li>.nav-header {
+    white-space: nowrap;
+}


### PR DESCRIPTION
If benchmark names are long, the carets in the benchmark tree view in the web UI may end up at different lines than the labels:

![tmp](https://cloud.githubusercontent.com/assets/35046/6156898/e70410b2-b245-11e4-8506-9840a6a34667.png)

Add a CSS fix to prevent this -- better to just let the text overflow.
Fixed example: https://pv.github.io/scipy-bench/#sparse_linalg_onenormest.BenchmarkOneNormEst.time_onenormest