### PR TITLE
Add Appveyor support

### DIFF
--- a/.continuous-integration/appveyor/install-miniconda.ps1
+++ b/.continuous-integration/appveyor/install-miniconda.ps1
@@ -1,0 +1,71 @@
+﻿# Sample script to install anaconda under windows
+# Authors: Stuart Mumford
+# Borrwed from: Olivier Grisel and Kyle Kastner
+# License: BSD 3 clause
+
+$MINICONDA_URL = "http://repo.continuum.io/miniconda/"
+
+function DownloadMiniconda ($version, $platform_suffix) {
+    $webclient = New-Object System.Net.WebClient
+    $filename = "Miniconda-" + $version + "-Windows-" + $platform_suffix + ".exe"
+
+    $url = $MINICONDA_URL + $filename
+
+    $basedir = $pwd.Path + "\"
+    $filepath = $basedir + $filename
+    if (Test-Path $filename) {
+        Write-Host "Reusing" $filepath
+        return $filepath
+    }
+
+    # Download and retry up to 3 times in case of network transient errors.
+    Write-Host "Downloading" $filename "from" $url
+    $retry_attempts = 2
+    for($i=0; $i -lt $retry_attempts; $i++){
+        try {
+            $webclient.DownloadFile($url, $filepath)
+            break
+        }
+        Catch [Exception]{
+            Start-Sleep 1
+        }
+   }
+   if (Test-Path $filepath) {
+       Write-Host "File saved at" $filepath
+   } else {
+       # Retry once to get the error message if any at the last try
+       $webclient.DownloadFile($url, $filepath)
+   }
+   return $filepath
+}
+
+function InstallMiniconda ($python_version, $architecture, $python_home) {
+    Write-Host "Installing miniconda" $python_version "for" $architecture "bit architecture to" $python_home
+    if (Test-Path $python_home) {
+        Write-Host $python_home "already exists, skipping."
+        return $false
+    }
+    if ($architecture -eq "x86") {
+        $platform_suffix = "x86"
+    } else {
+        $platform_suffix = "x86_64"
+    }
+    $filepath = DownloadMiniconda $python_version $platform_suffix
+    Write-Host "Installing" $filepath "to" $python_home
+    $args = "/InstallationType=AllUsers /S /AddToPath=1 /RegisterPython=1 /D=" + $python_home
+    Write-Host $filepath $args
+    Start-Process -FilePath $filepath -ArgumentList $args -Wait -Passthru
+    #Start-Sleep -s 15
+    if (Test-Path C:\conda) {
+        Write-Host "Miniconda $python_version ($architecture) installation complete"
+    } else {
+        Write-Host "Failed to install Python in $python_home"
+        Exit 1
+    }
+}
+
+function main () {
+    InstallMiniconda $env:MINICONDA_VERSION $env:PLATFORM $env:PYTHON
+}
+
+main

