### PR TITLE
Fix #294: Handle global commandline args

### DIFF
--- a/asv/commands/__init__.py
+++ b/asv/commands/__init__.py
@@ -11,7 +11,6 @@ import six
 
 from .. import config
 from .. import util
-from .. import __version__
 
 from . import common_args
 
@@ -67,6 +66,8 @@ def make_argparser():
     parser = argparse.ArgumentParser(
         "asv",
         description="Airspeed Velocity: Simple benchmarking tool for Python")
+
+    common_args.add_global_arguments(parser, suppress_defaults=False)
 
     subparsers = parser.add_subparsers(
         title='subcommands',

--- a/asv/commands/__init__.py
+++ b/asv/commands/__init__.py
@@ -13,6 +13,8 @@ from .. import config
 from .. import util
 from .. import __version__
 
+from . import common_args
+
 
 # This list is ordered in order of average workflow
 command_order = [
@@ -66,19 +68,6 @@ def make_argparser():
         "asv",
         description="Airspeed Velocity: Simple benchmarking tool for Python")
 
-    parser.add_argument(
-        "--verbose", "-v", action="store_true",
-        help="Increase verbosity")
-
-    parser.add_argument(
-        "--config",
-        help="Benchmark configuration file",
-        default='asv.conf.json')
-
-    parser.add_argument(
-        "--version", action="version", version="%(prog)s " + __version__,
-        help="Print program version")
-
     subparsers = parser.add_subparsers(
         title='subcommands',
         description='valid subcommands')
@@ -90,11 +79,13 @@ def make_argparser():
     commands = dict((x.__name__, x) for x in util.iter_subclasses(Command))
 
     for command in command_order:
-        commands[str(command)].setup_arguments(subparsers)
+        subparser = commands[str(command)].setup_arguments(subparsers)
+        common_args.add_global_arguments(subparser)
         del commands[command]
 
     for name, command in sorted(six.iteritems(commands)):
-        command.setup_arguments(subparsers)
+        subparser = command.setup_arguments(subparsers)
+        common_args.add_global_arguments(subparser)
 
     return parser, subparsers
 
@@ -103,6 +94,7 @@ def _make_docstring():
     parser, subparsers = make_argparser()
 
     lines = []
+
     for p in six.itervalues(subparsers.choices):
         lines.append(p.prog)
         lines.append('-' * len(p.prog))

--- a/asv/commands/common_args.py
+++ b/asv/commands/common_args.py
@@ -5,20 +5,33 @@ from __future__ import absolute_import, division, unicode_literals, print_functi
 
 import argparse
 
+from .. import __version__
 
-def add_global_arguments(parser):
+
+def add_global_arguments(parser, suppress_defaults=True):
+    # Suppressing defaults is needed in order to allow global
+    # arguments both before and after subcommand. Only the top-level
+    # parser should have suppress_defaults=False
+
+    if suppress_defaults:
+        suppressor = dict(default=argparse.SUPPRESS)
+    else:
+        suppressor = dict()
+
     parser.add_argument(
         "--verbose", "-v", action="store_true",
-        help="Increase verbosity")
+        help="Increase verbosity",
+        **suppressor)
 
     parser.add_argument(
         "--config",
         help="Benchmark configuration file",
-        default='asv.conf.json')
+        default=(argparse.SUPPRESS if suppress_defaults else 'asv.conf.json'))
 
     parser.add_argument(
         "--version", action="version", version="%(prog)s " + __version__,
-        help="Print program version")
+        help="Print program version",
+        **suppressor)
 
 
 def add_factor(parser):

--- a/asv/commands/common_args.py
+++ b/asv/commands/common_args.py
@@ -6,6 +6,21 @@ from __future__ import absolute_import, division, unicode_literals, print_functi
 import argparse
 
 
+def add_global_arguments(parser):
+    parser.add_argument(
+        "--verbose", "-v", action="store_true",
+        help="Increase verbosity")
+
+    parser.add_argument(
+        "--config",
+        help="Benchmark configuration file",
+        default='asv.conf.json')
+
+    parser.add_argument(
+        "--version", action="version", version="%(prog)s " + __version__,
+        help="Print program version")
+
+
 def add_factor(parser):
     parser.add_argument(
         '--factor', "-f", type=float, default=2.0,

--- a/test/test_dev.py
+++ b/test/test_dev.py
@@ -106,6 +106,7 @@ def test_dev_python_arg():
     argv = ['dev']
     args = parser.parse_args(argv)
     assert args.python == 'same'
+    assert not args.verbose
 
     argv = ['dev', '--python=foo']
     args = parser.parse_args(argv)
@@ -114,6 +115,16 @@ def test_dev_python_arg():
     argv = ['run', 'ALL']
     args = parser.parse_args(argv)
     assert args.python is None
+
+    argv = ['--verbose', '--config=foo', 'dev']
+    args = parser.parse_args(argv)
+    assert args.verbose
+    assert args.config == 'foo'
+
+    argv = ['dev', '--verbose', '--config=foo']
+    args = parser.parse_args(argv)
+    assert args.verbose
+    assert args.config == 'foo'
 
 
 def test_run_steps_arg():


### PR DESCRIPTION
So they appear in `asv $COMMAND --help`