### PR TITLE
Fix bug parsing revisions in 'asv compare'

### DIFF
--- a/asv/commands/compare.py
+++ b/asv/commands/compare.py
@@ -84,8 +84,8 @@ class Compare(Command):
     @classmethod
     def run_from_conf_args(cls, conf, args):
         return cls.run(conf=conf,
-                       hash_1=args.revision1[0],
-                       hash_2=args.revision2[0],
+                       hash_1=args.revision1,
+                       hash_2=args.revision2,
                        factor=args.factor, split=args.split,
                        machine=args.machine)
 

--- a/test/test_compare.py
+++ b/test/test_compare.py
@@ -13,6 +13,7 @@ import six
 from asv import config
 
 from asv.commands.compare import Compare
+from argparse import Namespace
 
 from . import tools
 
@@ -51,7 +52,9 @@ def test_compare(capsys, tmpdir):
          'repo': tools.generate_test_repo(tmpdir).path,
          'project': 'asv'})
 
-    Compare.run(conf, '22b920c6', 'fcf8c079', machine='cheetah')
+    mock_args = Namespace(revision1='22b920c6', revision2='fcf8c079', machine='cheetah',
+                          factor=2, split=False)
+    Compare.run_from_conf_args(conf, mock_args)
 
     text, err = capsys.readouterr()
     assert text.strip() == REFERENCE.strip()


### PR DESCRIPTION
@mdboom I noticed a bug when attempting to run ```asv compare``` on the pandas asv suite. I was seeing the following issue:

```
$ asv compare e118206d 912854 
All benchmarks:

    before     after       ratio
  [e       ] [9       ]
   310.58ns   311.98ns      1.00  attrs_caching.getattr_dataframe_index.time_getattr_dataframe_index
     3.66μs     3.75μs      1.03  attrs_caching.setattr_dataframe_index.time_setattr_dataframe_index
      [...]
```

Note that the before and after hashes have been truncated to the first character. The essence of this bug is that ```Compare.run_from_conf_args()``` has some custom logic that wasn't being covered by tests. Changing the tests to call this function confirms that the ```[0]```s are unnecessary.