### PR TITLE
Make difference between failed and skipped benchmarks

### DIFF
--- a/asv/benchmark.py
+++ b/asv/benchmark.py
@@ -603,7 +603,7 @@ if __name__ == '__main__':
         skip = benchmark.do_setup()
         try:
             if skip:
-                result = None
+                result = float('nan')
             else:
                 result = benchmark.do_run()
                 if profile_path is not None:

--- a/asv/graph.py
+++ b/asv/graph.py
@@ -95,7 +95,7 @@ class Graph(object):
         """
         # Add simple time series
         self.data_points.setdefault(date, [])
-        if value is not None:
+        if not _is_na(value):
             if not hasattr(value, '__len__'):
                 value = [value]
             else:
@@ -150,14 +150,14 @@ class Graph(object):
         # Discard missing data at edges
         i = 0
         for i in xrange(len(val)):
-            if any(v is not None for v in val[i][1]):
+            if any(not _is_na(v) for v in val[i][1]):
                 break
         else:
             i = len(val)
 
         j = i
         for j in xrange(len(val) - 1, i, -1):
-            if any(v is not None for v in val[j][1]):
+            if any(not _is_na(v) for v in val[j][1]):
                 break
 
         val = val[i:j+1]
@@ -183,9 +183,9 @@ class Graph(object):
             first_values = [None]*self.n_series
             for k, v in val:
                 for j, x in enumerate(v):
-                    if first_values[j] is None and x is not None:
+                    if first_values[j] is None and not _is_na(x):
                         first_values[j] = x
-                if not any(x is None for x in first_values):
+                if not any(_is_na(x) for x in first_values):
                     break
 
             first_values = [fv if fv is not None else 1.0 
@@ -198,9 +198,9 @@ class Graph(object):
                 # Fill missing data, unless it's missing from all
                 # parameter combinations
                 cur_vals = []
-                if any(x is not None for x in v):
+                if any(not _is_na(x) for x in v):
                     for j, x in enumerate(v):
-                        if x is None:
+                        if _is_na(x):
                             if last_values[j] is not None:
                                 x = last_values[j]
                             else:
@@ -241,12 +241,19 @@ class Graph(object):
         util.write_json(filename, val)
 
 
+def _is_na(value):
+    """
+    Return true if value is None or nan
+    """
+    return value is None or value != value
+
+
 def _mean_with_none(values):
     """
     Take a mean, with the understanding that None and NaN stand for
     missing data.
     """
-    values = [x for x in values if x is not None and x == x]
+    values = [x for x in values if not _is_na(x)]
     if values:
         return sum(values) / len(values)
     else:
@@ -258,7 +265,7 @@ def _geom_mean_with_none(values):
     Compute geometric mean, with the understanding that None and NaN
     stand for missing data.
     """
-    values = [x for x in values if x is not None and x == x]
+    values = [x for x in values if not _is_na(x)]
     if values:
         exponent = 1/len(values)
         prod = 1.0

