### PR TITLE
Run benchmark setup on every repeat, similarly as timeit does

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,10 @@ New Features
 
 API Changes
 ^^^^^^^^^^^
+Previously, the ``setup`` and ``teardown`` methods were run only once
+even when the benchmark had ``repeat > 1`` specified. This is now
+changed so that they are run on every repeat, and additionally before
+and after profiling runs.
 
 - Mirrors are no longer created for local repositories. (#314)
 - The parent directory of the benchmark suite is no longer inserted

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,10 +11,6 @@ New Features
 
 API Changes
 ^^^^^^^^^^^
-Previously, the ``setup`` and ``teardown`` methods were run only once
-even when the benchmark had ``repeat > 1`` specified. This is now
-changed so that they are run on every repeat, and additionally before
-and after profiling runs.
 
 - Mirrors are no longer created for local repositories. (#314)
 - The parent directory of the benchmark suite is no longer inserted
@@ -22,6 +18,10 @@ and after profiling runs.
 - In asv.conf.json matrix, ``null`` previously meant (undocumented)
   the latest version. Now it means that the package is to not be
   installed. (#329)
+- Previously, the ``setup`` and ``teardown`` methods were run only once
+  even when the benchmark method was run multiple times, for example due
+  to ``repeat > 1`` being present in timing benchmarks. This is now
+  changed so that also they are run multiple times. (#316)
 
 Bug Fixes
 ^^^^^^^^^

--- a/docs/source/writing_benchmarks.rst
+++ b/docs/source/writing_benchmarks.rst
@@ -285,6 +285,10 @@ possible, with as much extraneous setup moved to a ``setup`` function::
             for word in self.words:
                 word.upper()
 
+How ``setup`` and ``teardown`` behave for timing benchmarks
+is similar to the Python ``timeit`` module, and the behavior is controlled
+by the ``number`` and ``repeat`` attributes, as explained below.
+
 **Attributes**:
 
 - ``goal_time``: ``asv`` will automatically select the number of
@@ -294,6 +298,9 @@ possible, with as much extraneous setup moved to a ``setup`` function::
 
 - ``number``: Manually choose the number of iterations.  If ``number``
   is specified, ``goal_time`` is ignored.
+  Note that ``setup`` and ``teardown`` are not run between iterations:
+  ``setup`` runs first, then the timing routine is called ``number`` times,
+  and after that ``teardown`` runs.
 
 - ``repeat``: The number of times to repeat the benchmark, with each
   repetition running the benchmark ``number`` of times.  The minimum

--- a/docs/source/writing_benchmarks.rst
+++ b/docs/source/writing_benchmarks.rst
@@ -103,19 +103,23 @@ assigned specifically to each function.
 
 Similarly, benchmarks can also have a ``teardown`` function that is
 run after the benchmark.  This is useful if, for example, you need to
-clean up any changes made to the filesystem.  Generally, however, it
-is not required: each benchmark runs in its own process, so any
-tearing down of in-memory state happens automatically.
+clean up any changes made to the filesystem.
+
+Note that although different benchmarks run in separate processes, for
+a given benchmark repeated measurement (cf. ``repeat`` attribute) and
+profiling occur within the same process.  For these cases, the setup
+and teardown routines are run multiple times in the same process.
 
 If ``setup`` raises a ``NotImplementedError``, the benchmark is marked
 as skipped.
 
-Since each benchmark is run in its own process, the ``setup`` method
-is run for each benchmark that it is associated with.  If the
-``setup`` is especially expensive, the ``setup_cache`` method may be
-used instead, which only performs the setup calculation once and then
-caches the result to disk.  ``setup_cache`` can persist the data for
-the benchmarks it applies to in two ways:
+The ``setup`` method is run multiple times, for each benchmark and for
+each repeat.  If the ``setup`` is especially expensive, the
+``setup_cache`` method may be used instead, which only performs the
+setup calculation once and then caches the result to disk.  It is run
+only once also for repeated benchmarks and profiling, unlike
+``setup``.  ``setup_cache`` can persist the data for the benchmarks it
+applies to in two ways:
 
    - Returning a data structure, which ``asv`` pickles to disk, and
      then loads and passes it as the first argument to each benchmark.

--- a/docs/source/writing_benchmarks.rst
+++ b/docs/source/writing_benchmarks.rst
@@ -295,6 +295,7 @@ possible, with as much extraneous setup moved to a ``setup`` function::
   repetition running the benchmark ``number`` of times.  The minimum
   time from all of these repetitions is used as the final result.
   When not provided, defaults to ``timeit.default_repeat`` (3).
+  Setup and teardown are run on each repeat.
 
 - ``timer``: The timing function to use, which can be any source of
   monotonically increasing numbers, such as `time.clock`, `time.time`

--- a/test/benchmark/time_examples.py
+++ b/test/benchmark/time_examples.py
@@ -47,3 +47,25 @@ def time_with_timeout():
         pass
 
 time_with_timeout.timeout = 0.1
+
+
+class TimeWithRepeat(object):
+    # Check that setup is re-run on each repeat
+    called = None
+    number = 1
+    repeat = 10
+    count = 0
+
+    def setup(self):
+        assert self.called is None
+        self.called = False
+
+    def teardown(self):
+        assert self.called is True
+        self.called = None
+        print("<%d>" % (self.count,))
+
+    def time_it(self):
+        assert self.called is False
+        self.called = True
+        self.count += 1

--- a/test/test_benchmarks.py
+++ b/test/test_benchmarks.py
@@ -46,7 +46,7 @@ def test_find_benchmarks(tmpdir):
     assert len(b) == 3
 
     b = benchmarks.Benchmarks(conf, regex='example')
-    assert len(b) == 20
+    assert len(b) == 21
 
     b = benchmarks.Benchmarks(conf, regex='time_example_benchmark_1')
     assert len(b) == 2
@@ -56,7 +56,7 @@ def test_find_benchmarks(tmpdir):
     assert len(b) == 2
 
     b = benchmarks.Benchmarks(conf)
-    assert len(b) == 24
+    assert len(b) == 25
 
     envs = list(environment.get_environments(conf))
     b = benchmarks.Benchmarks(conf)
@@ -111,6 +111,11 @@ def test_find_benchmarks(tmpdir):
     with open(profile_path, 'wb') as fd:
         fd.write(times['time_secondary.track_value']['profile'])
     pstats.Stats(profile_path)
+
+    # Check for running setup on each repeat (one extra run from profile)
+    # The output would contain error messages if the asserts in the benchmark fail.
+    expected = ["<%d>" % j for j in range(1, 12)]
+    assert times['time_examples.TimeWithRepeat.time_it']['stderr'].split() == expected
 
 
 def test_invalid_benchmark_tree(tmpdir):


### PR DESCRIPTION
The benchmark setup should be run on every repeat, this is what users probably expect.