### PR TITLE
Add show_stderr option to asv continuous

### DIFF
--- a/asv/commands/continuous.py
+++ b/asv/commands/continuous.py
@@ -40,6 +40,9 @@ class Continuous(Command):
             if a benchmark gets twice as slow or twice as fast, it
             will be displayed in the results list.""")
         parser.add_argument(
+            "--show-stderr", "-e", action="store_true",
+            help="""Display the stderr output from the benchmarks.""")
+        parser.add_argument(
             "--bench", "-b", type=str, nargs="*",
             help="""Regular expression(s) for benchmark to run.  When
             not provided, all benchmarks are run.""")
@@ -59,11 +62,11 @@ class Continuous(Command):
     def run_from_conf_args(cls, conf, args):
         return cls.run(
             conf=conf, branch=args.branch, base=args.base, factor=args.factor,
-            bench=args.bench, machine=args.machine
+            show_stderr=args.show_stderr, bench=args.bench, machine=args.machine
         )
 
     @classmethod
-    def run(cls, conf, branch=None, base=None, factor=2.0, bench=None,
+    def run(cls, conf, branch=None, base=None, factor=2.0, show_stderr=False, bench=None,
             machine=None, _machine_file=None):
         repo = get_repo(conf)
         repo.pull()
@@ -82,7 +85,7 @@ class Continuous(Command):
 
         result = Run.run(
             conf, range_spec=commit_hashes, bench=bench,
-            machine=machine, _returns=run_objs,
+            show_stderr=show_stderr, machine=machine, _returns=run_objs,
             _machine_file=_machine_file)
         if result:
             return result

--- a/test/test_workflow.py
+++ b/test/test_workflow.py
@@ -121,7 +121,7 @@ def test_continuous(basic_conf):
     os.environ['_ASV_TEST_TRACK_FILE'] = join(tmpdir, 'track-file')
     try:
         sys.stdout = s
-        Continuous.run(conf, _machine_file=machine_file)
+        Continuous.run(conf, _machine_file=machine_file, show_stderr=True)
     finally:
         sys.stdout = stdout
         del os.environ['_ASV_TEST_TRACK_FILE']
@@ -130,6 +130,8 @@ def test_continuous(basic_conf):
     text = s.read()
     assert "SOME BENCHMARKS HAVE CHANGED SIGNIFICANTLY" in text
     assert "params_examples.track_find_test(2)              1.0        6.0   6.00000000x" in text
+    assert "params_examples.ClassOne" in text
+
 
 def test_find(basic_conf):
     tmpdir, local, conf, machine_file = basic_conf


### PR DESCRIPTION
Some more consistency between the benchmark-running commands. Some use cases, e.g. when running benchmarks during development and wanting to compare your current work against some old version.