### PR TITLE
Putting asv.conf.json on project top level

### DIFF
--- a/asv/commands/quickstart.py
+++ b/asv/commands/quickstart.py
@@ -23,16 +23,34 @@ class Quickstart(Command):
             help="The destination directory for the new benchmarking "
             "suite")
 
+        grp = parser.add_mutually_exclusive_group()
+        grp.add_argument(
+            "--top-level", action="store_true", dest="top_level", default=None,
+            help="Benchmarks are on the top level of the project's repository")
+        grp.add_argument(
+            "--no-top-level", action="store_false", dest="top_level", default=None,
+            help="Benchmarks are not in the project's repository top level")
+
         parser.set_defaults(func=cls.run_from_args)
 
         return parser
 
     @classmethod
     def run_from_args(cls, args):
-        return cls.run(dest=args.dest)
+        return cls.run(dest=args.dest, top_level=args.top_level)
 
     @classmethod
-    def run(cls, dest="."):
+    def run(cls, dest=".", top_level=None):
+        if top_level is None:
+            while True:
+                answer = raw_input("Is this the top level of your project repository? [y/n] ")
+                if answer.lower()[:1] == "y":
+                    top_level = True
+                    break
+                elif answer.lower()[:1] == "n":
+                    top_level = False
+                    break
+
         template_path = os.path.join(
             os.path.dirname(os.path.abspath(__file__)), '..', 'template')
         for entry in os.listdir(template_path):
@@ -50,5 +68,21 @@ class Quickstart(Command):
                 shutil.copytree(path, os.path.join(dest, entry))
             elif os.path.isfile(path):
                 shutil.copyfile(path, os.path.join(dest, entry))
+
+        if top_level:
+            conf_file = os.path.join(dest, 'asv.conf.json')
+
+            with open(conf_file, 'r') as f:
+                conf = f.read()
+
+            reps = [('"repo": "",', '"repo": ".",'),
+                    ('// "env_dir": "env",', '"env_dir": ".asv/env",'),
+                    ('// "results_dir": "results",', '"results_dir": ".asv/results",'),
+                    ('// "html_dir": "html",', '"html_dir": ".asv/html",')]
+            for src, dst in reps:
+                conf = conf.replace(src, dst)
+
+            with open(conf_file, 'w') as f:
+                f.write(conf)
 
         log.info("Edit asv.conf.json to get started.")

--- a/docs/source/using.rst
+++ b/docs/source/using.rst
@@ -30,7 +30,11 @@ benchmarking suite.  Change to the directory where you would like your
 new benchmarking suite to be created and run::
 
     $ asv quickstart
+    Is this the top level of your project repository? [y/n] n
     Edit asv.conf.json to get started.
+
+Answer 'y' if you want a default configuration more suitable for
+putting on the top level of your project's repository.
 
 Now that you have the bare bones of a benchmarking suite, let's edit
 the configuration file, ``asv.conf.json``.  Like most files that

--- a/test/test_quickstart.py
+++ b/test/test_quickstart.py
@@ -4,18 +4,43 @@
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
+import os
 from os.path import isfile, join
 
-import os
 import six
 
 from . import tools
+from asv import util
+import asv.commands.quickstart
 
 
 def test_quickstart(tmpdir):
     tmpdir = six.text_type(tmpdir)
 
-    tools.run_asv('quickstart', '--dest', tmpdir)
+    dest = join(tmpdir, 'separate')
+    os.makedirs(dest)
 
-    assert isfile(join(tmpdir, 'asv.conf.json'))
-    assert isfile(join(tmpdir, 'benchmarks', 'benchmarks.py'))
+    tools.run_asv('quickstart', '--no-top-level', '--dest', dest)
+
+    assert isfile(join(dest, 'asv.conf.json'))
+    assert isfile(join(dest, 'benchmarks', 'benchmarks.py'))
+    conf = util.load_json(join(dest, 'asv.conf.json'))
+    assert 'env_dir' not in conf
+    assert 'html_dir' not in conf
+    assert 'results_dir' not in conf
+
+    dest = join(tmpdir, 'same')
+    os.makedirs(dest)
+
+    try:
+        asv.commands.quickstart.raw_input = lambda msg: 'y'
+        tools.run_asv('quickstart', '--dest', dest)
+    finally:
+        del asv.commands.quickstart.raw_input
+
+    assert isfile(join(dest, 'asv.conf.json'))
+    assert isfile(join(dest, 'benchmarks', 'benchmarks.py'))
+    conf = util.load_json(join(dest, 'asv.conf.json'))
+    assert conf['env_dir'] != 'env'
+    assert conf['html_dir'] != 'html'
+    assert conf['results_dir'] != 'results'


### PR DESCRIPTION
Putting `asv.conf.json` on project repository top level has the advantage that running `asv` commands no longer requires `cd` to somewhere else. However, it usually also requires putting the repository clone to somewhere else than `conf.project`.

- Add config option `mirror_dir` for specifying the mirror location. Change the default value be `"project"` --- the mirror is a bare repository, so looking inside it is not usually useful.
- Make `asv quickstart` provide also a default config more suitable for putting on project top level.

This also requires gh-307 to work