### PR TITLE
CI: replace conda with retry script only after updating (which may overwrite)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -49,13 +49,13 @@ install:
       wget http://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh;
       chmod +x miniconda.sh;
       ./miniconda.sh -b;
+      export PATH=$HOME/miniconda/bin:$PATH;
+      conda update --yes conda;
       mv $HOME/miniconda/bin/conda $HOME/miniconda/bin/conda.real;
       echo -e '#!/bin/bash\n' > $HOME/miniconda/bin/conda;
       declare -f travis_retry >> $HOME/miniconda/bin/conda;
       echo -e '\ntravis_retry "$HOME/miniconda/bin/conda.real" "$@"' >> $HOME/miniconda/bin/conda;
       chmod +x $HOME/miniconda/bin/conda;
-      export PATH=$HOME/miniconda/bin:$PATH;
-      conda update --yes conda;
       if $TRAVIS_PYTHON -c 'import virtualenv'; then echo "ERROR: virtualenv package is installed"; exit 1; fi;
     else
       $TRAVIS_PIP install virtualenv;


### PR DESCRIPTION
Take 2 in using travis_retry for all conda commands on Travis-CI.