### PR TITLE
Fix Git.get_date to work also for annotated tags

### DIFF
--- a/asv/plugins/git.py
+++ b/asv/plugins/git.py
@@ -84,7 +84,7 @@ class Git(Repo):
         # TODO: This works on Linux, but should be extended for other platforms
         return int(self._run_git(
             ['show', hash, '--quiet', '--format=format:%at'],
-            valid_return_codes=(0, 1), dots=False).strip().split()[0]) * 1000
+            valid_return_codes=(0, 1), dots=False).strip().split()[-1]) * 1000
 
     def get_hashes_from_range(self, range_spec):
         if range_spec == 'master':


### PR DESCRIPTION
git show for these prints pgp signature etc before the formatted display.
For example, see `git show v0.15.1 --quiet --format=%ct` in scipy repository.