### PR TITLE
Display tracebacks for exceptions, except for UserErrors

### DIFF
--- a/asv/main.py
+++ b/asv/main.py
@@ -34,7 +34,7 @@ def main():
 
     try:
         result = args.func(args)
-    except (RuntimeError, util.UserError) as e:
+    except util.UserError as e:
         log.error(six.text_type(e))
         sys.stdout.write('\n')
         sys.exit(1)


### PR DESCRIPTION
The RuntimeError catch in main() apparently is for catching unexpected errors.
For these, it would be useful to include a traceback.

E.g., running `asv run --python=same NEW` ends up raising a NotImplementedError.
However, since there is no error message attached, it just prints `·` without a message
telling what went wrong, or that an error occurred. Since the exception pattern here is
so wide, it's probably best to print also a traceback.