### PR TITLE
Fix printing cloning and building log messages in wrong order 

### DIFF
--- a/asv/environment.py
+++ b/asv/environment.py
@@ -291,8 +291,8 @@ class Environment(object):
         self._repo.checkout(self._build_root, commit_hash)
 
     def build_project(self, commit_hash):
-        log.info("Building for {0}".format(self.name))
         self.checkout_project(commit_hash)
+        log.info("Building for {0}".format(self.name))
         self.run(['setup.py', 'build'], cwd=self._build_root)
         return self._build_root
 

--- a/asv/plugins/git.py
+++ b/asv/plugins/git.py
@@ -25,11 +25,11 @@ class Git(Repo):
         self._pulled = False
 
         if not os.path.isdir(self._path):
-            log.info("Cloning project")
             args = ['clone']
             if _checkout_copy:
                 args.append('--shared')
             else:
+                log.info("Cloning project")
                 args.append('--mirror')
             args.extend([url, self._path])
             self._run_git(args, chdir=False)

--- a/asv/plugins/mercurial.py
+++ b/asv/plugins/mercurial.py
@@ -34,7 +34,8 @@ class Hg(Repo):
             raise ImportError("hglib")
 
         if not os.path.exists(self._path):
-            log.info("Cloning project")
+            if not _checkout_copy:
+                log.info("Cloning project")
             if url.startswith("hg+"):
                 url = url[3:]
 


### PR DESCRIPTION
Cosmetic fix: the "Cloning..." message was printed after "Building...", which made it look as if cloning took a long time when in reality it was building at the time.

Print the build message immediately before the build command, in case
checkout() also prints something.  Do not print "Cloning..." message
when cloning the repositories from the local mirror repo into the
environments, as this action is likely to be fast.