### PR TITLE
Refactor asv continuous to use asv compare table printing

### DIFF
--- a/asv/commands/continuous.py
+++ b/asv/commands/continuous.py
@@ -5,17 +5,15 @@ from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
 import os
-
 import six
 
 from . import Command
 from .run import Run
-from .compare import unroll_result
+from .compare import Compare
 
-from ..console import truncate_left, color_print
 from ..repo import get_repo
+from ..console import color_print
 from .. import results
-from .. import util
 
 from . import common_args
 
@@ -75,73 +73,27 @@ class Continuous(Command):
         if result:
             return result
 
-        tabulated = []
-        all_benchmarks = {}
-        for commit_hash in commit_hashes:
-            subtab = {}
-            totals = {}
-
+        def results_iter(commit_hash):
             for env in run_objs['environments']:
                 filename = results.get_filename(
                     run_objs['machine_params']['machine'], commit_hash, env.name)
                 filename = os.path.join(conf.results_dir, filename)
                 result = results.Results.load(filename)
+                for name, benchmark in six.iteritems(run_objs['benchmarks']):
+                    yield name, result.results.get(name, float("nan"))
 
-                for benchmark_name, benchmark in six.iteritems(run_objs['benchmarks']):
-                    for name, value in unroll_result(benchmark_name,
-                                                     result.results.get(benchmark_name, None)):
-                        if value is not None:
-                            all_benchmarks[name] = benchmark
-                            subtab.setdefault(name, 0.0)
-                            totals.setdefault(name, 0)
-                            subtab[name] += value
-                            totals[name] += 1
+        status = Compare.print_table(conf, parent, head,
+                                     resultset_1=results_iter(parent),
+                                     resultset_2=results_iter(head),
+                                     factor=factor, split=False, only_changed=True,
+                                     sort_by_ratio=True)
+        worsened, improved = status
 
-            for name in totals.keys():
-                subtab[name] /= totals[name]
-
-            tabulated.append(subtab)
-
-        after, before = tabulated
-
-        table = []
-        slowed_down = False
-        for name, benchmark in six.iteritems(all_benchmarks):
-            if before[name] == 0:
-                if after[name] == 0:
-                    change = 1.0
-                else:
-                    change = float('inf')
-            else:
-                change = after[name] / before[name]
-
-            if change > factor or change < 1.0 / factor:
-                table.append(
-                    (change, before[name], after[name], name, benchmark))
-            if change > factor:
-                slowed_down = True
-
-        print("")
-
-        if not len(table):
+        if worsened:
+            color_print("SOME BENCHMARKS HAVE CHANGED SIGNIFICANTLY.\n", 'red')
+        elif improved:
+            color_print("SOME BENCHMARKS HAVE CHANGED SIGNIFICANTLY.\n", 'green')
+        else:
             color_print("BENCHMARKS NOT SIGNIFICANTLY CHANGED.\n", 'green')
-            return 0
 
-        table.sort(reverse=True)
-
-        color_print(
-            "{0:40s}   {1:>8}   {2:>8}   {3:>8}\n".format("BENCHMARK", "BEFORE", "AFTER", "FACTOR"),
-            'blue')
-        for change, before, after, name, benchmark in table:
-            before_display = util.human_value(before, benchmark['unit'])
-            after_display = util.human_value(after, benchmark['unit'])
-
-            print("{0:40s}   {1:>8}   {2:>8}   {3:.8f}x".format(
-                truncate_left(name, 40),
-                before_display, after_display, change))
-
-        print("")
-        color_print(
-            "SOME BENCHMARKS HAVE CHANGED SIGNIFICANTLY.\n", 'red')
-
-        return slowed_down
+        return worsened

--- a/test/example_results/cheetah/fcf8c079-py2.7-Cython-numpy1.8.json
+++ b/test/example_results/cheetah/fcf8c079-py2.7-Cython-numpy1.8.json
@@ -29,7 +29,7 @@
         "time_units.time_simple_unit_parse": 0.003806138038635254, 
         "time_units.time_unit_compose": 0.0015271089076995849, 
         "time_units.time_unit_parse": 0.011466357707977295, 
