### PR TITLE
Instead of replacing, take minimum of new and old results

### DIFF
--- a/asv/commands/compare.py
+++ b/asv/commands/compare.py
@@ -48,11 +48,6 @@ def unroll_result(benchmark_name, result):
         yield name, result
 
 
-def _isna(value):
-    # None (failed) or NaN (skipped)
-    return value is None or value != value
-
-
 class Compare(Command):
 
     @classmethod
@@ -162,18 +157,18 @@ class Compare(Command):
             time_1 = mean(results_1[benchmark])
             time_2 = mean(results_2[benchmark])
 
-            if _isna(time_1) or _isna(time_2):
+            if util.is_na(time_1) or util.is_na(time_2):
                 ratio = 'n/a'
             else:
                 ratio = "{0:6.2f}".format(time_2 / time_1)
 
-            if _isna(time_1) and _isna(time_2):
+            if util.is_na(time_1) and util.is_na(time_2):
                 color = 'red'
                 mark = ' '
-            elif _isna(time_1) and not _isna(time_2):
+            elif util.is_na(time_1) and not util.is_na(time_2):
                 color = 'green'
                 mark = '-'
-            elif not _isna(time_1) and _isna(time_2):
+            elif not util.is_na(time_1) and util.is_na(time_2):
                 color = 'red'
                 mark = '!'
             elif time_2 < time_1 / factor:

--- a/asv/commands/run.py
+++ b/asv/commands/run.py
@@ -104,6 +104,10 @@ class Run(Command):
             "--skip-existing", "-k", action="store_true",
             help="""Skip running benchmarks that have previous successful
             or failed results""")
+        parser.add_argument(
+            "--take-minimum", action="store_true",
+            help="""Instead of replacing existing results, take minimum of
+            the new and old results""")
 
         parser.set_defaults(func=cls.run_from_args)
 
@@ -119,14 +123,16 @@ class Run(Command):
             dry_run=args.dry_run, machine=args.machine,
             skip_successful=args.skip_existing_successful or args.skip_existing,
             skip_failed=args.skip_existing_failed or args.skip_existing,
-            skip_existing_commits=args.skip_existing_commits
+            skip_existing_commits=args.skip_existing_commits,
+            take_minimum=args.take_minimum
         )
 
     @classmethod
     def run(cls, conf, range_spec=None, steps=None, bench=None, parallel=1,
             show_stderr=False, quick=False, profile=False, python=None,
             dry_run=False, machine=None, _machine_file=None, skip_successful=False,
-            skip_failed=False, skip_existing_commits=False, _returns={}):
+            skip_failed=False, skip_existing_commits=False, take_minimum=False,
+            _returns={}):
         params = {}
         machine_params = Machine.load(
             machine_name=machine,
@@ -293,4 +299,5 @@ class Run(Command):
                                     benchmark_name,
                                     d['profile'])
 
-                        result.update_save(conf.results_dir)
+                        result.update_save(conf.results_dir,
+                                           take_minimum=take_minimum)

--- a/asv/graph.py
+++ b/asv/graph.py
@@ -95,7 +95,7 @@ class Graph(object):
         """
         # Add simple time series
         self.data_points.setdefault(date, [])
-        if not _is_na(value):
+        if not util.is_na(value):
             if not hasattr(value, '__len__'):
                 value = [value]
             else:
@@ -159,14 +159,14 @@ class Graph(object):
         # Discard missing data at edges
         i = 0
         for i in xrange(len(val)):
-            if any(not _is_na(v) for v in val[i][1]):
+            if any(not util.is_na(v) for v in val[i][1]):
                 break
         else:
             i = len(val)
 
         j = i
         for j in xrange(len(val) - 1, i, -1):
-            if any(not _is_na(v) for v in val[j][1]):
+            if any(not util.is_na(v) for v in val[j][1]):
                 break
 
         val = val[i:j+1]
@@ -192,9 +192,9 @@ class Graph(object):
             first_values = [None]*self.n_series
             for k, v in val:
                 for j, x in enumerate(v):
-                    if first_values[j] is None and not _is_na(x):
+                    if first_values[j] is None and not util.is_na(x):
                         first_values[j] = x
-                if not any(_is_na(x) for x in first_values):
+                if not any(util.is_na(x) for x in first_values):
                     break
 
             first_values = [fv if fv is not None else 1.0 
@@ -207,9 +207,9 @@ class Graph(object):
                 # Fill missing data, unless it's missing from all
                 # parameter combinations
                 cur_vals = []
-                if any(not _is_na(x) for x in v):
+                if any(not util.is_na(x) for x in v):
                     for j, x in enumerate(v):
-                        if _is_na(x):
+                        if util.is_na(x):
                             if last_values[j] is not None:
                                 x = last_values[j]
                             else:
@@ -250,19 +250,12 @@ class Graph(object):
         util.write_json(filename, val)
 
 
-def _is_na(value):
-    """
-    Return true if value is None or nan
-    """
-    return value is None or value != value
-
-
 def _mean_with_none(values):
     """
     Take a mean, with the understanding that None and NaN stand for
     missing data.
     """
-    values = [x for x in values if not _is_na(x)]
+    values = [x for x in values if not util.is_na(x)]
     if values:
         return sum(values) / len(values)
     else:
@@ -274,7 +267,7 @@ def _geom_mean_with_none(values):
     Compute geometric mean, with the understanding that None and NaN
     stand for missing data.
     """
