### PR TITLE
CI: try to get rid of conda timeouts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -49,6 +49,11 @@ install:
       wget http://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh;
       chmod +x miniconda.sh;
       ./miniconda.sh -b;
+      mv $HOME/miniconda/bin/conda $HOME/miniconda/bin/conda.real;
+      echo -e '#!/bin/bash\n' > $HOME/miniconda/bin/conda;
+      declare -f travis_retry >> $HOME/miniconda/bin/conda;
+      echo -e '\ntravis_retry "$HOME/miniconda/bin/conda.real" "$@"' >> $HOME/miniconda/bin/conda;
+      chmod +x $HOME/miniconda/bin/conda;
       export PATH=$HOME/miniconda/bin:$PATH;
       conda update --yes conda;
       if $TRAVIS_PYTHON -c 'import virtualenv'; then echo "ERROR: virtualenv package is installed"; exit 1; fi;


### PR DESCRIPTION
Try to get rid of conda timeouts by replacing the conda command with one that always uses `travis_retry` instead.