### PR TITLE
Use threaded HTTP server in asv preview

### DIFF
--- a/asv/commands/preview.py
+++ b/asv/commands/preview.py
@@ -96,5 +96,8 @@ class Preview(Command):
             import webbrowser
             webbrowser.open(base_url)
 
-        log.info("Press ^C to abort")
-        httpd.serve_forever()
+        log.info("Press ^C to abort\n")
+        try:
+            httpd.serve_forever()
+        except KeyboardInterrupt:
+            return

--- a/asv/commands/preview.py
+++ b/asv/commands/preview.py
@@ -35,8 +35,9 @@ def random_ports(port, n):
 
 def create_httpd(handler_cls, port=0):
     # Create a server that allows address reuse
-    class MyTCPServer(socketserver.TCPServer):
+    class MyTCPServer(socketserver.ThreadingTCPServer):
         allow_reuse_address = True
+        daemon_threads = True
 
     for port in random_ports(port, 5):
         try:

--- a/test/tools.py
+++ b/test/tools.py
@@ -350,6 +350,6 @@ def get_with_retry(browser, url):
         try:
             return browser.get(url)
         except TimeoutException:
-            pass
-    else:
-        raise TimeoutException
+            time.sleep(2)
+
+    return browser.get(url)


### PR DESCRIPTION
Switch `asv preview` to use a threaded HTTP server.

This also switches the tests to use the threaded server. This may possibly help with the timeouts on Travis-CI, since the threaded server does not get "stuck" if one request fails to complete.