### PR TITLE
Improve summary plot for parameterized tests

### DIFF
--- a/asv/graph.py
+++ b/asv/graph.py
@@ -77,7 +77,7 @@ class Graph(object):
         self.summary = summary
         self.path = os.path.join(*parts)
         self.n_series = None
-        self.scalar_series = False
+        self.scalar_series = True
 
     def add_data_point(self, date, value):
         """
@@ -97,8 +97,9 @@ class Graph(object):
         self.data_points.setdefault(date, [])
         if value is not None:
             if not hasattr(value, '__len__'):
-                self.scalar_series = True
                 value = [value]
+            else:
+                self.scalar_series = False
 
             if self.n_series is None:
                 self.n_series = len(value)
@@ -131,7 +132,13 @@ class Graph(object):
         Get the sorted and reduced data.
         """
 
+        if self.n_series is None:
+            # No non-null data points
+            self.n_series = 1
+
         def mean_axis0(v):
+            if not v:
+                return [None]*self.n_series
             return [_mean_with_none(x[j] for x in v)
                     for j in xrange(self.n_series)]
 
@@ -145,6 +152,8 @@ class Graph(object):
         for i in xrange(len(val)):
             if any(v is not None for v in val[i][1]):
                 break
+        else:
+            i = len(val)
 
         j = i
         for j in xrange(len(val) - 1, i, -1):

--- a/asv/graph.py
+++ b/asv/graph.py
@@ -5,7 +5,6 @@ from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
 import os
-import itertools
 
 import six
 from six.moves import xrange
@@ -77,6 +76,8 @@ class Graph(object):
 
         self.summary = summary
         self.path = os.path.join(*parts)
+        self.n_series = None
+        self.scalar_series = False
 
     def add_data_point(self, date, value):
         """
@@ -95,8 +96,15 @@ class Graph(object):
         # Add simple time series
         self.data_points.setdefault(date, [])
         if value is not None:
-            if self.summary and hasattr(value, '__len__'):
-                value = _mean_with_none(value)
+            if not hasattr(value, '__len__'):
+                self.scalar_series = True
+                value = [value]
+
+            if self.n_series is None:
+                self.n_series = len(value)
+            elif len(value) != self.n_series:
+                raise ValueError("Mismatching number of data series in graph")
+
             self.data_points[date].append(value)
 
     def resample_data(self, val):
@@ -122,33 +130,88 @@ class Graph(object):
         """
         Get the sorted and reduced data.
         """
-        def mean(v):
-            if not len(v):
-                return None
-            else:
-                if hasattr(v[0], '__len__'):
-                    return [_mean_with_none(x[j] for x in v)
-                            for j in range(len(v[0]))]
-                else:
-                    return _mean_with_none(v)
 
-        val = [(k, mean(v)) for (k, v) in
+        def mean_axis0(v):
+            return [_mean_with_none(x[j] for x in v)
+                    for j in xrange(self.n_series)]
+
+        # Average data over dates
+        val = [(k, mean_axis0(v)) for (k, v) in
                six.iteritems(self.data_points)]
         val.sort()
 
+        # Discard missing data at edges
         i = 0
         for i in xrange(len(val)):
-            if val[i][1] is not None:
+            if any(v is not None for v in val[i][1]):
                 break
 
         j = i
         for j in xrange(len(val) - 1, i, -1):
-            if val[j][1] is not None:
+            if any(v is not None for v in val[j][1]):
                 break
 
         val = val[i:j+1]
 
+        # Reduce data for summary
+        if self.summary and self.n_series > 1:
+            # Given multiple input series
+            #
+            #     val = [(x_0, (y[0,0], y[0,1], ..., y[0,n])), 
+            #            (x_1, (y[1,0], y[1,1], ..., y[1,n])),
+            #            ... ]
+            #
+            # calculate summary data series
+            #
+            #     z = geom_mean(y, axis=1)
+            #
+            # Missing data in y is filled by the previous non-null
+            # values (or the first non-null value, for nulls at the
+            # beginning), to avoid meaningless jumps in the result.
+            # Data points missing from all series are not filled.
+
+            # Find first non-null values
+            first_values = [None]*self.n_series
+            for k, v in val:
+                for j, x in enumerate(v):
+                    if first_values[j] is None and x is not None:
+                        first_values[j] = x
+                if not any(x is None for x in first_values):
+                    break
+
+            first_values = [fv if fv is not None else 1.0 
+                            for fv in first_values]
+
+            # Compute geom mean of filled series
+            last_values = [None]*self.n_series
+            new_val = []
+            for k, v in val:
+                # Fill missing data, unless it's missing from all
+                # parameter combinations
+                cur_vals = []
+                if any(x is not None for x in v):
+                    for j, x in enumerate(v):
+                        if x is None:
+                            if last_values[j] is not None:
+                                x = last_values[j]
+                            else:
+                                x = first_values[j]
+                        else:
+                            last_values[j] = x
+
+                        cur_vals.append(x)
+
+                # Mean of normalized values, on top of mean of means
+                v = _geom_mean_with_none(cur_vals)
+                new_val.append((k, v))
+
+            val = new_val
+        elif self.summary or self.scalar_series:
+            # Single-element series
+            val = [(k, v[0]) for k, v in val]
+
         if self.summary:
+            # Resample
             val = self.resample_data(val)
 
         return val
@@ -176,6 +239,24 @@ def _mean_with_none(values):
     """
     values = [x for x in values if x is not None and x == x]
     if values:
-        return sum(values) / float(len(values))
+        return sum(values) / len(values)
+    else:
+        return None
+
+
+def _geom_mean_with_none(values):
+    """
+    Compute geometric mean, with the understanding that None and NaN
+    stand for missing data.
+    """
+    values = [x for x in values if x is not None and x == x]
+    if values:
+        exponent = 1/len(values)
+        prod = 1.0
+        acc = 0
+        for x in values:
+            prod *= abs(x)**exponent
+            acc += x
+        return prod if acc >= 0 else -prod
     else:
         return None

--- a/test/test_graph.py
+++ b/test/test_graph.py
@@ -1,0 +1,100 @@
+from asv.graph import Graph
+
+
+def test_graph_single():
+    vals = [
+        (1, 1),
+        (2, 2),
+        (3, 3),
+        (4, 4),
+        (5, 5),
+        (6, None)
+    ]
+
+    # Should give same data back, excluding missing values at edges
+    g = Graph('foo', {}, {})
+    for k, v in vals:
+        g.add_data_point(k, v)
+    data = g.get_data()
+    assert data == vals[:-1]
+
+    # Should average duplicate values
+    g = Graph('foo', {}, {})
+    g.add_data_point(4, 3)
+    for k, v in vals:
+        g.add_data_point(k, v)
+    g.add_data_point(4, 5)
+    data = g.get_data()
+    assert data[3][0] == 4
+    assert abs(data[3][1] - (3 + 4 + 5)/3.) < 1e-10
+
+    # Summary graph should be the same as the main graph
+    g = Graph('foo', {}, {}, summary=True)
+    for k, v in vals:
+        g.add_data_point(k, v)
+    data = g.get_data()
+    assert len(data) == len(vals) - 1
+    for v, d in zip(vals, data):
+        kv, xv = v
+        kd, xd = d
+        assert kv == kd
+        assert abs(xv - xd) < 1e-10
+
+
+def test_graph_multi():
+    vals = [
+        (0, [None, None, None]),
+        (1, [1, None, None]),
+        (2, [2,    5, 4]),
+        (3, [3,    4, -60]),
+        (4, [4,    3, 2]),
+        (5, [None, 2, None]),
+        (6, [6,    1, None])
+    ]
+
+    filled_vals = [
+        (1, [1, 5, 4]),
+        (2, [2, 5, 4]),
+        (3, [3, 4, -60]),
+        (4, [4, 3, 2]),
+        (5, [4, 2, 2]),
+        (6, [6, 1, 2])
+    ]
+
+    # Should give same data back, with missing data at edges removed
+    g = Graph('foo', {}, {})
+    for k, v in vals:
+        g.add_data_point(k, v)
+    data = g.get_data()
+    assert data == vals[1:]
+
+    # Should average duplicate values
+    g = Graph('foo', {}, {})
+    g.add_data_point(4, [1, 2, 3])
+    for k, v in vals:
+        g.add_data_point(k, v)
+    g.add_data_point(4, [3, 2, 1])
+    data = g.get_data()
+    assert data[3][0] == 4
+    assert abs(data[3][1][0] - (1 + 4 + 3)/3.) < 1e-10
+    assert abs(data[3][1][1] - (2 + 3 + 2)/3.) < 1e-10
+    assert abs(data[3][1][2] - (3 + 2 + 1)/3.) < 1e-10
+
+    # The summary graph is obtained by geometric mean of filled data
+    g = Graph('foo', {}, {}, summary=True)
+    for k, v in vals:
+        g.add_data_point(k, v)
+    data = g.get_data()
+
+    for v, d in zip(filled_vals, data):
+        kv, xvs = v
+        kd, xd = d
+        assert kv == kd
+
+        # geom mean, with some sign convention
+        expected = _sgn(sum(xvs)) * (abs(xvs[0]*xvs[1]*xvs[2]))**(1./3)
+        assert abs(xd - expected) < 1e-10
+
+
+def _sgn(x):
+    return 1 if x >= 0 else -1

--- a/test/test_graph.py
+++ b/test/test_graph.py
@@ -96,5 +96,24 @@ def test_graph_multi():
         assert abs(xd - expected) < 1e-10
 
 
+def test_empty_graph():
+    g = Graph('foo', {}, {})
+    g.add_data_point(1, None)
+    g.add_data_point(2, None)
+    g.add_data_point(3, None)
+    data = g.get_data()
+    assert data == []
+
+
+    g = Graph('foo', {}, {})
+    g.add_data_point(1, None)
+    g.add_data_point(1, [None, None])
+    g.add_data_point(2, [None, None])
+    g.add_data_point(3, None)
+    g.add_data_point(4, [None, None])
+    data = g.get_data()
+    assert data == []
+
+
 def _sgn(x):
     return 1 if x >= 0 else -1


### PR DESCRIPTION
Take geometric mean over parameter sets instead of arithmetic mean.
Also fill in data that is missing only for some parameter combinations,
which avoids spurious jumps in the summary graph.

Also do minor refactoring for Graph, ensuring self.data_points format is
the same for scalar and vector series.

The geometric mean is probably the best choice for summarizing all
the results in a single curve --- the main interest in the plot is to see
relative changes, and the geom mean is the choice that gives equal
weights on log-scale. Within the constraint of one curve, I think gh-220 is fixed.

before: http://pav.iki.fi/tmp/asv-226/html-before/index.html
after: http://pav.iki.fi/tmp/asv-226/html-after/index.html (note several spurious jumps removed in sparse&spatial tests)