### PR TITLE
Ensure subprocesses are terminated on timeout even if they have spawned their own subprocesses

### DIFF
--- a/asv/util.py
+++ b/asv/util.py
@@ -291,7 +291,9 @@ def check_output(args, valid_return_codes=(0,), timeout=120, dots=True,
     if posix:
         # Run the subprocess in a separate process group, so that we
         # can kill it and all child processes it spawns e.g. on
-        # timeouts
+        # timeouts. Note that subprocess.Popen will wait until exec()
+        # before returning in parent process, so there is no race
+        # condition in setting the process group vs. calls to os.killpg
         preexec_fn = lambda: os.setpgid(0, 0)
     else:
         preexec_fn = None

--- a/test/test_subprocess.py
+++ b/test/test_subprocess.py
@@ -4,6 +4,7 @@
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
+import os
 import sys
 import time
 
@@ -11,7 +12,8 @@ from asv import util
 
 
 def test_timeout():
-    timeout_code = r"""
+    timeout_codes = []
+    timeout_codes.append(r"""
 import sys
 import time
 
@@ -22,22 +24,41 @@ sys.stderr.flush()
 time.sleep(60)
 sys.stdout.write("Stdout after waiting\n")
 sys.stderr.write("Stderr after waiting\n")
-    """
+    """)
 
-    t = time.time()
-    try:
-        util.check_output([
-            sys.executable, "-c", timeout_code], timeout=1)
-    except util.ProcessError as e:
-        assert len(e.stdout.strip().split('\n')) == 1
-        assert len(e.stderr.strip().split('\n')) == 1
-        print(e.stdout)
-        assert e.stdout.strip() == "Stdout before waiting"
-        assert e.stderr.strip() == "Stderr before waiting"
-    else:
-        assert False, "Expected timeout exception"
-    # Make sure the timeout is triggered in a sufficiently short amount of time
-    assert time.time() - t < 5.0
+    # Another example, where timeout is due to a hanging sub-subprocess
+    if getattr(os, 'setpgid', None):
+        # only on posix
+        timeout_codes.append(r"""
+import sys
+import time
+import subprocess
+
+sys.stdout.write("Stdout before waiting\n")
+sys.stderr.write("Stderr before waiting\n")
+sys.stdout.flush()
+sys.stderr.flush()
+subprocess.call([sys.executable, "-c",
+    "import sys, subprocess; subprocess.call([sys.executable, '-c', 'import time; time.sleep(60)'])"])
+sys.stdout.write("Stdout after waiting\n")
+sys.stderr.write("Stderr after waiting\n")
+        """)
+
+    for timeout_code in timeout_codes:
+        t = time.time()
+        try:
+            util.check_output([
+                sys.executable, "-c", timeout_code], timeout=1)
+        except util.ProcessError as e:
+            assert len(e.stdout.strip().split('\n')) == 1
+            assert len(e.stderr.strip().split('\n')) == 1
+            print(e.stdout)
+            assert e.stdout.strip() == "Stdout before waiting"
+            assert e.stderr.strip() == "Stderr before waiting"
+        else:
+            assert False, "Expected timeout exception"
+        # Make sure the timeout is triggered in a sufficiently short amount of time
+        assert time.time() - t < 5.0
 
 
 def test_exception():


### PR DESCRIPTION
It's possible for `check_output` to not exit within a specified timeout, if the subprocess spawns a sub-sub-process process that does not exit. The termination signal sent to the subprocess is not propagated automatically to the sub-sub-one on posix, and the wait for the subprocess doesn't finish before the sub-sub-process exits.

To fix this, launch the subprocess in a [new process group](https://en.wikipedia.org/wiki/Process_group) using [setpgid](http://pubs.opengroup.org/onlinepubs/009695399/functions/setpgid.html). On error/exception, kill the subprocess by sending the signal to the whole process group.

Also move the termination to a `finally:` block, ensuring ASV never leaves subprocesses running in the background.

(Real-world example:
```
cd scipy/benchmarks
asv run --bench interpolate.Leaks.track_leaks 6a035d6a^..6a035d6a
```
)