### PR TITLE
Fix bugs in compare, 'mark' was undefined in one code path, format skipped tests properly

### DIFF
--- a/test/example_results/cheetah/22b920c6-py2.7-Cython-numpy1.8.json
+++ b/test/example_results/cheetah/22b920c6-py2.7-Cython-numpy1.8.json
@@ -17,6 +17,8 @@
         "numpy": "1.8"
     }, 
     "results": {
+    	"time_AAA_failure": null,
+    	"time_AAA_skip": NaN,
         "time_coordinates.time_latitude": 0.0004540278911590576, 
         "time_quantity.time_quantity_array_conversion": 0.0017511451244354248, 
         "time_quantity.time_quantity_init_array": 0.0009337139129638672, 

--- a/test/example_results/cheetah/fcf8c079-py2.7-Cython-numpy1.8.json
+++ b/test/example_results/cheetah/fcf8c079-py2.7-Cython-numpy1.8.json
@@ -17,6 +17,8 @@
         "numpy": "1.8"
     }, 
     "results": {
+    	"time_AAA_failure": null,
+    	"time_AAA_skip": NaN,
         "time_coordinates.time_latitude": null, 
         "time_quantity.time_quantity_array_conversion": 0.15283851623535155, 
         "time_quantity.time_quantity_init_array": 0.10822079181671143, 

--- a/test/test_compare.py
+++ b/test/test_compare.py
@@ -25,6 +25,8 @@ All benchmarks:
 
     before     after       ratio
   [22b920c6] [fcf8c079]
+     failed     failed       n/a  time_AAA_failure
+        n/a        n/a       n/a  time_AAA_skip
 !  454.03μs     failed       n/a  time_coordinates.time_latitude
       1.00s      1.00s      1.00  time_other.time_parameterized(1)
       2.00s      4.00s      2.00  time_other.time_parameterized(2)


### PR DESCRIPTION
Fix some further bugs in `asv compare`.

- Variable `mark` was not defined in the "time_1 is None and time_2 is None" causing failure if the first test had failed results in both commits.
- Skipped tests were not formatted correctly, forgot to update the compare command when they were added...
