### PR TITLE
Check environment presence and install requirements only on creation

### DIFF
--- a/asv/commands/setup.py
+++ b/asv/commands/setup.py
@@ -14,19 +14,19 @@ from .. import util
 from . import common_args
 
 
-def _install_requirements(env):
+def _create(env):
     try:
         with log.set_level(logging.WARN):
-            env.install_requirements()
+            env.create()
     except:
         import traceback
         traceback.print_exc()
         raise
 
 
-def _install_requirements_multiprocess(env):
+def _create_multiprocess(env):
     try:
-        return _install_requirements(env)
+        return _create(env)
     except:
         import traceback
         traceback.print_exc()
@@ -66,16 +66,11 @@ class Setup(Command):
 
         log.info("Creating environments")
         with log.indent():
-            for env in environments:
-                env.create()
-
-        log.info("Installing dependencies")
-        with log.indent():
             if parallel != 1:
                 pool = multiprocessing.Pool(parallel)
-                pool.map(_install_requirements_multiprocess, environments)
+                pool.map(_create, environments)
                 pool.close()
             else:
-                list(map(_install_requirements, environments))
+                list(map(_create, environments))
 
         return environments

--- a/asv/plugins/conda.py
+++ b/asv/plugins/conda.py
@@ -71,6 +71,18 @@ class Conda(environment.Environment):
         for configuration in environment.iter_configuration_matrix(conf.matrix):
             yield cls(conf, python, configuration)
 
+    def check_presence(self):
+        if not super(Conda, self).check_presence():
+            return False
+        for fn in ['pip', 'python']:
+            if not os.path.isfile(os.path.join(self._path, 'bin', fn)):
+                return False
+        try:
+            self._run_executable('python', ['-c', 'pass'])
+        except (subprocess.CalledProcessError, OSError):
+            return False
+        return True
+
     def setup(self):
         try:
             conda = util.which('conda')

--- a/asv/plugins/conda.py
+++ b/asv/plugins/conda.py
@@ -83,7 +83,7 @@ class Conda(environment.Environment):
             return False
         return True
 
-    def setup(self):
+    def _setup(self):
         try:
             conda = util.which('conda')
         except IOError as e:
@@ -100,12 +100,10 @@ class Conda(environment.Environment):
             'python={0}'.format(self._python),
             'pip'])
 
-    def install_requirements(self):
-        if self._requirements_installed:
-            return
+        log.info("Installing requirements for {0}".format(self.name))
+        self._install_requirements()
 
-        self.create()
-
+    def _install_requirements(self):
         self.install('wheel')
 
         if self._requirements:
@@ -119,8 +117,6 @@ class Conda(environment.Environment):
                 else:
                     args.append(key)
             self._run_executable('conda', args)
-
-        self._requirements_installed = True
 
     def _run_executable(self, executable, args, **kwargs):
         return util.check_output([
@@ -137,5 +133,4 @@ class Conda(environment.Environment):
 
     def run(self, args, **kwargs):
         log.debug("Running '{0}' in {1}".format(' '.join(args), self.name))
-        self.install_requirements()
         return self._run_executable('python', args, **kwargs)

--- a/asv/plugins/virtualenv.py
+++ b/asv/plugins/virtualenv.py
@@ -6,6 +6,7 @@ from __future__ import absolute_import, division, unicode_literals, print_functi
 from distutils.version import LooseVersion
 import inspect
 import os
+import subprocess
 
 import six
 
@@ -84,6 +85,18 @@ class Virtualenv(environment.Environment):
             return False
         else:
             return True
+
+    def check_presence(self):
+        if not super(Virtualenv, self).check_presence():
+            return False
+        for fn in ['pip', 'python']:
+            if not os.path.isfile(os.path.join(self._path, 'bin', fn)):
+                return False
+        try:
+            self._run_executable('python', ['-c', 'pass'])
+        except (subprocess.CalledProcessError, OSError):
+            return False
+        return True
 
     def setup(self):
         """

--- a/asv/plugins/virtualenv.py
+++ b/asv/plugins/virtualenv.py
@@ -98,11 +98,11 @@ class Virtualenv(environment.Environment):
             return False
         return True
 
-    def setup(self):
+    def _setup(self):
         """
-        Setup the environment on disk.  If it doesn't exist, it is
-        created using virtualenv.  Then, all of the requirements are
-        installed into it using `pip install`.
+        Setup the environment on disk using virtualenv.
+        Then, all of the requirements are installed into
+        it using `pip install`.
         """
         log.info("Creating virtualenv for {0}".format(self.name))
         util.check_call([
@@ -111,12 +111,10 @@ class Virtualenv(environment.Environment):
             '--no-site-packages',
             self._path])
 
-    def install_requirements(self):
-        if self._requirements_installed:
-            return
+        log.info("Installing requirements for {0}".format(self.name))
+        self._install_requirements()
 
-        self.create()
-
+    def _install_requirements(self):
         self._run_executable('pip', ['install', 'wheel'])
 
         if self._requirements:
@@ -127,8 +125,6 @@ class Virtualenv(environment.Environment):
                 else:
                     args.append(key)
             self._run_executable('pip', args)
-
-        self._requirements_installed = True
 
     def _run_executable(self, executable, args, **kwargs):
         return util.check_output([
@@ -145,5 +141,4 @@ class Virtualenv(environment.Environment):
 
     def run(self, args, **kwargs):
         log.debug("Running '{0}' in {1}".format(' '.join(args), self.name))
-        self.install_requirements()
         return self._run_executable('python', args, **kwargs)

--- a/test/test_environment.py
+++ b/test/test_environment.py
@@ -46,8 +46,7 @@ def test_matrix_environments(tmpdir):
     # Only test the first two environments, since this is so time
     # consuming
     for env in environments[:2]:
-        env.setup()
-        env.install_requirements()
+        env.create()
 
         output = env.run(
             ['-c', 'import six, sys; sys.stdout.write(six.__version__)'])
@@ -80,7 +79,8 @@ def test_large_environment_matrix(tmpdir):
         # this test run a long time, we only set up the environment,
         # but don't actually install dependencies into it.  This is
         # enough to trigger the bug in #169.
-        env.setup()
+        env._install_requirements = lambda: None
+        env.create()
 
 
 @pytest.mark.xfail(not HAS_PYTHON_27,


### PR DESCRIPTION
Environments may be left in inoperable condition e.g. by `git clean -dxf` (which removes environment contents, but leaves the project repository clone standing), so add some quick consistency checks, and re-create the environment if the checks fail.

Also, make installing requirements part of the create() step. The requirements for each environment are unchanging, and calling pip install on them before running each command is not necessary.  This can as well be done at the same time when setting up the environment. I renamed `setup -> _setup` method, as it now is private within the Environment class hierarchy.

Fixes gh-248