### PR TITLE
Fix #274: Add setup_cache method support

### DIFF
--- a/asv/benchmarks.py
+++ b/asv/benchmarks.py
@@ -497,23 +497,26 @@ class Benchmarks(dict):
             with log.indent():
                 benchmarks = sorted(list(six.iteritems(self)))
 
+                if skip:
+                    benchmarks = [
+                        (name, benchmark) for (name, benchmark) in
+                        benchmarks if name not in skip]
+
                 setup_caches_done = set()
                 for name, benchmark in benchmarks:
                     key = benchmark.get('setup_cache_key')
                     if key is not None and key not in setup_caches_done:
                         log.info('Caching {0}'.format(key))
                         setup_caches_done.add(key)
-                        env.run(
+                        out, err, errcode = env.run(
                             [BENCHMARK_RUN_SCRIPT, 'setup_cache',
                              self._benchmark_dir, name,
                              cache_file.name],
-                            dots=False, display_error=True,
-                            return_stderr=True)
+                            dots=False, display_error=False,
+                            return_stderr=True, valid_return_codes=None)
 
                 times = {}
                 for name, benchmark in benchmarks:
-                    if skip and name in skip:
-                        continue
                     times[name] = run_benchmark(
                         benchmark, self._benchmark_dir, env,
                         cache_file.name, show_stderr=show_stderr,
@@ -529,7 +532,7 @@ class Benchmarks(dict):
                             [BENCHMARK_RUN_SCRIPT, 'teardown_cache',
                              self._benchmark_dir, name],
                             dots=False, display_error=True,
-                            return_stderr=True)
+                            return_stderr=True, valid_return_codes=None)
 
         finally:
             if os.path.isfile(cache_file.name):

--- a/asv/benchmarks.py
+++ b/asv/benchmarks.py
@@ -519,7 +519,6 @@ class Benchmarks(dict):
                                 # TODO: Store more information about failure
                                 times[name] = {'result': None}
                             continue
