### PR TITLE
Add support for branches

### DIFF
--- a/asv/branch_cache.py
+++ b/asv/branch_cache.py
@@ -1,0 +1,42 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+# -*- coding: utf-8 -*-
+
+from __future__ import absolute_import, division, unicode_literals, print_function
+
+import tempfile
+import six
+
+from . import util
+
+
+class BranchCache(object):
+    def __init__(self, conf, repo):
+        self._branches = conf.branches
+        self._repo = repo
+        if not self._branches:
+            # Master branch only
+            self._branches = [None]
+        self._hashes = None
+
+    def _load(self):
+        if self._hashes is not None:
+            return
+        self._hashes = {}
+        for branch in self._branches:
+            spec = self._repo.get_branch_range_spec(branch)
+            hashes = set(self._repo.get_hashes_from_range(spec))
+            self._hashes[spec] = (branch, hashes)
+
+    def get_branches(self, commit_hash):
+        self._load()
+        branches = []
+        for spec, item in six.iteritems(self._hashes):
+            branch, hashes = item
+            if commit_hash in hashes:
+                branches.append(branch)
+        return branches
+
+    def get_branch_commits(self, branch):
+        self._load()
+        spec = self._repo.get_branch_range_spec(branch)
+        return self._hashes[spec][1]

--- a/asv/commands/common_args.py
+++ b/asv/commands/common_args.py
@@ -3,6 +3,8 @@
 
 from __future__ import absolute_import, division, unicode_literals, print_function
 
+import argparse
+
 
 def add_factor(parser):
     parser.add_argument(
@@ -59,3 +61,12 @@ def add_parallel(parser):
         help="""Build (but don't benchmark) in parallel.  The value is
         the number of CPUs to use, or if no number provided, use the
         number of cores on this machine.""")
+
+
+def positive_int(string):
+    try:
+        value = int(string)
+        if not value > 0:
+            raise argparse.ArgumentTypeError("%r is not a positive integer" % (string,))
+    except ValueError:
+        raise argparse.ArgumentTypeError("%r is not an integer" % (string,))

--- a/asv/commands/publish.py
+++ b/asv/commands/publish.py
@@ -140,9 +140,6 @@ class Publish(Command):
 
             branch_cache = BranchCache(conf, repo)
 
-            for branch in conf.branches:
-                params.setdefault('branch', set()).add(branch)
-
         log.step()
         log.info("Loading results")
         with log.indent():
@@ -195,6 +192,7 @@ class Publish(Command):
             val = list(val)
             val.sort(key=lambda x: x or '')
             params[key] = val
