### PR TITLE
Fix inverted benchmark regex selection logic

### DIFF
--- a/asv/benchmarks.py
+++ b/asv/benchmarks.py
@@ -279,10 +279,7 @@ class Benchmarks(dict):
         self._all_benchmarks = {}
         for benchmark in benchmarks:
             self._all_benchmarks[benchmark['name']] = benchmark
-            for reg in regex:
-                if not re.search(reg, benchmark['name']):
-                    break
-            else:
+            if not regex or any(re.search(reg, benchmark['name']) for reg in regex):
                 self[benchmark['name']] = benchmark
 
     @classmethod

--- a/test/test_benchmarks.py
+++ b/test/test_benchmarks.py
@@ -45,6 +45,10 @@ def test_find_benchmarks(tmpdir):
     b = benchmarks.Benchmarks(conf, regex='time_example_benchmark_1')
     assert len(b) == 2
 
+    b = benchmarks.Benchmarks(conf, regex=['time_example_benchmark_1',
+                                           'some regexp that does not match anything'])
+    assert len(b) == 2
+
     b = benchmarks.Benchmarks(conf)
     assert len(b) == 16
 


### PR DESCRIPTION
Benchmark should be selected if any regex matches, not only if all of them match.