### PR TITLE
In JS UI for parameterized benchmarks, don't include x-axis in parameter permutation set

### DIFF
--- a/asv/www/asv.js
+++ b/asv/www/asv.js
@@ -858,8 +858,10 @@ $(function() {
                 /* For parameterized tests: names of benchmark parameters */
                 var params = master_json.benchmarks[current_benchmark].params;
                 var param_names = master_json.benchmarks[current_benchmark].param_names;
-                /* Selected permutations of benchmark parameters */
-                var param_permutations = permutations(param_selection);
+                /* Selected permutations of benchmark parameters, omitting x-axis */
+                var selection = obj_copy(param_selection);
+                selection[x_coordinate_axis] = [null]; /* value not referenced, set to null */
+                var param_permutations = permutations(selection);
 
                 /* Generate a master list of URLs and legend labels for
                    the graphs. */


### PR DESCRIPTION
Forgot one necessary part of the last set of changes in gh-205.

This results to same values plotted multiple times, if multiple items selections were previously active for the current x-axis parameter. Example: go to https://pv.github.io/scipy-bench/#sparse.Matvec.time_matvec and select "matrix" as x-axis.

Fix is fairly straightforward: the current x-axis needs to be excluded from the permutation set.