+        params['branch'] = conf.branches  # maintain same order as in conf file
         util.write_json(os.path.join(conf.html_dir, "index.json"), {
             'project': conf.project,
             'project_url': conf.project_url,

--- a/asv/commands/run.py
+++ b/asv/commands/run.py
@@ -7,7 +7,6 @@ from __future__ import (absolute_import, division, print_function,
 import six
 
 import logging
-import argparse
 
 from . import Command
 from ..benchmarks import Benchmarks
@@ -54,14 +53,6 @@ class Run(Command):
             "run", help="Run a benchmark suite",
             description="Run a benchmark suite.")
 
-        def positive_int(string):
-            try:
-                value = int(string)
-                if not value > 0:
-                    raise argparse.ArgumentTypeError("%r is not a positive integer" % (string,))
-            except ValueError:
-                raise argparse.ArgumentTypeError("%r is not an integer" % (string,))
-
         parser.add_argument(
             'range', nargs='?', default=None,
             help="""Range of commits to benchmark.  For a git
@@ -75,7 +66,7 @@ class Run(Command):
             there are existing benchmarks on any machine. By default,
             will benchmark the head of the current master branch.""")
         parser.add_argument(
-            "--steps", "-s", type=positive_int, default=None,
+            "--steps", "-s", type=common_args.positive_int, default=None,
             help="""Maximum number of steps to benchmark.  This is
             used to subsample the commits determined by range to a
             reasonable number.""")

--- a/asv/commands/run.py
+++ b/asv/commands/run.py
@@ -7,6 +7,7 @@ from __future__ import (absolute_import, division, print_function,
 import six
 
 import logging
+import argparse
 
 from . import Command
 from ..benchmarks import Benchmarks
@@ -15,6 +16,7 @@ from ..machine import Machine
 from ..repo import get_repo
 from ..results import (Results, find_latest_result_hash, get_existing_hashes,
                        iter_results_for_machine_and_hash)
+from ..branch_cache import BranchCache
 from .. import util
 
 from .setup import Setup
@@ -52,6 +54,14 @@ class Run(Command):
             "run", help="Run a benchmark suite",
             description="Run a benchmark suite.")
 
+        def positive_int(string):
+            try:
+                value = int(string)
+                if not value > 0:
+                    raise argparse.ArgumentTypeError("%r is not a positive integer" % (string,))
+            except ValueError:
+                raise argparse.ArgumentTypeError("%r is not an integer" % (string,))
+
         parser.add_argument(
             'range', nargs='?', default=None,
             help="""Range of commits to benchmark.  For a git
@@ -65,7 +75,7 @@ class Run(Command):
             there are existing benchmarks on any machine. By default,
             will benchmark the head of the current master branch.""")
         parser.add_argument(
-            "--steps", "-s", type=int, default=0,
+            "--steps", "-s", type=positive_int, default=None,
             help="""Maximum number of steps to benchmark.  This is
             used to subsample the commits determined by range to a
             reasonable number.""")
@@ -123,7 +133,7 @@ class Run(Command):
         )
 
     @classmethod
-    def run(cls, conf, range_spec=None, steps=0, bench=None, parallel=1,
+    def run(cls, conf, range_spec=None, steps=None, bench=None, parallel=1,
             show_stderr=False, quick=False, profile=False, python=None,
             dry_run=False, machine=None, _machine_file=None, skip_successful=False,
             skip_failed=False, skip_existing_commits=False, _returns={}):
@@ -151,13 +161,26 @@ class Run(Command):
         elif range_spec == 'EXISTING':
             commit_hashes = [h for h, d in get_existing_hashes(
                 conf.results_dir)]
-        elif range_spec == 'NEW':
-            latest_result = find_latest_result_hash(
-                machine_params.machine, conf.results_dir)
-            commit_hashes = repo.get_hashes_from_range(
-                repo.get_new_range_spec(latest_result))
-        elif range_spec == "ALL":
-            commit_hashes = repo.get_hashes_from_range("")
+        elif range_spec in ('NEW', 'ALL'):
+            branch_cache = BranchCache(conf, repo)
+            commit_hashes = []
+            seen = set()
+            for branch in conf.branches:
+                if range_spec == 'NEW':
+                    branch_hashes = branch_cache.get_branch_commits(branch)
+                    latest_result = find_latest_result_hash(
+                        machine_params.machine, conf.results_dir,
+                        hashes=branch_hashes)
+                    spec = repo.get_new_range_spec(latest_result, branch)
+                else:
+                    spec = repo.get_branch_range_spec(branch)
+
+                new_hashes = repo.get_hashes_from_range(spec)
+
+                for commit_hash in new_hashes:
+                    if commit_hash not in seen:
+                        seen.add(commit_hash)
+                        commit_hashes.append(commit_hash)
         elif isinstance(range_spec, list):
             commit_hashes = range_spec
         else:
@@ -167,14 +190,8 @@ class Run(Command):
             log.error("No commit hashes selected")
             return 1
 
-        if steps > 0:
-            spacing = max(float(len(commit_hashes)) / steps, 1)
-            spaced = []
-            i = 0
-            while int(i) < len(commit_hashes) and len(spaced) < steps:
-                spaced.append(commit_hashes[int(i)])
-                i += spacing
-            commit_hashes = spaced
+        if steps is not None:
+            commit_hashes = util.pick_n(commit_hashes, steps)
 
         environments = Setup.run(conf=conf, parallel=parallel)
         if len(environments) == 0:

--- a/asv/config.py
+++ b/asv/config.py
@@ -21,6 +21,7 @@ class Config(object):
         self.project = "project"
         self.project_url = "#"
         self.repo = None
+        self.branches = [None]
         self.pythons = ["{0[0]}.{0[1]}".format(sys.version_info)]
         self.matrix = {}
         self.env_dir = "env"
@@ -60,6 +61,12 @@ class Config(object):
         if not getattr(conf, "repo", None):
             raise util.UserError(
                 "No repo specified in config file.")
+
+        if not getattr(conf, "branches", [None]):
+            # If 'branches' attribute is present, at least some must
+            # be listed.
+            raise util.UserError(
+                "No branches specified in config file.")
 
         return conf
 

--- a/asv/plugins/git.py
+++ b/asv/plugins/git.py
@@ -59,8 +59,17 @@ class Git(Repo):
         return util.check_output(
             [self._git] + args, **kwargs)
 
-    def get_new_range_spec(self, latest_result):
-        return '{0}..master'.format(latest_result)
+    def get_new_range_spec(self, latest_result, branch=None):
+        if branch is None:
+            return '{0}..master'.format(latest_result)
+        else:
+            return '{0}..{1}'.format(latest_result, branch)
+
+    def get_branch_range_spec(self, branch):
+        if branch is None:
+            return 'master'
+        else:
+            return branch
 
     def pull(self):
         # We assume the remote isn't updated during the run of asv
@@ -87,8 +96,6 @@ class Git(Repo):
             valid_return_codes=(0, 1), dots=False).strip().split()[0]) * 1000
 
     def get_hashes_from_range(self, range_spec):
