### PR TITLE
Provide user-visible feedback when benchmark times out

### DIFF
--- a/asv/benchmarks.py
+++ b/asv/benchmarks.py
@@ -107,6 +107,14 @@ def run_benchmark(benchmark, root, env, show_stderr=False, quick=False,
 
             err = err.strip()
             out = out.strip()
+
+            if errcode:
+                if errcode == util.TIMEOUT_RETCODE:
+                    if err:
+                        err += "\n\n"
+                    err += "asv: benchmark timed out (timeout {0}s)\n".format(benchmark['timeout'])
+                result['errcode'] = errcode
+
             if err or out:
                 err += out
                 if benchmark['params']:
@@ -117,9 +125,6 @@ def run_benchmark(benchmark, root, env, show_stderr=False, quick=False,
                 result.setdefault('stderr', '')
                 result['stderr'] += head_msg
                 result['stderr'] += err
-
-            if errcode:
-                result['errcode'] = errcode
 
         # Display status
         if failure_count > 0:

--- a/test/benchmark/time_examples.py
+++ b/test/benchmark/time_examples.py
@@ -40,3 +40,10 @@ def time_with_warnings():
     warnings.warn('after')
 
 time_with_warnings.goal_time = 0.1
+
+
+def time_with_timeout():
+    while True:
+        pass
+
+time_with_timeout.timeout = 0.1

--- a/test/test_benchmarks.py
+++ b/test/test_benchmarks.py
@@ -43,7 +43,7 @@ def test_find_benchmarks(tmpdir):
     assert len(b) == 3
 
     b = benchmarks.Benchmarks(conf, regex='example')
-    assert len(b) == 12
+    assert len(b) == 13
 
     b = benchmarks.Benchmarks(conf, regex='time_example_benchmark_1')
     assert len(b) == 2
@@ -53,13 +53,13 @@ def test_find_benchmarks(tmpdir):
     assert len(b) == 2
 
     b = benchmarks.Benchmarks(conf)
-    assert len(b) == 16
+    assert len(b) == 17
 
     envs = list(environment.get_environments(conf))
     b = benchmarks.Benchmarks(conf)
     times = b.run_benchmarks(envs[0], profile=True, show_stderr=True)
 
-    assert len(times) == 16
+    assert len(times) == 17
     assert times[
         'time_examples.TimeSuite.time_example_benchmark_1']['result'] is not None
     # Benchmarks that raise exceptions should have a time of "None"

--- a/test/test_workflow.py
+++ b/test/test_workflow.py
@@ -73,11 +73,20 @@ def test_run_publish(basic_conf):
     tmpdir, local, conf, machine_file = basic_conf
 
     # Tests a typical complete run/publish workflow
-    Run.run(conf, range_spec="master~5..master", steps=2,
-            _machine_file=machine_file, quick=True)
+    s = StringIO()
+    stdout = sys.stdout
+    try:
+        sys.stdout = s
+        Run.run(conf, range_spec="master~5..master", steps=2,
+                _machine_file=machine_file, quick=True, show_stderr=True)
+    finally:
+        sys.stdout = stdout
+    s.seek(0)
+    text = s.read()
 
     assert len(os.listdir(join(tmpdir, 'results_workflow', 'orangutan'))) == 5
     assert len(os.listdir(join(tmpdir, 'results_workflow'))) == 2
+    assert 'asv: benchmark timed out (timeout 0.1s)' in text
 
     Publish.run(conf)
 


### PR DESCRIPTION
Inform the user if a benchmark was terminated due to a timeout, by appending a message in the error stream. This should make debugging things easier (currently, timeout is signalled only by a `failed` text, with no indication for the reason).