### PR TITLE
Add page load timeouts to web tests

### DIFF
--- a/test/test_web.py
+++ b/test/test_web.py
@@ -19,7 +19,7 @@ from asv.commands.run import Run
 from asv.commands.publish import Publish
 
 from . import tools
-from .tools import browser
+from .tools import browser, get_with_retry
 from .test_workflow import basic_conf
 
 
@@ -68,7 +68,7 @@ def test_web_smoketest(browser, basic_html):
     conf, dvcs = basic_html
 
     with tools.preview(conf.html_dir) as base_url:
-        browser.get(base_url)
+        get_with_retry(browser, base_url)
 
         assert browser.title == 'airspeed velocity of an unladen asv'
 
@@ -140,7 +140,7 @@ def test_web_regressions(browser, tmpdir):
     bad_commit_hash = dvcs.get_hash('master~9')
 
     with tools.preview(conf.html_dir) as base_url:
-        browser.get(base_url)
+        get_with_retry(browser, base_url)
 
         regressions_btn = browser.find_element_by_link_text('Show regressions')
         regressions_btn.click()

--- a/test/tools.py
+++ b/test/tools.py
@@ -35,6 +35,7 @@ try:
     from selenium import webdriver
     from selenium.webdriver.common.desired_capabilities import DesiredCapabilities
     from selenium.webdriver.support.ui import WebDriverWait
+    from selenium.common.exceptions import TimeoutException
     HAVE_WEBDRIVER = True
 except ImportError:
     HAVE_WEBDRIVER = False
@@ -284,6 +285,10 @@ def browser(request, pytestconfig):
     # Create the browser
     browser = driver_cls(**driver_options)
 
+    # Set timeouts
+    browser.set_page_load_timeout(30)
+    browser.set_script_timeout(30)
+
     # Clean up on fixture finalization
     def fin():
         browser.quit()
@@ -331,3 +336,13 @@ def preview(base_path):
     finally:
         httpd.shutdown()
         thread.join()
+
+
+def get_with_retry(browser, url):
+    for j in range(2):
+        try:
+            return browser.get(url)
+        except TimeoutException:
+            pass
+    else:
+        raise TimeoutException


### PR DESCRIPTION
Some googling shows other people are having similar problems:
https://www.google.fi/search?q=selenium+hang+travis

This one contains a potential solution --- set up timeouts, and just retry on failure: https://stackoverflow.com/questions/29108260/geb-selenium-tests-hang-loading-new-page

Related to gh-287

**EDIT**: also avoid shutting down the preview web server in a way that can block. I managed to reproduce a hang at this point, so best to do this defensively. I'm not sure, but perhaps phantomjs kept connections alive sometimes and prevented the server from shutting down; at the same time, the main process cannot send new instructions to phantomjs because it's waiting for the http server to exit -> deadlock (until socket timeout)?