-        "time_units.time_unit_to": 4.8321509361267087e-05, 
+        "time_units.time_unit_to": 1.8321509361267087e-05, 
         "time_units.time_very_simple_unit_parse": 1.3104991912841798e-05,
 	"time_other.time_parameterized": {
 	    "params": [["1", "2", "3"]],

--- a/test/test_compare.py
+++ b/test/test_compare.py
@@ -25,6 +25,7 @@ All benchmarks:
 
     before     after       ratio
   [22b920c6] [fcf8c079]
+!       n/a     failed       n/a  params_examples.ParamSuite.track_value
      failed     failed       n/a  time_AAA_failure
         n/a        n/a       n/a  time_AAA_skip
 !  454.03μs     failed       n/a  time_coordinates.time_latitude
@@ -40,10 +41,9 @@ All benchmarks:
 +  125.11μs     3.81ms     30.42  time_units.time_simple_unit_parse
      1.64ms     1.53ms      0.93  time_units.time_unit_compose
 +  372.11μs    11.47ms     30.81  time_units.time_unit_parse
-    69.09μs    48.32μs      0.70  time_units.time_unit_to
+-   69.09μs    18.32μs      0.27  time_units.time_unit_to
     11.87μs    13.10μs      1.10  time_units.time_very_simple_unit_parse
 """
-
 
 def test_compare(capsys, tmpdir):
     tmpdir = six.text_type(tmpdir)

--- a/test/test_compare.py
+++ b/test/test_compare.py
@@ -45,6 +45,20 @@ All benchmarks:
     11.87μs    13.10μs      1.10  time_units.time_very_simple_unit_parse
 """
 
+REFERENCE_ONLY_CHANGED = """
+    before     after       ratio
+  [22b920c6] [fcf8c079]
+!       n/a     failed       n/a  params_examples.ParamSuite.track_value
+!  454.03μs     failed       n/a  time_coordinates.time_latitude
+!     3.00s     failed       n/a  time_other.time_parameterized(3)
++  933.71μs   108.22ms    115.90  time_quantity.time_quantity_init_array
++    1.75ms   152.84ms     87.28  time_quantity.time_quantity_array_conversion
++  372.11μs    11.47ms     30.81  time_units.time_unit_parse
++  125.11μs     3.81ms     30.42  time_units.time_simple_unit_parse
++    1.31ms     7.75ms      5.91  time_quantity.time_quantity_ufunc_sin
+-   69.09μs    18.32μs      0.27  time_units.time_unit_to
+"""
+
 def test_compare(capsys, tmpdir):
     tmpdir = six.text_type(tmpdir)
     os.chdir(tmpdir)
@@ -60,3 +74,12 @@ def test_compare(capsys, tmpdir):
 
     text, err = capsys.readouterr()
     assert text.strip() == REFERENCE.strip()
+
+    # Check print_table output as called from Continuous
+    status = Compare.print_table(conf, '22b920c6', 'fcf8c079', factor=2, machine='cheetah',
+                                 split=False, only_changed=True, sort_by_ratio=True)
+    worsened, improved = status
+    assert worsened
+    assert improved
+    text, err = capsys.readouterr()
+    assert text.strip() == REFERENCE_ONLY_CHANGED.strip()

--- a/test/test_workflow.py
+++ b/test/test_workflow.py
@@ -141,7 +141,7 @@ def test_continuous(capfd, basic_conf):
 
     text, err = capfd.readouterr()
     assert "SOME BENCHMARKS HAVE CHANGED SIGNIFICANTLY" in text
-    assert "params_examples.track_find_test(2)              1.0        6.0   6.00000000x" in text
+    assert "+     1.00s      6.00s      6.00  params_examples.track_find_test(2)" in text
     assert "params_examples.ClassOne" in text
 
 


### PR DESCRIPTION
The table printing code in `asv continuous` has some bugs when printing failed benchmarks.
While it's possible to fix these, it seemed better to refactor it to use the same table printing code as `asv compare`.
The format of the printed table changes a bit though (for the better IMHO).

In the first commit, also improve asv compare table printing and catch one zero division error.