### PR TITLE
Really mirror the upstream repository + refactor Repo API

### DIFF
--- a/asv/commands/continuous.py
+++ b/asv/commands/continuous.py
@@ -66,11 +66,8 @@ class Continuous(Command):
         repo = get_repo(conf)
         repo.pull()
 
-        repo.checkout_remote_branch('origin', branch)
-        head = repo.get_hash_from_head()
-
-        repo.checkout_parent()
-        parent = repo.get_hash_from_head()
+        head = repo.get_hash_from_name(branch)
+        parent = repo.get_hash_from_parent(branch)
 
         commit_hashes = [head, parent]
         run_objs = {}

--- a/asv/commands/profiling.py
+++ b/asv/commands/profiling.py
@@ -144,14 +144,10 @@ class Profile(Command):
         machine_name = Machine.get_unique_machine_name()
         if revision is None:
             revision = 'master'
-        commit_hash = repo.get_hash_from_tag(revision)
+        commit_hash = repo.get_hash_from_name(revision)
 
         profile_data = None
-
-        # Even if we don't end up running the profile, we need to
-        # checkout the correct commit_hash so the line numbers in the
-        # profile data match up with what's in the source tree.
-        repo.checkout(commit_hash)
+        checked_out = set()
 
         # First, we see if we already have the profile in the results
         # database
@@ -162,6 +158,12 @@ class Profile(Command):
                     if result.has_profile(benchmark):
                         if (environment is None or
                             result.env.name == environment):
+                            if result.env.name not in checked_out:
+                                # We need to checkout the correct commit so that
+                                # the line numbers in the profile data match up with
+                                # what's in the source tree.
+                                result.env.checkout_project(commit_hash)
+                                checked_out.add(result.env.name)
                             profile_data = result.get_profile(benchmark)
                             break
 

--- a/asv/commands/profiling.py
+++ b/asv/commands/profiling.py
@@ -143,8 +143,9 @@ class Profile(Command):
 
         machine_name = Machine.get_unique_machine_name()
         if revision is None:
-            revision = 'master'
-        commit_hash = repo.get_hash_from_name(revision)
+            commit_hash = repo.get_hash_from_master()
+        else:
+            commit_hash = repo.get_hash_from_name(revision)
 
         profile_data = None
         checked_out = set()
@@ -174,7 +175,7 @@ class Profile(Command):
                 log.error("No environments selected")
                 return
 
