### PR TITLE
Use py.test stdout/stderr capture mechanism in tests

### DIFF
--- a/test/test_compare.py
+++ b/test/test_compare.py
@@ -13,7 +13,6 @@ import six
 from asv import config
 
 from asv.commands.compare import Compare
-from io import StringIO
 
 from . import tools
 
@@ -43,8 +42,7 @@ All benchmarks:
 """
 
 
-def test_compare(tmpdir):
-
+def test_compare(capsys, tmpdir):
     tmpdir = six.text_type(tmpdir)
     os.chdir(tmpdir)
 
@@ -53,14 +51,7 @@ def test_compare(tmpdir):
          'repo': tools.generate_test_repo(tmpdir).path,
          'project': 'asv'})
 
-    s = StringIO()
-    stdout = sys.stdout
+    Compare.run(conf, '22b920c6', 'fcf8c079', machine='cheetah')
 
-    try:
-        sys.stdout = s
-        Compare.run(conf, '22b920c6', 'fcf8c079', machine='cheetah')
-    finally:
-        sys.stdout = stdout
-
-    s.seek(0)
-    assert s.read().strip() == REFERENCE.strip()
+    text, err = capsys.readouterr()
+    assert text.strip() == REFERENCE.strip()

--- a/test/test_workflow.py
+++ b/test/test_workflow.py
@@ -5,7 +5,6 @@ from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
 import glob
-from io import StringIO
 import os
 from os.path import abspath, dirname, join, isfile
 import shutil
@@ -69,20 +68,13 @@ def basic_conf(tmpdir):
     return tmpdir, local, conf, machine_file
 
 
-def test_run_publish(basic_conf):
+def test_run_publish(capfd, basic_conf):
     tmpdir, local, conf, machine_file = basic_conf
 
     # Tests a typical complete run/publish workflow
-    s = StringIO()
-    stdout = sys.stdout
-    try:
-        sys.stdout = s
-        Run.run(conf, range_spec="master~5..master", steps=2,
-                _machine_file=machine_file, quick=True, show_stderr=True)
-    finally:
-        sys.stdout = stdout
-    s.seek(0)
-    text = s.read()
+    Run.run(conf, range_spec="master~5..master", steps=2,
+            _machine_file=machine_file, quick=True, show_stderr=True)
+    text, err = capfd.readouterr()
 
     assert len(os.listdir(join(tmpdir, 'results_workflow', 'orangutan'))) == 5
     assert len(os.listdir(join(tmpdir, 'results_workflow'))) == 2
@@ -111,20 +103,14 @@ def test_run_publish(basic_conf):
         assert data[0][1][2] is None
 
     # Check that the skip options work
-    s = StringIO()
-    stdout = sys.stdout
-    try:
-        sys.stdout = s
-        Run.run(conf, range_spec="master~5..master", steps=2,
-                _machine_file=join(tmpdir, 'asv-machine.json'), quick=True,
-                skip_successful=True, skip_failed=True)
-        Run.run(conf, range_spec="master~5..master", steps=2,
-                _machine_file=join(tmpdir, 'asv-machine.json'), quick=True,
-                skip_existing_commits=True)
-    finally:
-        sys.stdout = stdout
-    s.seek(0)
-    text = s.read()
+    capfd.readouterr()
+    Run.run(conf, range_spec="master~5..master", steps=2,
+            _machine_file=join(tmpdir, 'asv-machine.json'), quick=True,
+            skip_successful=True, skip_failed=True)
+    Run.run(conf, range_spec="master~5..master", steps=2,
+            _machine_file=join(tmpdir, 'asv-machine.json'), quick=True,
+            skip_existing_commits=True)
+    text, err = capfd.readouterr()
     assert 'Running benchmarks.' not in text
 
     # Check EXISTING works
@@ -139,41 +125,27 @@ def test_run_publish(basic_conf):
     Publish.run(conf)
 
 
-def test_continuous(basic_conf):
+def test_continuous(capfd, basic_conf):
     tmpdir, local, conf, machine_file = basic_conf
 
     # Check that asv continuous runs
-    s = StringIO()
-    stdout = sys.stdout
-    try:
-        sys.stdout = s
-        Continuous.run(conf, branch="master^", _machine_file=machine_file, show_stderr=True)
-    finally:
-        sys.stdout = stdout
+    Continuous.run(conf, branch="master^", _machine_file=machine_file, show_stderr=True)
 
-    s.seek(0)
-    text = s.read()
+    text, err = capfd.readouterr()
     assert "SOME BENCHMARKS HAVE CHANGED SIGNIFICANTLY" in text
     assert "params_examples.track_find_test(2)              1.0        6.0   6.00000000x" in text
     assert "params_examples.ClassOne" in text
 
 
-def test_find(basic_conf):
+def test_find(capfd, basic_conf):
     tmpdir, local, conf, machine_file = basic_conf
 
     # Test find at least runs
-    s = StringIO()
-    stdout = sys.stdout
-    try:
-        sys.stdout = s
-        Find.run(conf, "master~5..master", "params_examples.track_find_test",
-                 _machine_file=machine_file)
-    finally:
-        sys.stdout = stdout
+    Find.run(conf, "master~5..master", "params_examples.track_find_test",
+             _machine_file=machine_file)
 
     # Check it found the first commit after the initially tested one
-    s.seek(0)
-    output = s.read()
+    output, err = capfd.readouterr()
 
     regression_hash = check_output(
         [which('git'), 'rev-parse', 'master^'], cwd=conf.repo)


### PR DESCRIPTION
Use py.test native stdout/stderr capture mechanism in tests, rather than manually changing sys.stdout.

This has the advantage that if an exception is raised during the time the output is redirected, py.test will print the output (e.g. from ProcessError logging) which makes debugging easier. This does not occur automatically when sys.stdout is redirected manually; if we do the printing manually, some output can still be lost when using multiprocessing. The fd-level py.test output capture seems to solve this issue.