--- a/.continuous-integration/appveyor/windows_sdk.cmd
+++ b/.continuous-integration/appveyor/windows_sdk.cmd
@@ -1,0 +1,47 @@
+:: To build extensions for 64 bit Python 3, we need to configure environment
+:: variables to use the MSVC 2010 C++ compilers from GRMSDKX_EN_DVD.iso of:
+:: MS Windows SDK for Windows 7 and .NET Framework 4 (SDK v7.1)
+::
+:: To build extensions for 64 bit Python 2, we need to configure environment
+:: variables to use the MSVC 2008 C++ compilers from GRMSDKX_EN_DVD.iso of:
+:: MS Windows SDK for Windows 7 and .NET Framework 3.5 (SDK v7.0)
+::
+:: 32 bit builds do not require specific environment configurations.
+::
+:: Note: this script needs to be run with the /E:ON and /V:ON flags for the
+:: cmd interpreter, at least for (SDK v7.0)
+::
+:: More details at:
+:: https://github.com/cython/cython/wiki/64BitCythonExtensionsOnWindows
+:: http://stackoverflow.com/a/13751649/163740
+::
+:: Author: Olivier Grisel
+:: License: CC0 1.0 Universal: http://creativecommons.org/publicdomain/zero/1.0/
+@ECHO OFF
+
+SET COMMAND_TO_RUN=%*
+SET WIN_SDK_ROOT=C:\Program Files\Microsoft SDKs\Windows
+
+SET MAJOR_PYTHON_VERSION="%PYTHON_VERSION:~0,1%"
+IF %MAJOR_PYTHON_VERSION% == "2" (
+    SET WINDOWS_SDK_VERSION="v7.0"
+) ELSE IF %MAJOR_PYTHON_VERSION% == "3" (
+    SET WINDOWS_SDK_VERSION="v7.1"
+) ELSE (
+    ECHO Unsupported Python version: "%MAJOR_PYTHON_VERSION%"
+    EXIT 1
+)
+
+IF "%PYTHON_ARCH%"=="64" (
+    ECHO Configuring Windows SDK %WINDOWS_SDK_VERSION% for Python %MAJOR_PYTHON_VERSION% on a 64 bit architecture
+    SET DISTUTILS_USE_SDK=1
+    SET MSSdk=1
+    "%WIN_SDK_ROOT%\%WINDOWS_SDK_VERSION%\Setup\WindowsSdkVer.exe" -q -version:%WINDOWS_SDK_VERSION%
+    "%WIN_SDK_ROOT%\%WINDOWS_SDK_VERSION%\Bin\SetEnv.cmd" /x64 /release
+    ECHO Executing: %COMMAND_TO_RUN%
+    call %COMMAND_TO_RUN% || EXIT 1
+) ELSE (
+    ECHO Using default MSVC build environment for 32 bit architecture
+    ECHO Executing: %COMMAND_TO_RUN%
+    call %COMMAND_TO_RUN% || EXIT 1
+)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,47 @@
+# AppVeyor.com is a Continuous Integration service to build and run tests under
+# Windows
+
+environment:
+
+  global:
+      PYTHON: "C:\\conda"
+      MINICONDA_VERSION: "latest"
+      CMD_IN_ENV: "cmd /E:ON /V:ON /C .\\.continuous-integration\\appveyor\\windows_sdk.cmd"
+
+  matrix:
+
+      - PYTHON_VERSION: "2.6"
+        platform: x64
+        PYTHON_ARCH: "64"
+      - PYTHON_VERSION: "2.7"
+        platform: x64
+        PYTHON_ARCH: "64"
+      - PYTHON_VERSION: "2.7"
+        platform: x86
+        PYTHON_ARCH: "32"
+      - PYTHON_VERSION: "3.4"
+        platform: x64
+        PYTHON_ARCH: "64"
+
+install:
+    # Install miniconda using a powershell script.
+    - "powershell .continuous-integration/appveyor/install-miniconda.ps1"
+    - "SET PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%"
+
+    # Install the build and runtime dependencies of the project.
+    - "conda update --yes conda"
+    # Create a conda environment
+    - "conda create -q --yes -n test -c python=%PYTHON_VERSION%"
+    - "activate test"
+
+    # Check that we have the expected version of Python
+    - "python --version"
+
+    # Install specified version of numpy and dependencies
+    - "conda install -q --yes six pytest"
+
+# Not a .NET project
+build: false
+
+test_script:
+  - "%CMD_IN_ENV% python setup.py test"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -31,7 +31,7 @@ install:
     # Install the build and runtime dependencies of the project.
     - "conda update --yes conda"
     # Create a conda environment
-    - "conda create -q --yes -n test -c python=%PYTHON_VERSION%"
+    - "conda create -q --yes -n test python=%PYTHON_VERSION%"
     - "activate test"
 
     # Check that we have the expected version of Python

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -37,7 +37,7 @@ install:
     # Check that we have the expected version of Python
     - "python --version"
 
-    # Install specified version of numpy and dependencies
+    # Install specified version of dependencies
     - "conda install -q --yes six pytest"
 
 # Not a .NET project


### PR DESCRIPTION
I expect this to fail without the fixes in #280.

Note this goes a little beyond what we need by including support for compiling C extensions (which we don't have), but it was easy enough to do since it was already in astropy's recipe.