-            if revision != "master":
+            if revision is not None:
                 for env in environments:
                     if not env.can_install_project():
                         raise util.UserError(

--- a/asv/commands/publish.py
+++ b/asv/commands/publish.py
@@ -173,7 +173,7 @@ class Publish(Command):
             tags = {}
             for tag in repo.get_tags():
                 log.dot()
-                tags[tag] = repo.get_date_from_tag(tag)
+                tags[tag] = repo.get_date_from_name(tag)
 
         log.step()
         log.info("Writing index")

--- a/asv/plugins/mercurial.py
+++ b/asv/plugins/mercurial.py
@@ -22,7 +22,7 @@ from ..repo import Repo
 class Hg(Repo):
     dvcs = "hg"
 
-    def __init__(self, url, path, shared=False):
+    def __init__(self, url, path, _checkout_copy=False):
         # TODO: shared repositories in Mercurial are only possible
         # through an extension, and it's not clear how to use those in
         # this context.  So here, we always make full clones for
@@ -37,13 +37,13 @@ class Hg(Repo):
             log.info("Cloning project")
             if url.startswith("hg+"):
                 url = url[3:]
-            hglib.clone(url, dest=self._path)
+
+            # Mercurial branches are global, so there is no need for
+            # an analog of git --mirror
+            hglib.clone(url, dest=self._path,
+                        noupdate=(not _checkout_copy))
 
         self._repo = hglib.open(self._path)
-
-    @property
-    def path(self):
-        return self._path
 
     @classmethod
     def url_match(cls, url):
@@ -73,12 +73,17 @@ class Hg(Repo):
 
         log.info("Fetching recent changes")
         self._repo.pull()
-        self.checkout('tip')
         self._pulled = True
 
-    def checkout(self, branch='tip'):
-        self._repo.update(branch, clean=True)
-        self.clean()
+    def checkout(self, path, commit_hash):
+        subrepo = Hg(self._path, path, _checkout_copy=True)
+
+        # Need to pull -- the copy is not updated automatically, since
+        # the repository data is not shared
+        subrepo.pull()
+
+        subrepo._repo.update(commit_hash, clean=True)
+        subrepo.clean()
 
     def clean(self):
         # TODO: Implement purge manually or call it on the command line
@@ -92,21 +97,17 @@ class Hg(Repo):
     def get_hashes_from_range(self, range_spec):
         return [rev.node for rev in self._repo.log(range_spec)]
 
-    def get_hash_from_tag(self, tag):
-        return self._repo.log(tag)[0].rev
+    def get_hash_from_name(self, name):
+        return self._repo.log(name)[0].rev
 
-    def get_hash_from_head(self):
-        return self.get_hash_from_tag('tip')
+    def get_hash_from_master(self):
+        return self.get_hash_from_name('tip')
+
+    def get_hash_from_parent(self, name):
+        return self.get_hash_from_name('p1({0})'.format(name))
 
     def get_tags(self):
         return [item[0] for item in self._repo.tags()]
 
-    def get_date_from_tag(self, tag):
-        return self.get_date(tag)
-
-    def checkout_remote_branch(self, remote, branch):
-        self._repo.pull(remote)
-        self.checkout('tip')
-
-    def checkout_parent(self):
-        self.checkout('p1(.)')
+    def get_date_from_name(self, name):
+        return self.get_date(name)

--- a/asv/repo.py
+++ b/asv/repo.py
@@ -12,8 +12,10 @@ class Repo(object):
     """
     Base class for repository handlers.
     """
-    def __init__(self, url, path, shared=False):
+    def __init__(self, url, path):
         """
+        Create a mirror of the repository at `url`, without a working tree.
+
         Parameters
         ----------
         url : str
@@ -21,10 +23,21 @@ class Repo(object):
 
         path : str
             The local path to clone into
+        """
+        raise NotImplementedError()
 
-        shared : bool, optional.
-            When `True`, share the repository history with the source
-            repo's history.
+    def checkout(self, path, commit_hash):
+        """
+        Check out a clean working tree from the current repository
+        to the given path
+
+        Parameters
+        ----------
+        path : str
+            The local path to check out into
+        commit_hash : str
+            The commit hash to check out
+
         """
         raise NotImplementedError()
 
@@ -43,19 +56,6 @@ class Repo(object):
         """
         raise NotImplementedError()
 
-    def checkout(self, branch):
-        """
-        Checkout a given branch or commit hash.  Also cleans the
-        checkout of any non-source-controlled files.
-        """
-        raise NotImplementedError()
-
-    def clean(self):
-        """
-        Clean the repository of any non-checked-in files.
-        """
-        raise NotImplementedError()
-
     def get_date(self, hash):
         """
         Get a Javascript timestamp for a particular commit.
@@ -69,16 +69,22 @@ class Repo(object):
         """
         raise NotImplementedError()
 
-    def get_hash_from_tag(self, range):
+    def get_hash_from_name(self, name):
         """
         Get a hash from a given tag, branch or hash.  The acceptable
         syntax will depend on the DVCS used.
         """
         raise NotImplementedError()
 
-    def get_hash_from_head(self):
+    def get_hash_from_master(self):
         """
-        Get the hash of the currently checked-out commit.
+        Get the hash of the current master branch commit.
+        """
+        raise NotImplementedError()
+
+    def get_hash_from_parent(self, name):
+        """
+        Checkout the parent of the currently checked out commit.
         """
         raise NotImplementedError()
 
@@ -88,21 +94,9 @@ class Repo(object):
         """
         raise NotImplementedError()
 
-    def get_date_from_tag(self, tag):
+    def get_date_from_name(self, name):
         """
-        Get a Javascript timestamp for a particular tag.
-        """
-        raise NotImplementedError()
-
-    def checkout_remote_branch(self, remote, branch):
-        """
-        Fetch and then checkout a remote branch.
-        """
-        raise NotImplementedError()
-
-    def checkout_parent(self):
-        """
-        Checkout the parent of the currently checked out commit.
+        Get a Javascript timestamp for a particular name.
         """
         raise NotImplementedError()
 
@@ -114,7 +108,7 @@ class NoRepository(Repo):
 
     dvcs = "none"
 
-    def __init__(self, url=None, path=None, shared=False):
+    def __init__(self, url=None, path=None):
         self.url = None
         self.path = None
 
@@ -130,11 +124,11 @@ class NoRepository(Repo):
     def url_match(cls, url):
         return False
 
-    def checkout(self, branch):
-        self._check_branch(branch)
+    def checkout(self, path, commit_hash):
+        self._check_branch(commit_hash)
 
-    def clean(self, branch):
-        self._check_branch(branch)
+    def clean(self):
+        return
 
     def get_date(self, hash):
         self._raise_error()
@@ -142,22 +136,19 @@ class NoRepository(Repo):
     def get_hashes_from_range(self, range):
         return [None]
 
-    def get_hash_from_head(self):
+    def get_hash_from_master(self):
         return None
 
-    def get_hash_from_tag(self, range):
+    def get_hash_from_name(self, name):
         return None
+
+    def get_hash_from_parent(self, name):
+        self._raise_error()
 
     def get_tags(self):
         return []
 
-    def get_date_from_tag(self, tag):
-        self._raise_error()
-
-    def checkout_remote_branch(self, remote, branch):
-        self._raise_error()
-
-    def checkout_parent(self):
+    def get_date_from_name(self, name):
         self._raise_error()
 
 

--- a/test/test_repo.py
+++ b/test/test_repo.py
@@ -16,14 +16,18 @@ except ImportError:
     hglib = None
 
 def _test_generic_repo(conf,
+                       tmpdir,
                        hash_range="ae0c27b65741..e6f382a704f7",
                        master="master",
                        branch="gh-pages"):
 
+    workcopy_dir = six.text_type(tmpdir.join("workcopy"))
+
     r = repo.get_repo(conf)
-    r.checkout(master)
-    r.checkout(branch)
-    r.checkout(master)
+
+    r.checkout(workcopy_dir, master)
+    r.checkout(workcopy_dir, branch)
+    r.checkout(workcopy_dir, master)
 
     hashes = r.get_hashes_from_range(hash_range)
     assert len(hashes) == 4
@@ -33,7 +37,7 @@ def _test_generic_repo(conf,
 
     tags = r.get_tags()
     for tag in tags:
-        r.get_date_from_tag(tag)
+        r.get_date_from_name(tag)
 
 
 def test_repo_git(tmpdir):
@@ -41,7 +45,7 @@ def test_repo_git(tmpdir):
 
     conf.project = six.text_type(tmpdir.join("repo"))
     conf.repo = "https://github.com/spacetelescope/asv.git"
-    _test_generic_repo(conf)
+    _test_generic_repo(conf, tmpdir)
 
 
 @pytest.mark.xfail(hglib is None,
@@ -51,5 +55,5 @@ def test_repo_hg(tmpdir):
 
     conf.project = six.text_type(tmpdir.join("repo"))
     conf.repo = "hg+https://bitbucket.org/nds-org/nds-labs"
-    _test_generic_repo(conf, hash_range="a8ca24ac6b77:9dc758deba8",
+    _test_generic_repo(conf, tmpdir, hash_range="a8ca24ac6b77:9dc758deba8",
                        master="tip", branch="dev")


### PR DESCRIPTION
This PR does the following refactoring:

- Remove the concept of "currently checked out revision" from the Repo API. Checkouts of working trees are now always done to a specified directory at an explicit commit hash (whether the result is a clone or not is an implementation detail for the Repo plugin).
- Make Git mirror the remote repository, so that remote branches are available in all asv commands. Mercurial works like this already.
- Don't check out a working tree for the main mirror repository, only do it inside environments
- Replace `checkout_parent` with `get_hash_from_parent`
- Always use `get_hash_from_master` for getting master branch, to be nicer to Mercurial
- Make sure to call `hg pull` on environment-specific repos, as `--shared` in not used for hg
- Rename `_tag` -> `_name` in Repo methods where appropriate
- Allow specifying base branch to compare against in `asv continuous`

The main advantages of this is making all remote branches available to asv (which is what the user will likely expect) and not checking out unnecessary working trees. It also removes the concept of sub-Repo objects in the environment-specific clones, which is slightly simpler and may be better for Subversion.