### PR TITLE
Clean up command line option nargs usage

### DIFF
--- a/asv/commands/compare.py
+++ b/asv/commands/compare.py
@@ -57,15 +57,15 @@ class Compare(Command):
             description="Compare two sets of results")
 
         parser.add_argument(
-            'revision1', nargs=1,
+            'revision1',
             help="""The reference revision.""")
 
         parser.add_argument(
-            'revision2', nargs=1,
+            'revision2',
             help="""The revision being compared""")
 
         parser.add_argument(
-            '--threshold', '-t', nargs='?', type=float, default=2,
+            '--threshold', '-t', type=float, default=2,
             help="""The threshold to use to color-code divergent results. This
                     is a factor, so for example setting this to 2 will
                     highlight all results differing by more than a factor of
@@ -77,7 +77,7 @@ class Compare(Command):
            improved, stayed the same, and gotten worse""")
 
         parser.add_argument(
-            '--machine', '-m', nargs='?', type=str, default=None,
+            '--machine', '-m', type=str, default=None,
             help="""The machine to compare the revisions for""")
 
 

--- a/asv/commands/continuous.py
+++ b/asv/commands/continuous.py
@@ -34,7 +34,7 @@ class Continuous(Command):
             'branch', default=None,
             help="""The commit/branch to test. By default, the master branch.""")
         parser.add_argument(
-            '--factor', "-f", nargs='?', type=float, default=2.0,
+            '--factor', "-f", type=float, default=2.0,
             help="""The factor above or below which a result is
             considered problematic.  For example, with a factor of 2,
             if a benchmark gets twice as slow or twice as fast, it
@@ -43,11 +43,11 @@ class Continuous(Command):
             "--show-stderr", "-e", action="store_true",
             help="""Display the stderr output from the benchmarks.""")
         parser.add_argument(
-            "--bench", "-b", type=str, nargs="*",
+            "--bench", "-b", type=str, action="append",
             help="""Regular expression(s) for benchmark to run.  When
             not provided, all benchmarks are run.""")
         parser.add_argument(
-            "--machine", "-m", nargs='?', type=str, default=None,
+            "--machine", "-m", type=str, default=None,
             help="""Use the given name to retrieve machine
             information.  If not provided, the hostname is used.  If
             no entry with that name is found, and there is only one

--- a/asv/commands/dev.py
+++ b/asv/commands/dev.py
@@ -18,11 +18,11 @@ class Dev(Run):
                 --quick --show-stderr --python=same``""")
 
         parser.add_argument(
-            "--bench", "-b", type=str, nargs="*",
+            "--bench", "-b", type=str, action="append",
             help="""Regular expression(s) for benchmark to run.  When
             not provided, all benchmarks are run.""")
         parser.add_argument(
-            "--python", nargs='?', type=str,
+            "--python", type=str,
             default="same",
             help="""Specify a Python interpreter in which to run the
             benchmarks.  By default, uses the same Python interpreter
@@ -34,7 +34,7 @@ class Dev(Run):
             dependencies.  A specific revision may not be provided
             when --python is provided.""")
         parser.add_argument(
-            "--machine", "-m", nargs='?', type=str, default=None,
+            "--machine", "-m", type=str, default=None,
             help="""Use the given name to retrieve machine
             information.  If not provided, the hostname is used.  If
             that is not found, and there is only one entry in

--- a/asv/commands/find.py
+++ b/asv/commands/find.py
@@ -37,13 +37,13 @@ class Find(Command):
             when the regression in the range is mostly monotonic.""")
 
         parser.add_argument(
-            'range', type=str, nargs=1, metavar=('from..to',),
+            'range', type=str, metavar=('from..to',),
             help="""Range of commits to search.  For a git
             repository, this is passed as the first argument to ``git
             log``.  See 'specifying ranges' section of the
             `gitrevisions` manpage for more info.""")
         parser.add_argument(
-            "bench", type=str, nargs=1, metavar=('benchmark_name',),
+            "bench", type=str, metavar=('benchmark_name',),
             help="""Name of benchmark to use in search.""")
         parser.add_argument(
             "--invert", "-i", action="store_true",
@@ -54,7 +54,7 @@ class Find(Command):
             help="""Display the stderr output from the benchmarks when
             they fail.""")
         parser.add_argument(
-            "--machine", "-m", nargs='?', type=str, default=None,
+            "--machine", "-m", type=str, default=None,
             help="""Use the given name to retrieve machine
             information.  If not provided, the hostname is used.  If
             that is not found, and there is only one entry in

--- a/asv/commands/profiling.py
+++ b/asv/commands/profiling.py
@@ -45,7 +45,7 @@ class Profile(Command):
             description="Profile a benchmark")
 
         parser.add_argument(
-            'benchmark', nargs='?',
+            'benchmark',
             help="""The benchmark to profile.  Must be a
             fully-specified benchmark name.""")
         parser.add_argument(
@@ -53,11 +53,11 @@ class Profile(Command):
             help="""The revision of the project to profile.  May be a
             commit hash, or a tag or branch name.""")
         parser.add_argument(
-            '--gui', '-g', nargs='?',
+            '--gui', '-g',
             help="""Display the profile in the given gui.  Use
             --gui=list to list available guis.""")
         parser.add_argument(
-            '--output', '-o', nargs='?',
+            '--output', '-o',
             help="""Save the profiling information to the given file.
             This file is in the format written by the `cProfile`
             standard library module.  If not provided, prints a simple
@@ -67,7 +67,7 @@ class Profile(Command):
             help="""Forcibly re-run the profile, even if the data
             already exists in the results database.""")
         parser.add_argument(
-            '--environment', '-e', nargs='?',
+            '--environment', '-e',
             help="""Which environment to use.  Your benchmarking
             project may have multiple environments if it has a
             dependency matrix or multiple versions of Python
@@ -75,7 +75,7 @@ class Profile(Command):
             directory as already created by the run command. If `None`
             is specified, one will be chosen at random.""")
         parser.add_argument(
-            "--python", nargs='?', type=str, default=None,
+            "--python", type=str, default=None,
             help="""Specify a Python interpreter in which to run the
             benchmarks.  It may be an executable to be searched for on
             the $PATH, an absolute path, or the special value "same"

--- a/asv/commands/rm.py
+++ b/asv/commands/rm.py
@@ -26,7 +26,7 @@ class Rm(Command):
             """)
 
         parser.add_argument(
-            'patterns', nargs='*',
+            'patterns', nargs='+',
             help="""Pattern(s) to match, each of the form X=Y.  X may
             be one of "benchmark", "commit_hash", "python" or any of
             the machine or environment params.  Y is a case-sensitive

--- a/asv/commands/run.py
+++ b/asv/commands/run.py
@@ -67,7 +67,7 @@ class Run(Command):
             used to subsample the commits determined by range to a
             reasonable number.""")
         parser.add_argument(
-            "--bench", "-b", type=str, nargs="?",
+            "--bench", "-b", type=str, action="append",
             help="""Regular expression(s) for benchmark to run.  When
             not provided, all benchmarks are run.""")
         parser.add_argument(
@@ -89,7 +89,7 @@ class Run(Command):
             benchmark functions faster.  The results are unlikely to
             be useful, and thus are not saved.""")
         parser.add_argument(
-            "--python", nargs='?', type=str,
+            "--python", type=str,
             default=None,
             help="""Specify a Python interpreter in which to run the
             benchmarks.  It may be an executable to be searched for on
@@ -108,7 +108,7 @@ class Run(Command):
             default=None,
             help="""Do not save any results to disk.""")
         parser.add_argument(
-            "--machine", "-m", nargs='?', type=str, default=None,
+            "--machine", "-m", type=str, default=None,
             help="""Use the given name to retrieve machine
             information.  If not provided, the hostname is used.  If
             that is not found, and there is only one entry in


### PR DESCRIPTION
Use nargs='?' in dash-dash options only if const= is set, i.e., only for --parallel. The other dash-dash options require an argument, e.g. `asv run --machine` requires a machine name to make sense.

Remove nargs='?' from the benchmark name argument in asv profile, as that is a required argument.

For the --bench option, use action="append" rather than nargs='*'. Having --bench slurp command line arguments greedily is confusing to use with commands that have positional arguments. For example `asv dev --bench somename master..HEAD` [behaves in a confusing way](https://github.com/scipy/scipy/issues/4574#issuecomment-76538641); `asv dev` doesn't actually take positional arguments but the commit name is slurped by `--bench`.