### PR TITLE
Indicate in ProcessError if the command timed out

### DIFF
--- a/asv/util.py
+++ b/asv/util.py
@@ -213,8 +213,12 @@ class ProcessError(subprocess.CalledProcessError):
         self.stderr = stderr
 
     def __str__(self):
-        return "Command '{0}' returned non-zero exit status {1}".format(
-            ' '.join(self.args), self.retcode)
+        if self.retcode == TIMEOUT_RETCODE:
+            return "Command '{0}' timed out".format(
+                ' '.join(self.args))
+        else:
+            return "Command '{0}' returned non-zero exit status {1}".format(
+                ' '.join(self.args), self.retcode)
 
 
 def check_call(args, valid_return_codes=(0,), timeout=60, dots=True,

--- a/test/test_subprocess.py
+++ b/test/test_subprocess.py
@@ -55,6 +55,8 @@ sys.stderr.write("Stderr after waiting\n")
             print(e.stdout)
             assert e.stdout.strip() == "Stdout before waiting"
             assert e.stderr.strip() == "Stderr before waiting"
+            assert e.retcode == util.TIMEOUT_RETCODE
+            assert "timed out" in str(e)
         else:
             assert False, "Expected timeout exception"
         # Make sure the timeout is triggered in a sufficiently short amount of time
@@ -76,6 +78,8 @@ sys.exit(1)
         assert len(e.stderr.strip().split('\n')) == 1
         assert e.stdout.strip() == "Stdout before error"
         assert e.stderr.strip() == "Stderr before error"
+        assert e.retcode == 1
+        assert "returned non-zero exit status 1" in str(e)
     else:
         assert False, "Expected exception"
 


### PR DESCRIPTION
It can be helpful if the fact that a command timed out is indicated also in error messages.