-    values = [x for x in values if not _is_na(x)]
+    values = [x for x in values if not util.is_na(x)]
     if values:
         exponent = 1/len(values)
         prod = 1.0

--- a/asv/util.py
+++ b/asv/util.py
@@ -806,6 +806,13 @@ def is_nan(x):
     return False
 
 
+def is_na(x):
+    """
+    Return true if value is None or nan
+    """
+    return x is None or is_nan(x)
+
+
 if not WIN:
     long_path_open = open
     long_path_rmtree = shutil.rmtree

--- a/test/test_results.py
+++ b/test/test_results.py
@@ -59,3 +59,90 @@ def test_get_result_hash_from_prefix(tmpdir):
         results.get_result_hash_from_prefix(str(results_dir), 'machine', 'e')
 
     assert 'one of multiple commits' in str(excinfo.value)
+
+
+def test_minimum_of_results():
+    nan = float('nan')
+
+    param_res_1 = dict(params=[[1, 2], [3, 4]],
+                       result=[1, 1, 1, 1])
+    param_res_2 = dict(params=[[1, 2], [3, 4]],
+                       result=[2, 2, 2, 2])
+    param_res_2_incomp = dict(params=[[1, 2, 3], [3, 4, 5]],
+                              result=[2, 2, 9,
+                                      2, 2, 9,
+                                      9, 9, 9,
+                                      9, 9, 9])
+    param_res_1_incomp = dict(params=[[1, 2, 3], [3, 4, 5]],
+                              result=[1, 1, 9,
+                                      1, 1, 9,
+                                      9, 9, 9,
+                                      9, 9, 9])
+    param_res_incomp = dict(params=[['a', 'b', 'c']], result=[1, 1, 1])
+    param_res_1_nan = dict(params=[[1, 2], [3, 4]],
+                           result=[1, nan, 1, nan])
+    param_res_1_none = dict(params=[[1, 2], [3, 4]],
+                            result=[1, None, None, 1])
+    param_res_malform1 = dict(paramx=param_res_1['params'], result=param_res_1['result'])
+    param_res_malform2 = dict(params=param_res_1['params'], resultx=param_res_1['result'])
+
+    datasets = [
+        # no result
+        (None, None, None),
+        (None, nan, None),
+        (nan, None, nan),
+        (nan, nan, nan),
+        (None, 1, None),
+        (None, 1.0, None),
+        (nan, 1, nan),
+        (nan, 1.0, nan),
+        (nan, 1, nan),
+        (None, param_res_1, None),
+        (nan, param_res_1, nan),
+        (param_res_1, None, param_res_1),
+        (param_res_1, nan, param_res_1),
+        # float/int
+        (1, 2, 1),
+        (1.0, 2, 1.0),
+        (1, 2.0, 1),
+        (1.0, 2.0, 1.0),
+        (2, 1, 1),
+        (2, 1.0, 1.0),
+        (2.0, 1, 1),
+        (2.0, 1.0, 1.0),
+        # parameterized results, malformed
+        (param_res_1, 3, param_res_1),
+        (3, param_res_1, 3),
+        (param_res_malform1, param_res_2, param_res_malform1),
+        (param_res_malform2, param_res_2, param_res_malform2),
+        (param_res_2, param_res_malform1, param_res_2),
+        (param_res_2, param_res_malform2, param_res_2),
+        (3, param_res_1, 3),
+        # parameterized results
+        (param_res_1, param_res_2, param_res_1),
+        (param_res_2, param_res_1, param_res_1),
+        (param_res_1, param_res_2_incomp, param_res_1),
+        (param_res_2, param_res_1_incomp, param_res_1),
+        (param_res_2, param_res_incomp, param_res_2),
+        (param_res_2, param_res_1_none, dict(params=param_res_2['params'],
+                                             result=[1, 2, 2, 1])),
+        (param_res_2, param_res_1_nan, dict(params=param_res_2['params'],
+                                            result=[1, 2, 1, 2])),
+        (param_res_1_none, param_res_1, dict(params=param_res_1['params'],
+                                             result=[1, None, None, 1])),
+        (param_res_1_nan, param_res_1, dict(params=param_res_1['params'],
+                                            result=[1, nan, 1, nan])),
+        (param_res_1_nan, param_res_1_none, param_res_1_nan),
+        (param_res_1_none, param_res_1_nan, param_res_1_none),
+    ]
+
+    for a, b, c in datasets:
+        d = results.minimum_of_results(a, b)
+
+        if isinstance(d, dict) and d.get('params') and d.get('result'):
+            assert d['params'] == c['params'], (a, b, c, d)
+            assert len(d['result']) == len(c['result']), (a, b, c, d)
+            assert all(x == y or (util.is_nan(x) and util.is_nan(y))
+                       for x, y in zip(c['result'], d['result'])), (a, b, c, d)
+        else:
+            assert d == c or (util.is_nan(d) and util.is_nan(c)), (a, b, c, d)


### PR DESCRIPTION
Add option to `asv run` for taking minimum of new and old results, rather than just replacing old with new. May be useful for reducing scatter in some cases.

(Requested by @juliantaylor)