### PR TITLE
Always call benchmark script with absolute path + actually test this

### DIFF
--- a/asv/benchmarks.py
+++ b/asv/benchmarks.py
@@ -229,8 +229,8 @@ def _run_benchmark_single(benchmark, root, env, param_idx, profile, quick, cwd):
 
         result_file.close()
         out, err, errcode = env.run(
-            [BENCHMARK_RUN_SCRIPT, 'run', root, name, str(quick),
-             profile_path, result_file.name],
+            [BENCHMARK_RUN_SCRIPT, 'run', os.path.abspath(root),
+             name, str(quick), profile_path, result_file.name],
             dots=False, timeout=benchmark['timeout'],
             display_error=False, return_stderr=True,
             valid_return_codes=None, cwd=cwd)
@@ -334,8 +334,8 @@ class Benchmarks(dict):
             try:
                 result_file.close()
                 env.run(
-                    [BENCHMARK_RUN_SCRIPT, 'discover', root,
-                     result_file.name],
+                    [BENCHMARK_RUN_SCRIPT, 'discover',
+                     os.path.abspath(root), result_file.name],
                     dots=False)
 
                 with open(result_file.name, 'r') as fp:
@@ -510,7 +510,8 @@ class Benchmarks(dict):
                         log.info("Setting up {0}".format(setup_cache_key))
                         out, err, errcode = env.run(
                             [BENCHMARK_RUN_SCRIPT, 'setup_cache',
-                             self._benchmark_dir, benchmark_set[0][0]],
+                             os.path.abspath(self._benchmark_dir),
+                             benchmark_set[0][0]],
                             dots=False, display_error=False,
                             return_stderr=True, valid_return_codes=None,
                             cwd=tmpdir)

--- a/test/test_benchmarks.py
+++ b/test/test_benchmarks.py
@@ -5,6 +5,7 @@ from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
 import os
+import shutil
 from os.path import join, dirname
 
 import pstats
@@ -24,7 +25,6 @@ INVALID_BENCHMARK_DIR = join(
     dirname(__file__), 'benchmark.invalid')
 
 ASV_CONF_JSON = {
-    'benchmark_dir': BENCHMARK_DIR,
     'project': 'asv'
     }
 
@@ -33,9 +33,12 @@ def test_find_benchmarks(tmpdir):
     tmpdir = six.text_type(tmpdir)
     os.chdir(tmpdir)
 
+    shutil.copytree(BENCHMARK_DIR, 'benchmark')
+
     d = {}
     d.update(ASV_CONF_JSON)
-    d['env_dir'] = join(tmpdir, "env")
+    d['env_dir'] = "env"
+    d['benchmark_dir'] = 'benchmark'
     d['repo'] = tools.generate_test_repo(tmpdir, [0]).path
     conf = config.Config.from_json(d)
 
@@ -117,7 +120,7 @@ def test_invalid_benchmark_tree(tmpdir):
     d = {}
     d.update(ASV_CONF_JSON)
     d['benchmark_dir'] = INVALID_BENCHMARK_DIR
-    d['env_dir'] = join(tmpdir, "env")
+    d['env_dir'] = "env"
     d['repo'] = tools.generate_test_repo(tmpdir, [0]).path
     conf = config.Config.from_json(d)
 

--- a/test/test_dev.py
+++ b/test/test_dev.py
@@ -7,7 +7,7 @@ from __future__ import (absolute_import, division, print_function,
 import os
 import sys
 import re
-from os.path import abspath, dirname, join
+from os.path import abspath, dirname, join, relpath
 import shutil
 import pytest
 
@@ -28,15 +28,20 @@ def basic_conf(tmpdir):
     local = abspath(dirname(__file__))
     os.chdir(tmpdir)
 
+    # Use relative paths on purpose since this is what will be in
+    # actual config files
+
+    shutil.copytree(os.path.join(local, 'benchmark'), 'benchmark')
+
     shutil.copyfile(join(local, 'asv-machine.json'),
                     join(tmpdir, 'asv-machine.json'))
 
     conf = config.Config.from_json({
-        'env_dir': join(tmpdir, 'env'),
-        'benchmark_dir': join(local, 'benchmark'),
-        'results_dir': join(tmpdir, 'results_workflow'),
-        'html_dir': join(tmpdir, 'html'),
-        'repo': tools.generate_test_repo(tmpdir).path,
+        'env_dir': 'env',
+        'benchmark_dir': 'benchmark',
+        'results_dir': 'results_workflow',
+        'html_dir': 'html',
+        'repo': relpath(tools.generate_test_repo(tmpdir).path),
         'project': 'asv',
         'matrix': {
             "six": [None],

--- a/test/test_workflow.py
+++ b/test/test_workflow.py
@@ -6,7 +6,7 @@ from __future__ import (absolute_import, division, print_function,
 
 import glob
 import os
-from os.path import abspath, dirname, join, isfile
+from os.path import abspath, dirname, join, isfile, relpath
 import shutil
 import sys
 
@@ -47,6 +47,11 @@ def basic_conf(tmpdir):
     local = abspath(dirname(__file__))
     os.chdir(tmpdir)
 
+    # Use relative paths on purpose since this is what will be in
+    # actual config files
+
+    shutil.copytree(os.path.join(local, 'benchmark'), 'benchmark')
+
     machine_file = join(tmpdir, 'asv-machine.json')
 
     shutil.copyfile(join(local, 'asv-machine.json'),
@@ -55,11 +60,11 @@ def basic_conf(tmpdir):
     repo_path = tools.generate_test_repo(tmpdir, dummy_values).path
 
     conf = config.Config.from_json({
-        'env_dir': join(tmpdir, 'env'),
-        'benchmark_dir': join(local, 'benchmark'),
-        'results_dir': join(tmpdir, 'results_workflow'),
-        'html_dir': join(tmpdir, 'html'),
-        'repo': repo_path,
+        'env_dir': 'env',
+        'benchmark_dir': 'benchmark',
+        'results_dir': 'results_workflow',
+        'html_dir': 'html',
+        'repo': relpath(repo_path),
         'dvcs': 'git',
         'project': 'asv',
         'matrix': {


### PR DESCRIPTION
This wasn't caught previously, because all tests used absolute paths in the config.

See https://github.com/spacetelescope/asv/commit/7564627ba4af275d0d753fefd22e5fe80a3c75e5#commitcomment-12233571