--- a/asv/util.py
+++ b/asv/util.py
@@ -153,12 +153,17 @@ def human_value(value, unit):
         The unit the value is in.  Currently understands `seconds` and `bytes`.
     """
     if isinstance(value, (int, float)):
-        if unit == 'seconds':
+        if value != value:
+            # nan
+            display = "n/a"
+        elif unit == 'seconds':
             display = human_time(value)
         elif unit == 'bytes':
             display = human_file_size(value)
         else:
             display = json.dumps(value)
+    elif value is None:
+        display = "failed"
     else:
         display = json.dumps(value)
 

--- a/docs/source/dev.rst
+++ b/docs/source/dev.rst
@@ -106,7 +106,7 @@ A benchmark suite directory has the following layout.  The
       - ``results``: A dictionary from benchmark names to benchmark
         results.
 
-        - If non-parameterized benchmark, the result is a single value
+        - If non-parameterized benchmark, the result is a single value.
 
         - For parameterized benchmarks, the result is a dictionary
           with keys ``params`` and ``result``. The ``params`` value
@@ -119,6 +119,10 @@ A benchmark suite directory has the following layout.  The
           the parameter combination ``itertools.product(*params)[n]``,
           i.e., the results appear in cartesian product order, with
           the last parameters varying fastest.
+
+        - In the results, ``null`` indicates a failed benchmark,
+          including failures in installing the project version. ``NaN``
+          indicates a benchmark explicitly skipped by the benchmark suite.
 
 - ``$html_dir/``: The output of ``asv publish``, that turns the raw
   results in ``$results_dir/`` into something viewable in a web
@@ -160,3 +164,5 @@ A benchmark suite directory has the following layout.  The
       corresponding to ``itertools.product`` iteration over the
       parameter combinations, similarly as in the result files. For
       non-parameterized benchmarks, it is directly the result.
+      Missing values (eg. failed and skipped benchmarks) are
+      represented by ``null``.

--- a/docs/source/writing_benchmarks.rst
+++ b/docs/source/writing_benchmarks.rst
@@ -105,6 +105,9 @@ clean up any changes made to the filesystem.  Generally, however, it
 is not required: each benchmark runs in its own process, so any
 tearing down of in-memory state happens automatically.
 
+If ``setup`` raises a ``NotImplementedError``, the benchmark is marked
+as skipped.
+
 .. _benchmark-attributes:
 
 Benchmark attributes
@@ -160,8 +163,8 @@ This will also make the setup and teardown functions parameterized::
             for i in self.obj:
                 pass
 
-If ``setup`` raises a ``NotImplementedError``, the test is skipped
-for the parameter values in question.
+If ``setup`` raises a ``NotImplementedError``, the benchmark is marked
+as skipped for the parameter values in question.
 
 The parameter values can be any Python objects. However, it is often
 best to use only strings or numbers, because these have simple

--- a/test/test_benchmarks.py
+++ b/test/test_benchmarks.py
@@ -84,7 +84,7 @@ def test_find_benchmarks(tmpdir):
 
     assert isinstance(times['params_examples.time_skip']['result']['result'][0], float)
     assert isinstance(times['params_examples.time_skip']['result']['result'][1], float)
-    assert times['params_examples.time_skip']['result']['result'][2] is None
+    assert _isnan(times['params_examples.time_skip']['result']['result'][2])
 
     profile_path = os.path.join(tmpdir, 'test.profile')
     with open(profile_path, 'wb') as fd:
@@ -125,28 +125,34 @@ def test_table_formatting():
     assert table == expected
 
     benchmark = {'params': [["'a'", "'b'", "'c'"], ["[1]", "[2]"]], 'param_names': ['param1', 'param2'], "unit": "seconds"}
-    result = [1, 2, 3, 4, 5, 6]
-    expected = ("======== ======= =======\n"
-                "--            param2    \n"
-                "-------- ---------------\n"
-                " param1    [1]     [2]  \n"
-                "======== ======= =======\n"
-                "   a      1.00s   2.00s \n"
-                "   b      3.00s   4.00s \n"
-                "   c      5.00s   6.00s \n"
-                "======== ======= =======")
+    result = [1, 2, None, 4, 5, float('nan')]
+    expected = ("======== ======== =======\n"
+                "--            param2     \n"
+                "-------- ----------------\n"
+                " param1    [1]      [2]  \n"
+                "======== ======== =======\n"
+                "   a      1.00s    2.00s \n"
+                "   b      failed   4.00s \n"
+                "   c      5.00s     n/a  \n"
+                "======== ======== =======")
     table = "\n".join(benchmarks._format_benchmark_result(result, benchmark, max_width=80))
     assert table == expected
 
-    expected = ("======== ======== =======\n"
-                " param1   param2         \n"
-                "-------- -------- -------\n"
-                "   a       [1]     1.00s \n"
-                "   a       [2]     2.00s \n"
-                "   b       [1]     3.00s \n"
-                "   b       [2]     4.00s \n"
-                "   c       [1]     5.00s \n"
-                "   c       [2]     6.00s \n"
-                "======== ======== =======")
+    expected = ("======== ======== ========\n"
+                " param1   param2          \n"
+                "-------- -------- --------\n"
+                "   a       [1]     1.00s  \n"
+                "   a       [2]     2.00s  \n"
+                "   b       [1]     failed \n"
+                "   b       [2]     4.00s  \n"
+                "   c       [1]     5.00s  \n"
+                "   c       [2]      n/a   \n"
+                "======== ======== ========")
     table = "\n".join(benchmarks._format_benchmark_result(result, benchmark, max_width=0))
     assert table == expected
+
+
+def _isnan(x):
+    if isinstance(x, float):
+        return x != x
+    return False

--- a/test/test_graph.py
+++ b/test/test_graph.py
@@ -8,7 +8,8 @@ def test_graph_single():
         (3, 3),
         (4, 4),
         (5, 5),
-        (6, None)
+        (6, None),
+        (7, float('nan')),
     ]
 
     # Should give same data back, excluding missing values at edges
@@ -16,7 +17,7 @@ def test_graph_single():
     for k, v in vals:
         g.add_data_point(k, v)
     data = g.get_data()
-    assert data == vals[:-1]
+    assert data == vals[:-2]
 
     # Should average duplicate values
     g = Graph('foo', {}, {})
@@ -33,7 +34,7 @@ def test_graph_single():
     for k, v in vals:
         g.add_data_point(k, v)
     data = g.get_data()
-    assert len(data) == len(vals) - 1
+    assert len(data) == len(vals) - 2
     for v, d in zip(vals, data):
         kv, xv = v
         kd, xd = d
@@ -44,7 +45,7 @@ def test_graph_single():
 def test_graph_multi():
     vals = [
         (0, [None, None, None]),
-        (1, [1, None, None]),
+        (1, [1, None, float('nan')]),
         (2, [2,    5, 4]),
         (3, [3,    4, -60]),
         (4, [4,    3, 2]),
@@ -66,7 +67,8 @@ def test_graph_multi():
     for k, v in vals:
         g.add_data_point(k, v)
     data = g.get_data()
-    assert data == vals[1:]
+    assert data[0] == (1, [1, None, None])
+    assert data[1:] == vals[2:]
 
     # Should average duplicate values
     g = Graph('foo', {}, {})
@@ -113,6 +115,27 @@ def test_empty_graph():
     g.add_data_point(4, [None, None])
     data = g.get_data()
     assert data == []
+
+
+def test_nan():
+    g = Graph('foo', {}, {})
+    g.add_data_point(1, 1)
+    g.add_data_point(2, 2)
+    g.add_data_point(2, float('nan'))
+    g.add_data_point(3, 3)
+    g.add_data_point(4, float('nan'))
+    data = g.get_data()
+    assert data == [(1, 1), (2, 2), (3,3)]
+
+
+    g = Graph('foo', {}, {})
+    g.add_data_point(1, None)
+    g.add_data_point(1, [1, float('nan')])
+    g.add_data_point(2, [2, 2])
+    g.add_data_point(3, [float('nan'), float('nan')])
+    g.add_data_point(4, [None, float('nan')])
+    data = g.get_data()
+    assert data == [(1, [1, None]), (2, [2, 2])]
 
 
 def _sgn(x):


### PR DESCRIPTION
Represent explicitly skipped benchmarks with NaN values, and failed benchmarks with None/null.

The practical difference here is that later on, you might want to use `--skip-existing-successful` to re-run failed tests e.g. due to fixes in the benchmark, but not re-run tests that you explicitly skipped in the benchmark suite.