### PR TITLE
Remove unused routine & fix race condition

### DIFF
--- a/asv/commands/setup.py
+++ b/asv/commands/setup.py
@@ -24,15 +24,6 @@ def _create(env):
         raise
 
 
-def _create_multiprocess(env):
-    try:
-        return _create(env)
-    except:
-        import traceback
-        traceback.print_exc()
-        raise
-
-
 class Setup(Command):
     @classmethod
     def setup_arguments(cls, subparsers):

--- a/asv/environment.py
+++ b/asv/environment.py
@@ -262,7 +262,17 @@ class Environment(object):
                 shutil.rmtree(self._path)
 
             if not os.path.exists(self._env_dir):
-                os.makedirs(self._env_dir)
+                try:
+                    os.makedirs(self._env_dir)
+                except OSError:
+                    # Environment.create may be called in parallel for
+                    # environments with different self._path, but same
+                    # self._env_dir. This causes a race condition for
+                    # the above makedirs() call --- but not for the
+                    # rest of the processing. Therefore, we will just
+                    # ignore the error here, as things will fail at a
+                    # later stage if there is really was a problem.
+                    pass
 
             try:
                 self._setup()


### PR DESCRIPTION
There's an unused `_create_multiprocess` routine that could be removed.

When replacing `install_requirements` -> `create` in gh-252 I (accidentally) made it call `_create` instead of `_create_multiprocess`. However, now that I look at it again, `_create` and `_create_multiprocess` are the same (they were so [also before](https://github.com/spacetelescope/asv/blob/bb16d18185756a737be6579d17a526d243695242/asv/commands/setup.py#L14)), so one can be removed, seems to work OK currently.