-                        assert os.path.isfile(os.path.join(tmpdir, 'cache.pickle'))
 
                     for name, benchmark in benchmark_set:
                         times[name] = run_benchmark(

--- a/docs/source/writing_benchmarks.rst
+++ b/docs/source/writing_benchmarks.rst
@@ -346,8 +346,7 @@ memory usage you want to track::
 
    The peak memory benchmark also counts memory usage during the
    ``setup`` routine, which may confound the benchmark results. One
-   way to avoid this is to spawn a separate subprocess for executing
-   memory-intensive setup tasks.
+   way to avoid this is to use ``setup_cache`` instead.
 
 
 .. _tracking:

--- a/docs/source/writing_benchmarks.rst
+++ b/docs/source/writing_benchmarks.rst
@@ -108,6 +108,21 @@ tearing down of in-memory state happens automatically.
 If ``setup`` raises a ``NotImplementedError``, the benchmark is marked
 as skipped.
 
+Additionally, if the ``setup`` method is computationally expensive,
+the ``setupClass`` ``classmethod`` may be used instead.  Any
+attributes this method sets on the class will be cached to disk and
+reused for all benchmarks in the class.  For example::
+
+    class Suite:
+        @classmethod
+        def setupClass(cls):
+            cls.fib = [1, 1]
+            for i in range(100):
+                cls.fib.append(cls.fib[-2] + cls.fib[-1])
+
+        def track_fib(self):
+            return self.fib[-1]
+
 .. _benchmark-attributes:
 
 Benchmark attributes

--- a/docs/source/writing_benchmarks.rst
+++ b/docs/source/writing_benchmarks.rst
@@ -238,8 +238,7 @@ You can also provide informative names for the parameters::
 These will appear in the test output; if not provided you get default
 names such as "param1", "param2".
 
-Note that ``setup_cache`` and ``teardown_cache`` are not
-parameterized.
+Note that ``setup_cache`` is not parameterized.
 
 Benchmark types
 ---------------

--- a/test/benchmark/cache_examples.py
+++ b/test/benchmark/cache_examples.py
@@ -22,14 +22,14 @@ class ClassLevelSetup:
 
 def setup_cache():
     with open("data.txt", "wb") as fd:
-        fd.write("42\n")
+        fd.write(b"42\n")
     return {'foo': 42, 'bar': 12}
 
 
 def track_cache_foo(d):
     assert os.path.isfile("data.txt")
     with open("data.txt", "rb") as fd:
-        assert fd.read().strip() == '42'
+        assert fd.read().strip() == b'42'
     return d['foo']
 
 

--- a/test/benchmark/cache_examples.py
+++ b/test/benchmark/cache_examples.py
@@ -3,6 +3,8 @@
 
 from __future__ import absolute_import, division, unicode_literals, print_function
 
+import os
+
 
 class ClassLevelSetup:
     def setup_cache(self):
@@ -19,10 +21,15 @@ class ClassLevelSetup:
 
 
 def setup_cache():
+    with open("data.txt", "wb") as fd:
+        fd.write("42\n")
     return {'foo': 42, 'bar': 12}
 
 
 def track_cache_foo(d):
+    assert os.path.isfile("data.txt")
+    with open("data.txt", "rb") as fd:
+        assert fd.read().strip() == '42'
     return d['foo']
 
 
@@ -35,6 +42,7 @@ def my_setup_cache():
 
 
 def track_my_cache_foo(d):
+    assert not os.path.isfile("data.txt")
     return d['foo']
 track_my_cache_foo.setup_cache = my_setup_cache
 

--- a/test/benchmark/track_examples.py
+++ b/test/benchmark/track_examples.py
@@ -5,13 +5,35 @@ from __future__ import absolute_import, division, unicode_literals, print_functi
 
 
 class ClassLevelSetup:
-    @classmethod
-    def setupclass(cls):
-        assert not hasattr(cls, 'big_list')
-        cls.big_list = [0] * 500
+    def setup_cache(self):
+        return [0] * 500
 
-    def track_example(self):
-        return len(self.big_list)
+    def teardown_cache(self):
+        pass
 
-    def track_example2(self):
-        return len(self.big_list)
+    def track_example(self, big_list):
+        return len(big_list)
+
+    def track_example2(self, big_list):
+        return len(big_list)
+
+
+def setup_cache():
+    return {'foo': 42, 'bar': 12}
+
+
+def track_cache_foo(d):
+    return d['foo']
+
+
+def track_cache_bar(d):
+    return d['bar']
+
+
+def my_setup_cache():
+    return {'foo': 0, 'bar': 1}
+
+
+def track_my_cache_foo(d):
+    return d['foo']
+track_my_cache_foo.setup_cache = my_setup_cache

--- a/test/benchmark/track_examples.py
+++ b/test/benchmark/track_examples.py
@@ -37,3 +37,11 @@ def my_setup_cache():
 def track_my_cache_foo(d):
     return d['foo']
 track_my_cache_foo.setup_cache = my_setup_cache
+
+
+class ClassLevelSetupFail:
+    def setup_cache(self):
+        raise RuntimeError()
+
+    def track_fail(self):
+        return -1

--- a/test/benchmark/track_examples.py
+++ b/test/benchmark/track_examples.py
@@ -1,0 +1,17 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+# -*- coding: utf-8 -*-
+
+from __future__ import absolute_import, division, unicode_literals, print_function
+
+
+class ClassLevelSetup:
+    @classmethod
+    def setupclass(cls):
+        assert not hasattr(cls, 'big_list')
+        cls.big_list = [0] * 500
+
+    def track_example(self):
+        return len(self.big_list)
+
+    def track_example2(self):
+        return len(self.big_list)

--- a/test/test_benchmarks.py
+++ b/test/test_benchmarks.py
@@ -43,7 +43,7 @@ def test_find_benchmarks(tmpdir):
     assert len(b) == 3
 
     b = benchmarks.Benchmarks(conf, regex='example')
-    assert len(b) == 16
+    assert len(b) == 19
 
     b = benchmarks.Benchmarks(conf, regex='time_example_benchmark_1')
     assert len(b) == 2
@@ -53,7 +53,7 @@ def test_find_benchmarks(tmpdir):
     assert len(b) == 2
 
     b = benchmarks.Benchmarks(conf)
-    assert len(b) == 20
+    assert len(b) == 23
 
     envs = list(environment.get_environments(conf))
     b = benchmarks.Benchmarks(conf)
@@ -97,6 +97,10 @@ def test_find_benchmarks(tmpdir):
 
     assert times['track_examples.ClassLevelSetup.track_example']['result'] == 500
     assert times['track_examples.ClassLevelSetup.track_example2']['result'] == 500
+
+    assert times['track_examples.track_cache_foo']['result'] == 42
+    assert times['track_examples.track_cache_bar']['result'] == 12
+    assert times['track_examples.track_my_cache_foo']['result'] == 0
 
     profile_path = join(tmpdir, 'test.profile')
     with open(profile_path, 'wb') as fd:

--- a/test/test_benchmarks.py
+++ b/test/test_benchmarks.py
@@ -43,7 +43,7 @@ def test_find_benchmarks(tmpdir):
     assert len(b) == 3
 
     b = benchmarks.Benchmarks(conf, regex='example')
-    assert len(b) == 14
+    assert len(b) == 16
 
     b = benchmarks.Benchmarks(conf, regex='time_example_benchmark_1')
     assert len(b) == 2
@@ -53,7 +53,7 @@ def test_find_benchmarks(tmpdir):
     assert len(b) == 2
 
     b = benchmarks.Benchmarks(conf)
-    assert len(b) == 18
+    assert len(b) == 20
 
     envs = list(environment.get_environments(conf))
     b = benchmarks.Benchmarks(conf)
@@ -94,6 +94,9 @@ def test_find_benchmarks(tmpdir):
     assert util.is_nan(times['params_examples.time_skip']['result']['result'][2])
 
     assert times['peakmem_examples.peakmem_list']['result'] >= 4 * 2**20
+
+    assert times['track_examples.ClassLevelSetup.track_example']['result'] == 500
+    assert times['track_examples.ClassLevelSetup.track_example2']['result'] == 500
 
     profile_path = join(tmpdir, 'test.profile')
     with open(profile_path, 'wb') as fd:

--- a/test/test_benchmarks.py
+++ b/test/test_benchmarks.py
@@ -43,7 +43,7 @@ def test_find_benchmarks(tmpdir):
     assert len(b) == 3
 
     b = benchmarks.Benchmarks(conf, regex='example')
-    assert len(b) == 19
+    assert len(b) == 20
 
     b = benchmarks.Benchmarks(conf, regex='time_example_benchmark_1')
     assert len(b) == 2
@@ -53,7 +53,7 @@ def test_find_benchmarks(tmpdir):
     assert len(b) == 2
 
     b = benchmarks.Benchmarks(conf)
-    assert len(b) == 23
+    assert len(b) == 24
 
     envs = list(environment.get_environments(conf))
     b = benchmarks.Benchmarks(conf)
@@ -101,6 +101,8 @@ def test_find_benchmarks(tmpdir):
     assert times['track_examples.track_cache_foo']['result'] == 42
     assert times['track_examples.track_cache_bar']['result'] == 12
     assert times['track_examples.track_my_cache_foo']['result'] == 0
+
+    assert times['track_examples.ClassLevelSetupFail.track_fail']['result'] == None
 
     profile_path = join(tmpdir, 'test.profile')
     with open(profile_path, 'wb') as fd:

--- a/test/test_benchmarks.py
+++ b/test/test_benchmarks.py
@@ -95,14 +95,14 @@ def test_find_benchmarks(tmpdir):
 
     assert times['peakmem_examples.peakmem_list']['result'] >= 4 * 2**20
 
-    assert times['track_examples.ClassLevelSetup.track_example']['result'] == 500
-    assert times['track_examples.ClassLevelSetup.track_example2']['result'] == 500
+    assert times['cache_examples.ClassLevelSetup.track_example']['result'] == 500
+    assert times['cache_examples.ClassLevelSetup.track_example2']['result'] == 500
 
-    assert times['track_examples.track_cache_foo']['result'] == 42
-    assert times['track_examples.track_cache_bar']['result'] == 12
-    assert times['track_examples.track_my_cache_foo']['result'] == 0
+    assert times['cache_examples.track_cache_foo']['result'] == 42
+    assert times['cache_examples.track_cache_bar']['result'] == 12
+    assert times['cache_examples.track_my_cache_foo']['result'] == 0
 
-    assert times['track_examples.ClassLevelSetupFail.track_fail']['result'] == None
+    assert times['cache_examples.ClassLevelSetupFail.track_fail']['result'] == None
 
     profile_path = join(tmpdir, 'test.profile')
     with open(profile_path, 'wb') as fd:


### PR DESCRIPTION
Caches results in a shelf between benchmark runs.

Cache is created/destroyed once per environment.