-        if range_spec == 'master':
-            range_spec = 'master^!'
         args = ['log', '--quiet', '--first-parent', '--format=format:%H']
         if range_spec != "":
             args += [range_spec]

--- a/asv/plugins/mercurial.py
+++ b/asv/plugins/mercurial.py
@@ -63,8 +63,16 @@ class Hg(Repo):
 
         return False
 
-    def get_new_range_spec(self, latest_result):
-        return '{0}::tip'.format(latest_result)
+    def get_new_range_spec(self, latest_result, branch=None):
+        if branch is None:
+            return '{0}::tip'.format(latest_result)
+        else:
+            return '{0}::{1}'.format(latest_result, branch)
+
+    def get_branch_range_spec(self, branch):
+        if branch is None:
+            branch = 'tip'
+        return 'ancestors({0})'.format(branch)
 
     def pull(self):
         # We assume the remote isn't updated during the run of asv

--- a/asv/repo.py
+++ b/asv/repo.py
@@ -49,10 +49,18 @@ class Repo(object):
         """
         raise NotImplementedError()
 
-    def get_new_range_spec(self, latest_result):
+    def get_new_range_spec(self, latest_result, branch=None):
         """
         Returns a formatted string giving the results between the 
-        latest result and the newest hash.
+        latest result and the newest hash in a given branch.
+        If no branch given, use the 'master' branch.
+        """
+        raise NotImplementedError()
+
+    def get_branch_range_spec(self, branch):
+        """
+        Returns a formatted string giving the results in a given branch.
+        If branch is None, use the 'master' branch.
         """
         raise NotImplementedError()
 

--- a/asv/results.py
+++ b/asv/results.py
@@ -78,7 +78,7 @@ def get_existing_hashes(results):
     return hashes
 
 
-def find_latest_result_hash(machine, root):
+def find_latest_result_hash(machine, root, hashes=None):
     """
     Find the latest result for the given machine.
     """
@@ -87,7 +87,7 @@ def find_latest_result_hash(machine, root):
     latest_date = 0
     latest_hash = ''
     for commit_hash, date in iter_existing_hashes(root):
-        if date > latest_date:
+        if date > latest_date and (hashes is None or commit_hash in hashes):
             latest_date = date
             latest_hash = commit_hash
 

--- a/asv/template/asv.conf.json
+++ b/asv/template/asv.conf.json
@@ -13,6 +13,11 @@
     // project being benchmarked
     "repo": "",
 
+    // List of branches to benchmark. If not provided, defaults to "master"
+    // (for git) or "tip" (for mercurial).
+    // "branches": ["master"], // for git
+    // "branches": ["tip"],    // for mercurial
+
     // The DVCS being used.  If not set, it will be automatically
     // determined from "repo" by looking at the protocol in the URL
     // (if remote), or by looking for special directories, such as

--- a/asv/util.py
+++ b/asv/util.py
@@ -450,6 +450,20 @@ def iter_chunks(s, n):
         yield chunk
 
 
+def pick_n(items, n):
+    """Pick n items, attempting to get equal index spacing.
+    """
+    if not (n > 0):
+        raise ValueError("Invalid number of items to pick")
+    spacing = max(float(len(items)) / n, 1)
+    spaced = []
+    i = 0
+    while int(i) < len(items) and len(spaced) < n:
+        spaced.append(items[int(i)])
+        i += spacing
+    return spaced
+
+
 def get_multiprocessing(parallel):
     """
     If parallel indicates that we want to do multiprocessing,

