### PR TITLE
No mirror for local repos

### DIFF
--- a/asv/plugins/git.py
+++ b/asv/plugins/git.py
@@ -19,20 +19,26 @@ from .. import util
 class Git(Repo):
     dvcs = "git"
 
-    def __init__(self, url, path, _checkout_copy=False):
+    def __init__(self, url, mirror_path):
         self._git = util.which("git")
-        self._path = os.path.abspath(path)
+        self._path = os.path.abspath(mirror_path)
         self._pulled = False
 
-        if not os.path.isdir(self._path):
-            args = ['clone']
-            if _checkout_copy:
-                args.append('--shared')
-            else:
-                log.info("Cloning project")
-                args.append('--mirror')
-            args.extend([url, self._path])
-            self._run_git(args, chdir=False)
+        if self.is_local_repo(url):
+            # Local repository, no need for mirror
+            self._path = os.path.abspath(url)
+            self._pulled = True
+        elif not os.path.isdir(self._path):
+            # Clone is missing
+            log.info("Cloning project")
+            self._run_git(['clone', '--mirror', url, self._path],
+                           cwd=None)
+
+    @classmethod
+    def is_local_repo(cls, path):
+        return os.path.isdir(path) and (
+            os.path.isdir(os.path.join(path, '.git')) or
+            os.path.isdir(os.path.join(path, 'objects')))
 
     @classmethod
     def url_match(cls, url):
@@ -45,19 +51,16 @@ class Git(Repo):
                 return True
 
         # Check for a local path
-        if os.path.isdir(url) and os.path.isdir(os.path.join(url, '.git')):
+        if cls.is_local_repo(url):
             return True
 
         return False
 
-    def _run_git(self, args, chdir=True, **kwargs):
-        if chdir:
+    def _run_git(self, args, cwd=True, **kwargs):
+        if cwd is True:
             cwd = self._path
-        else:
-            cwd = None
         kwargs['cwd'] = cwd
-        return util.check_output(
-            [self._git] + args, **kwargs)
+        return util.check_output([self._git] + args, **kwargs)
 
     def get_new_range_spec(self, latest_result, branch=None):
         if branch is None:
@@ -77,7 +80,7 @@ class Git(Repo):
     def pull(self):
         # We assume the remote isn't updated during the run of asv
         # itself.
-        if self._pulled is True:
+        if self._pulled:
             return
 
         log.info("Fetching recent changes")
@@ -85,12 +88,12 @@ class Git(Repo):
         self._pulled = True
 
     def checkout(self, path, commit_hash):
-        subrepo = Git(self._path, path, _checkout_copy=True)
-        subrepo._run_git(['checkout', '-f', commit_hash])
-        subrepo.clean()
+        if not os.path.isdir(path):
+            self._run_git(['clone', '--shared', self._path, path],
+                          cwd=None)
 
-    def clean(self):
-        self._run_git(['clean', '-fxd'])
+        self._run_git(['checkout', '-f', commit_hash], cwd=path)
+        self._run_git(['clean', '-fdx'], cwd=path)
 
     def get_date(self, hash):
         # TODO: This works on Linux, but should be extended for other platforms

--- a/asv/repo.py
+++ b/asv/repo.py
@@ -11,8 +11,10 @@ from . import util
 class Repo(object):
     """
     Base class for repository handlers.
+
+    There are no commands that modify the source repository.
     """
-    def __init__(self, url, path):
+    def __init__(self, url, mirror_path):
         """
         Create a mirror of the repository at `url`, without a working tree.
 
@@ -21,8 +23,11 @@ class Repo(object):
         url : str
             The URL to the repository to clone
 
-        path : str
-            The local path to clone into
+        mirror_path : str
+            The local path into which to put a mirror of the repository.
+            Creating the local mirror is optional, and may be skipped if
+            the performance is adequate also without it.
+
         """
         raise NotImplementedError()
 
@@ -141,9 +146,6 @@ class NoRepository(Repo):
 
     def checkout(self, path, commit_hash):
         self._check_branch(commit_hash)
-
-    def clean(self):
-        return
 
     def get_date(self, hash):
         self._raise_error()

--- a/test/test_repo.py
+++ b/test/test_repo.py
@@ -34,6 +34,13 @@ def _test_generic_repo(conf, tmpdir, hash_range, master, branch):
     r.checkout(workcopy_dir, branch)
     r.checkout(workcopy_dir, master)
 
+    # check recovering from corruption
+    for pth in ['.hg', '.git']:
+        pth = os.path.join(workcopy_dir, pth)
+        if os.path.isdir(pth):
+            shutil.rmtree(pth)
+    r.checkout(workcopy_dir, master)
+
     hashes = r.get_hashes_from_range(hash_range)
     assert len(hashes) == 4
 


### PR DESCRIPTION
Local repositories don't really need a mirror repository, as the performance will be OK anyway.
In addition, this allows referring to HEAD, which is useful for "repo": "." configs.

In order to preserve backward compat, make checking out working trees more robust, by trying to re-create the work tree repo if it appears to be malfunctioning.