### PR TITLE
For Travis-CI, install six and pytest in install phase

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,7 @@ install:
     fi
     if [[ $TRAVIS_PYTHON_VERSION == 2* ]]; then $TRAVIS_PIP install "mercurial>=3.3" ; fi;
     if [[ $TRAVIS_PYTHON_VERSION == 2* ]]; then $TRAVIS_PIP install python-hglib==1.5 ; fi;
-    $TRAVIS_PIP install selenium
+    $TRAVIS_PIP install selenium six pytest
 
 script:
   - $TRAVIS_PYTHON setup.py test


### PR DESCRIPTION
This ensures that tests will be marked as test setup failure rather than
as test failure, if downloading these packages fails. Moreover, it
ensures installing packages is done via pip, not setuptools.