--- a/asv/www/asv.js
+++ b/asv/www/asv.js
@@ -263,6 +263,9 @@ $(function() {
             state[param] = values;
 
             if (values.length > 1 && param !== 'machine') {
+                if (param == 'branch') {
+                    state[param] = [values[0]];
+                }
                 make_value_selector_panel(nav, param, values, function(i, value, button) {
                     var value_display;
                     if (!value)
@@ -271,6 +274,10 @@ $(function() {
                         value_display = value;
 
                     button.text(value_display);
+
+                    if (param == 'branch' && i > 0) {
+                        button.removeClass('active');
+                    }
 
                     if (values.length > 1) {
                         button.on('click', function(evt) {

--- a/docs/source/asv.conf.json.rst
+++ b/docs/source/asv.conf.json.rst
@@ -40,6 +40,15 @@ The repository may be readonly.
    Mercurial used in ``asv`` (``python-hglib``) is being ported to Python 3.
    At the present time, Mercurial support will only function on Python 2.
 
+``branches``
+------------
+Branches to generate benchmark results for.
+
+This controls how the benchmark results are displayed, and what
+benchmarks ``asv run ALL`` and ``asv run NEW`` run.
+
+If not provided, "master" (Git) or "tip" (Mercurial) is chosen.
+
 ``show_commit_url``
 -------------------
 The base URL to show information about a particular commit.  The

--- a/test/test_benchmarks.py
+++ b/test/test_benchmarks.py
@@ -36,7 +36,7 @@ def test_find_benchmarks(tmpdir):
     d = {}
     d.update(ASV_CONF_JSON)
     d['env_dir'] = join(tmpdir, "env")
-    d['repo'] = tools.generate_test_repo(tmpdir, [0])
+    d['repo'] = tools.generate_test_repo(tmpdir, [0]).path
     conf = config.Config.from_json(d)
 
     b = benchmarks.Benchmarks(conf, regex='secondary')
@@ -107,7 +107,7 @@ def test_invalid_benchmark_tree(tmpdir):
     d.update(ASV_CONF_JSON)
     d['benchmark_dir'] = INVALID_BENCHMARK_DIR
     d['env_dir'] = join(tmpdir, "env")
-    d['repo'] = tools.generate_test_repo(tmpdir, [0])
+    d['repo'] = tools.generate_test_repo(tmpdir, [0]).path
     conf = config.Config.from_json(d)
 
     with pytest.raises(util.UserError):

--- a/test/test_compare.py
+++ b/test/test_compare.py
@@ -50,7 +50,7 @@ def test_compare(tmpdir):
 
     conf = config.Config.from_json(
         {'results_dir': RESULT_DIR,
-         'repo': tools.generate_test_repo(tmpdir),
+         'repo': tools.generate_test_repo(tmpdir).path,
          'project': 'asv'})
 
     s = StringIO()

--- a/test/test_conf.py
+++ b/test/test_conf.py
@@ -24,6 +24,7 @@ def test_config():
         "jinja2": [],
     }
     assert conf.benchmark_dir == 'benchmark'
+    assert conf.branches == [None]
 
 
 class CustomCommand(Command):

--- a/test/test_dev.py
+++ b/test/test_dev.py
@@ -37,7 +37,7 @@ def basic_conf(tmpdir):
         'benchmark_dir': join(local, 'benchmark'),
         'results_dir': join(tmpdir, 'results_workflow'),
         'html_dir': join(tmpdir, 'html'),
-        'repo': tools.generate_test_repo(tmpdir),
+        'repo': tools.generate_test_repo(tmpdir).path,
         'project': 'asv',
         'matrix': {
             "six": [None],

--- a/test/test_publish.py
+++ b/test/test_publish.py
@@ -26,7 +26,7 @@ def test_publish(tmpdir):
         {'benchmark_dir': BENCHMARK_DIR,
          'results_dir': RESULT_DIR,
          'html_dir': join(tmpdir, 'html'),
-         'repo': tools.generate_test_repo(tmpdir, list(range(10))),
+         'repo': tools.generate_test_repo(tmpdir, list(range(10))).path,
          'project': 'asv'})
 
     Publish.run(conf)

--- a/test/test_publish.py
+++ b/test/test_publish.py
@@ -5,12 +5,15 @@ from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
 import os
-from os.path import abspath, dirname, join, isfile
+from os.path import abspath, dirname, join, isfile, isdir
+import shutil
 
 import six
 
 from asv import config
 from asv.commands.publish import Publish
+from asv import util
+
 
 from . import tools
 
@@ -22,16 +25,82 @@ def test_publish(tmpdir):
     tmpdir = six.text_type(tmpdir)
     os.chdir(tmpdir)
 
+    result_dir = join(tmpdir, 'sample_results')
+    os.makedirs(result_dir)
+    os.makedirs(join(result_dir, 'cheetah'))
+
+    # Synthesize history with two branches that both have commits
+    result_files = [fn for fn in os.listdir(join(RESULT_DIR, 'cheetah'))
+                    if fn.endswith('.json') and fn != 'machine.json']
+    master_values = list(range(len(result_files)*2//3))
+    branch_values = list(range(len(master_values), len(result_files)))
+    dvcs = tools.generate_test_repo(tmpdir, master_values, 'git',
+                                    [('master~6', 'some-branch', branch_values)])
+
+    # Copy and modify result files, fixing commit hashes and setting result
+    # dates to distinguish the two branches
+    master_commits = dvcs.get_branch_hashes('master')
+    only_branch = [x for x in dvcs.get_branch_hashes('some-branch')
+                   if x not in master_commits]
+    commits = master_commits + only_branch
+    for k, item in enumerate(zip(result_files, commits)):
+        fn, commit = item
+        src = join(RESULT_DIR, 'cheetah', fn)
+        dst = join(result_dir, 'cheetah', commit[:8] + fn[8:])
+        data = util.load_json(src, cleanup=False)
+        data['commit_hash'] = commit
+        if commit in only_branch:
+            data['date'] = -k
+        else:
+            data['date'] = k
+        util.write_json(dst, data)
+
+    shutil.copyfile(join(RESULT_DIR, 'benchmarks.json'),
+                    join(result_dir, 'benchmarks.json'))
+    shutil.copyfile(join(RESULT_DIR, 'cheetah', 'machine.json'),
+                    join(result_dir, 'cheetah', 'machine.json'))
+
+
+    # Publish the synthesized data
     conf = config.Config.from_json(
         {'benchmark_dir': BENCHMARK_DIR,
-         'results_dir': RESULT_DIR,
+         'results_dir': result_dir,
          'html_dir': join(tmpdir, 'html'),
-         'repo': tools.generate_test_repo(tmpdir, list(range(10))).path,
+         'repo': dvcs.path,
          'project': 'asv'})
 
     Publish.run(conf)
 
+    # Check output
     assert isfile(join(tmpdir, 'html', 'index.html'))
     assert isfile(join(tmpdir, 'html', 'index.json'))
     assert isfile(join(tmpdir, 'html', 'asv.js'))
     assert isfile(join(tmpdir, 'html', 'asv.css'))
+    assert not isdir(join(tmpdir, 'html', 'graphs', 'Cython', 'arch-x86_64',
+                          'branch-some-branch'))
+
+    def check_file(branch):
+        fn = join(tmpdir, 'html', 'graphs', 'Cython', 'arch-x86_64', 'branch-' + branch,
+                  'cpu-Intel(R) Core(TM) i5-2520M CPU @ 2.50GHz (4 cores)',
+                  'machine-cheetah', 'numpy-1.8', 'os-Linux (Fedora 20)', 'python-2.7', 'ram-8.2G',
+                  'time_coordinates.time_latitude.json')
+        data = util.load_json(fn, cleanup=False)
+        if branch == 'master':
+            # we set all dates positive for master above
+            assert all(x[0] >= 0 for x in data)
+        else:
+            # we set some dates negative for some-branch above
+            assert any(x[0] < 0 for x in data) and any(x[0] >= 0 for x in data)
+
+    check_file("master")
+
+    # Publish with branches set in the config
+    conf.branches = ['master', 'some-branch']
+    Publish.run(conf)
+
+    # Check output
+    check_file("master")
+    check_file("some-branch")
+
+    index = util.load_json(join(tmpdir, 'html', 'index.json'))
+    assert index['params']['branch'] == ['master', 'some-branch']

--- a/test/test_workflow.py
+++ b/test/test_workflow.py
@@ -50,7 +50,7 @@ def basic_conf(tmpdir):
     shutil.copyfile(join(local, 'asv-machine.json'),
                     machine_file)
 
-    repo_path = tools.generate_test_repo(tmpdir, dummy_values)
+    repo_path = tools.generate_test_repo(tmpdir, dummy_values).path
 
     conf = config.Config.from_json({
         'env_dir': join(tmpdir, 'env'),

--- a/test/test_workflow.py
+++ b/test/test_workflow.py
@@ -172,6 +172,76 @@ def test_find(basic_conf):
     assert "Greatest regression found: {0}".format(regression_hash[:8]) in output
 
 
+def _test_run_branches(tmpdir, dvcs, conf, machine_file, range_spec,
+                       branches, initial_commit):
+    # Find the current head commits for each branch
+    commits = [initial_commit]
+    for branch in branches:
+        commits.append(dvcs.get_hash(branch))
+
+    # Run tests
+    Run.run(conf, range_spec=range_spec,
+            _machine_file=machine_file, quick=True)
+
+    # Check that files for all commits expected were generated
+    expected = set(['machine.json'])
+    for commit in commits:
+        for psver in ['1.2', '2.1']:
+            expected.add('{0}-py{1[0]}.{1[1]}-psutil{2}-six.json'.format(
+                commit[:8], sys.version_info, psver))
+
+    result_files = os.listdir(join(tmpdir, 'results_workflow', 'orangutan'))
+
+    if range_spec == 'NEW':
+        assert set(result_files) == expected
+    elif range_spec == 'ALL':
+        assert set(expected).difference(result_files) == set([])
+    else:
+        raise ValueError()
+
+
+def test_run_new_all(basic_conf):
+    tmpdir, local, conf, machine_file = basic_conf
+    conf.wheel_cache_size = 5
+
+    extra_branches = [('master~1', 'some-branch', [12])]
+    dvcs_path = os.path.join(tmpdir, 'test_repo2')
+    dvcs = tools.generate_test_repo(dvcs_path, [1, 2],
+                                    extra_branches=extra_branches)
+    conf.repo = dvcs.path
+
+    initial_commit = dvcs.get_hash("master~1")
+
+    def init_results():
+        results_dir = os.path.join(tmpdir, 'results_workflow')
+        if os.path.isdir(results_dir):
+            shutil.rmtree(results_dir)
+        Run.run(conf, range_spec=initial_commit+"^!",
+                bench=["time_secondary.track_value"],
+                _machine_file=join(tmpdir, 'asv-machine.json'), quick=True,
+                skip_successful=True, skip_failed=True)
+
+    # Without branches in config, should just use master
+    init_results()
+    _test_run_branches(tmpdir, dvcs, conf, machine_file, 'NEW',
+                       branches=['master'], initial_commit=initial_commit)
+
+    init_results()
+    _test_run_branches(tmpdir, dvcs, conf, machine_file, 'ALL',
+                       branches=['master'], initial_commit=initial_commit)
+
+    # With branches in config
+    conf.branches = ['master', 'some-branch']
+
+    init_results()
+    _test_run_branches(tmpdir, dvcs, conf, machine_file, 'NEW',
+                       branches=['master', 'some-branch'], initial_commit=initial_commit)
+
+    init_results()
+    _test_run_branches(tmpdir, dvcs, conf, machine_file, 'ALL',
+                       branches=['master', 'some-branch'], initial_commit=initial_commit)
+
+
 if __name__ == '__main__':
     from asv import console
     console.log.enable()

--- a/test/test_workflow.py
+++ b/test/test_workflow.py
@@ -87,7 +87,7 @@ def test_run_publish(basic_conf):
     assert isfile(join(tmpdir, 'html', 'asv.css'))
 
     # Check parameterized test json data format
-    filename = glob.glob(join(tmpdir, 'html', 'graphs', 'arch-x86_64',
+    filename = glob.glob(join(tmpdir, 'html', 'graphs', 'arch-x86_64', 'branch-master',
                               'cpu-Blazingly fast', 'machine-orangutan', 'os-GNU',
                               'Linux', 'psutil-2.1', 'python-*', 'ram-128GB',
                               'six', 'params_examples.time_skip.json'))[0]

--- a/test/tools.py
+++ b/test/tools.py
@@ -67,6 +67,10 @@ class Git(object):
     def get_hash(self, name):
         return self._run_git(['rev-parse', name]).strip()
 
+    def get_branch_hashes(self, branch):
+        return [x.strip() for x in self._run_git(['rev-list', branch]).splitlines()
+                if x.strip()]
+
 
 _hg_config = """
 [ui]
@@ -114,6 +118,10 @@ class Hg(object):
         if log:
             return log[0][1]
         return None
+
+    def get_branch_hashes(self, branch):
+        log = self._repo.log('ancestors({0})'.format(branch))
+        return [entry[1] for entry in log]
 
 
 def copy_template(src, dst, dvcs, values):

--- a/test/tools.py
+++ b/test/tools.py
@@ -199,7 +199,7 @@ def generate_test_repo(tmpdir, values=[0], dvcs_type='git',
             dvcs.create_branch(start_commit, branch_name)
             for i, value in enumerate(values):
                 mapping = {
-                    'version': "{0}.{1}".format(branch_name, i),
+                    'version': "{0}".format(i),
                     'dummy_value': value
                 }
                 copy_template(template_path, dvcs_path, dvcs, mapping)


### PR DESCRIPTION
This adds support for branches:

- config option for specifying the branches, defaults to only the 'master' branch
- separate lines in graphs for each branch, implemented via the generic machine parameter set thing (no JS changes needed, nice design!)
- run NEW and run ALL run benchmarks for all specified branches. The `--steps` option applies to each branch separately
- branch information is not stored in asv result files, as it can be obtained from the repository when needed (for subversion this can be cached)

This is still a bit work in progress:

- [x] some more manual testing is needed
- [x] update docs and sample config