### PR TITLE
exclude/include rules in config

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,7 @@ New Features
 - Automatic detection and listing of performance regressions. (#236)
 - Support for Windows. (#282)
 - New ``setup_cache`` method. (#277)
+- Exclude/include rules in configuration matrix. (#329)
 
 API Changes
 ^^^^^^^^^^^
@@ -14,6 +15,9 @@ API Changes
 - Mirrors are no longer created for local repositories. (#314)
 - The parent directory of the benchmark suite is no longer inserted
   into ``sys.path``. (#307)
+- In asv.conf.json matrix, ``null`` previously meant (undocumented)
+  the latest version. Now it means that the package is to not be
+  installed. (#329)
 
 Bug Fixes
 ^^^^^^^^^

--- a/asv/config.py
+++ b/asv/config.py
@@ -25,6 +25,8 @@ class Config(object):
         self.branches = [None]
         self.pythons = ["{0[0]}.{0[1]}".format(sys.version_info)]
         self.matrix = {}
+        self.exclude = []
+        self.include = []
         self.env_dir = "env"
         self.benchmark_dir = "benchmarks"
         self.results_dir = "results"

--- a/asv/environment.py
+++ b/asv/environment.py
@@ -11,8 +11,10 @@ from __future__ import (absolute_import, division, print_function,
 
 import hashlib
 import os
+import re
 import shutil
 import sys
+import itertools
 import subprocess
 
 import six
@@ -26,31 +28,72 @@ from . import wheel_cache
 WIN = (os.name == "nt")
 
 
-def iter_configuration_matrix(matrix):
+def iter_requirement_matrix(conf):
     """
-    Iterate through all combinations of the given configuration
-    matrix.
+    Iterate through all combinations of the given requirement
+    matrix and python versions.
     """
-    if len(matrix) == 0:
-        yield dict()
-        return
 
-    # TODO: Deal with matrix exclusions
-    matrix = dict(matrix)
-    key = next(six.iterkeys(matrix))
-    entry = matrix[key]
-    del matrix[key]
+    if not conf.environment_type:
+        env_classes = get_environment_classes(conf)
 
-    for result in iter_configuration_matrix(matrix):
-        if len(entry):
-            for value in entry:
-                d = dict(result)
-                d[key] = value
-                yield d
+    platform_keys = {
+        'environment_type': conf.environment_type,
+        'sys_platform': sys.platform
+    }
+
+    # Parse input
+    keys = ['python'] + sorted(conf.matrix.keys())
+    values = [conf.pythons] + [conf.matrix[key] for key in keys[1:]]
+    values = [value if isinstance(value, list) else [value]
+              for value in values]
+    values = [[''] if value == [] else value
+              for value in values]
+
+    # Cartesian product of everything
+    all_combinations = itertools.product(*values)
+
+    # Process excludes
+    for combination in all_combinations:
+        target = dict(zip(keys, combination))
+        target.update(platform_keys)
+
+        if not conf.environment_type:
+            target['environment_type'] = env_classes[target['python']]
+
+        for rule in conf.exclude:
+            # check if all fields in the rule match
+            for key, value in rule.items():
+                if value is None:
+                    if key in target and target[key] is not None:
+                        break
+                elif key not in target or target[key] is None:
+                    break
+                else:
+                    w = str(target[key])
+                    m = re.match(str(value), w)
+                    if m is None or m.end() != len(w):
+                        break
+            else:
+                # rule matched
+                break
         else:
-            d = dict(result)
-            d[key] = None
-            yield d
+            # not excluded
+            yield dict(item for item in zip(keys, combination)
+                       if item[1] is not None)
+
+    # Process includes
+    for include in conf.include:
+        if 'python' not in include:
+            raise util.UserError("include rule '{0}' does not specify Python version".format(include))
+
+        include = dict(include)
+
+        for key in list(include.keys()):
+            if include[key] is None:
+                include.pop(key)
+
+        yield include
 
 
 def get_env_name(python, requirements):
@@ -61,7 +104,7 @@ def get_env_name(python, requirements):
     reqs = list(six.iteritems(requirements))
     reqs.sort()
     for key, val in reqs:
-        if val is not None:
+        if val:
             name.append(''.join([key, val]))
         else:
             name.append(key)
@@ -79,9 +122,36 @@ def get_environments(conf):
     conf : dict
         asv configuration object
     """
+
+    for requirements in iter_requirement_matrix(conf):
+        python = requirements.pop('python')
+
+        if 'environment_type' in requirements:
+            cls = get_environment_class_by_name(requirements.pop('environment_type'))
+        else:
+            cls = get_environment_class(conf, python)
+
+        try:
+            yield cls(conf, python, requirements)
+        except EnvironmentUnavailable as err:
+            log.warn(str(err))
+
+
+def get_environment_classes(conf):
+    """
+    Get a matching environment type for each Python version required.
+    """
+    env_classes = {}
+
     for python in conf.pythons:
-        for env in get_environments_for_python(conf, python):
-            yield env
+        env_classes[python] = get_environment_class(conf, python)
+
+    for include in conf.include:
+        python = include.get('python')
+        if python is not None:
+            env_classes[python] = get_environment_class(conf, python)
+
+    return env_classes
 
 
 def get_environment_class(conf, python):
@@ -109,11 +179,7 @@ def get_environment_class(conf, python):
         conf.environment_type = 'existing'
 
     if conf.environment_type:
-        for cls in util.iter_subclasses(Environment):
-            if cls.tool_name == conf.environment_type:
-                return cls
-        raise ValueError(
-            "Unknown environment type '{0}'".format(conf.environment_type))
+        return get_environment_class_by_name(conf.environment_type)
     else:
         log.warn(
             "No `environment_type` specified in asv.conf.json. "
@@ -126,34 +192,18 @@ def get_environment_class(conf, python):
             "No way to create environment for '{0}'".format(python))
 
 
-def get_environments_for_python(conf, python):
+def get_environment_class_by_name(environment_type):
     """
-    Get an iterator of Environment subclasses for the given python
-    specifier and all combinations in the configuration matrix.
-
-    Parameters
-    ----------
-    conf : dict
-        asv configuration object
-
-    python : str
-        Python version specifier.  Acceptable values depend on the
-        Environment plugins installed but generally are:
-
-        - 'X.Y': A Python version, in which case conda or virtualenv
-          will be used to create a new environment.
-
-        - 'python' or '/usr/bin/python': Search for the given
-          executable on the search PATH, and use that.  It is assumed
-          that all dependencies and the benchmarked project itself are
-          already installed.
+    Find the environment class with the given name.
     """
-    cls = get_environment_class(conf, python)
-    for env in cls.get_environments(conf, python):
-        yield env
+    for cls in util.iter_subclasses(Environment):
+        if cls.tool_name == environment_type:
+            return cls
+    raise ValueError(
+        "Unknown environment type '{0}'".format(environment_type))
 
 
-class PythonMissingError(BaseException):
+class EnvironmentUnavailable(BaseException):
     pass
 
 
@@ -162,27 +212,13 @@ class Environment(object):
     Manage a single environment -- a combination of a particular
     version of Python and a set of dependencies for the benchmarked
     project.
-
-    Environments are created in the
     """
     tool_name = None
 
-    def __init__(self, conf):
-        self._env_dir = conf.env_dir
-        self._path = os.path.abspath(os.path.join(
-            self._env_dir, self.hashname))
-
-        self._is_setup = False
-
-        self._repo = get_repo(conf)
-        self._cache = wheel_cache.WheelCache(conf, self._path)
-        self._build_root = os.path.abspath(os.path.join(self._path, 'project'))
-
-    @classmethod
-    def get_environments(cls, conf, python):
+    def __init__(self, conf, python, requirements):
         """
-        Get all of the environments for the configuration matrix for
-        the given Python version specifier.
+        Get an environment for a given requirement matrix and
+        Python version specifier.
 
         Parameters
         ----------
@@ -193,8 +229,25 @@ class Environment(object):
             A Python version specifier.  This is the same as passed to
             the `matches` method, and its exact meaning depends on the
             environment.
+
+        requirements : dict (str -> str)
+            Mapping from package names to versions
+
+        Raises
+        ------
+        EnvironmentUnavailable
+            The environment for the given combination is not available.
+
         """
-        raise NotImplementedError()
+        self._env_dir = conf.env_dir
+        self._path = os.path.abspath(os.path.join(
+            self._env_dir, self.hashname))
+
+        self._is_setup = False
+
+        self._repo = get_repo(conf)
+        self._cache = wheel_cache.WheelCache(conf, self._path)
+        self._build_root = os.path.abspath(os.path.join(self._path, 'project'))
 
     @classmethod
     def matches(self, python):
@@ -413,24 +466,24 @@ class Environment(object):
 class ExistingEnvironment(Environment):
     tool_name = "existing"
 
-    def __init__(self, conf, executable):
+    def __init__(self, conf, executable, requirements):
+        if executable == 'same':
+            executable = sys.executable
+
         self._executable = executable
-        self._python = util.check_output(
-            [executable,
-             '-c',
-             'import sys; '
-             'print(str(sys.version_info[0]) + "." + str(sys.version_info[1]))'
-         ]).strip()
+        try:
+            self._python = util.check_output(
+                [executable,
+                 '-c',
+                 'import sys; '
+                 'print(str(sys.version_info[0]) + "." + str(sys.version_info[1]))'
+                 ]).strip()
+        except (util.ProcessError, OSError):
+            raise EnvironmentUnavailable()
+
         self._requirements = {}
 
-        super(ExistingEnvironment, self).__init__(conf)
-
-    @classmethod
-    def get_environments(cls, conf, python):
-        if python == 'same':
-            python = sys.executable
-
-        yield cls(conf, util.which(python))
+        super(ExistingEnvironment, self).__init__(conf, executable, requirements)
 
     @classmethod
     def matches(cls, python):

--- a/asv/graph.py
+++ b/asv/graph.py
@@ -63,10 +63,10 @@ class Graph(object):
         l = list(six.iteritems(self.params))
         l.sort()
         for key, val in l:
-            if val is None:
-                parts.append(key)
-            else:
+            if val:
                 parts.append('{0}-{1}'.format(key, val))
+            else:
+                parts.append(key)
         parts.append(benchmark_name)
 
         self.path = os.path.join(*parts)

--- a/asv/plugins/conda.py
+++ b/asv/plugins/conda.py
@@ -42,7 +42,7 @@ class Conda(environment.Environment):
         """
         self._python = python
         self._requirements = requirements
-        super(Conda, self).__init__(conf)
+        super(Conda, self).__init__(conf, python, requirements)
 
     @classmethod
     def matches(self, python):
@@ -69,11 +69,6 @@ class Conda(environment.Environment):
                 return False
             else:
                 return True
-
-    @classmethod
-    def get_environments(cls, conf, python):
-        for configuration in environment.iter_configuration_matrix(conf.matrix):
-            yield cls(conf, python, configuration)
 
     def _setup(self):
         try:
@@ -104,7 +99,7 @@ class Conda(environment.Environment):
             # otherwise. It's also quicker than doing it one by one.
             args = ['install', '-p', self._path, '--yes']
             for key, val in six.iteritems(self._requirements):
-                if val is not None:
+                if val:
                     args.append("{0}={1}".format(key, val))
                 else:
                     args.append(key)

--- a/asv/template/asv.conf.json
+++ b/asv/template/asv.conf.json
@@ -76,7 +76,10 @@
     // ],
     //
     // "include": [
-    //     {"python": "2.7", "numpy": "1.8"}, // additional env for python2.7
+    //     // additional env for python2.7
+    //     {"python": "2.7", "numpy": "1.8"},
+    //     // additional env if run on windows+conda
+    //     {"platform": "win32", "environment_type": "conda", "libpython": ""},
     // ],
 
     // The directory (relative to the current directory) that benchmarks are

--- a/asv/template/asv.conf.json
+++ b/asv/template/asv.conf.json
@@ -40,11 +40,44 @@
 
     // The matrix of dependencies to test.  Each key is the name of a
     // package (in PyPI) and the values are version numbers.  An empty
-    // list indicates to just test against the default (latest)
-    // version.
+    // list or empty string indicates to just test against the default
+    // (latest) version. null indicates that the package is to not be
+    // installed.
+    //
     // "matrix": {
-    //     "numpy": ["1.6", "1.7"]
+    //     "numpy": ["1.6", "1.7"],
+    //     "six": ["", null],        // test with and without six installed
     // },
+
+    // Combinations of libraries/python versions can be excluded/included
+    // from the set to test. Each entry is a dictionary containing additional
+    // key-value pairs to include/exclude.
+    //
+    // An exclude entry excludes entries where all values match. The
+    // values are regexps that should match the whole string.
+    //
+    // An include entry adds an environment. Only the packages listed
+    // are installed. The 'python' key is required. The exclude rules
+    // do not apply to includes.
+    //
+    // In addition to package names, the following keys are available:
+    //
+    // - python
+    //     Python version, as in the *pythons* variable above.
+    // - environment_type
+    //     Environment type, as above.
+    // - sys_platform
+    //     Platform, as in sys.platform. Possible values for the common
+    //     cases: 'linux2', 'win32', 'cygwin', 'darwin'.
+    //
+    // "exclude": [
+    //     {"python": "3.2", "sys_platform": "win32"}, // skip py3.2 on windows
+    //     {"environment_type": "conda", "six": null}, // don't run without six on conda
+    // ],
+    //
+    // "include": [
+    //     {"python": "2.7", "numpy": "1.8"}, // additional env for python2.7
+    // ],
 
     // The directory (relative to the current directory) that benchmarks are
     // stored in.  If not provided, defaults to "benchmarks"
@@ -53,7 +86,6 @@
     // The directory (relative to the current directory) to cache the Python
     // environments in.  If not provided, defaults to "env"
     // "env_dir": "env",
-
 
     // The directory (relative to the current directory) that raw benchmark
     // results are stored in.  If not provided, defaults to "results".

--- a/docs/source/asv.conf.json.rst
+++ b/docs/source/asv.conf.json.rst
@@ -182,16 +182,23 @@ If specified, must be a list of dictionaries, indicating
 the versions of packages to be installed. The dictionary must also
 include a ``python`` key specifying the Python version.
 
+In addition, the following keys can be present: ``sys_platform``,
+``environment_type``.  If present, the include rule is active only if
+the values match, using same matching rules as explained for
+``exclude`` above.
+
 The exclude rules are not applied to includes.
 
 For example::
 
     "include": [
-        {'python': '2.7', 'numpy': '1.8.2'}
+        {'python': '2.7', 'numpy': '1.8.2'},
+        {'platform': 'win32', 'environment_type': 'conda', 'libpython': ''}
     ]
 
-This corresponds to one additional environment running on Python 2.7
-and including the specified version of Numpy.
+This corresponds to two additional environments. One runs on Python 2.7
+and including the specified version of Numpy. The second is active only
+for Conda on Windows, and installs the latest version of ``libpython``.
 
 ``benchmark_dir``
 -----------------

--- a/test/test_environment.py
+++ b/test/test_environment.py
@@ -183,13 +183,19 @@ def test_matrix_expand_include():
     conf.pythons = ["2.6"]
     conf.matrix = {'a': '1'}
     conf.include = [
-        {'python': '3.4', 'b': '2'}
+        {'python': '3.4', 'b': '2'},
+        {'sys_platform': sys.platform, 'python': '2.7', 'b': '3'},
+        {'sys_platform': sys.platform + 'nope', 'python': '2.7', 'b': '3'},
+        {'environment_type': 'nope', 'python': '2.7', 'b': '4'},
+        {'environment_type': 'something', 'python': '2.7', 'b': '5'},
     ]
 
     combinations = _sorted_dict_list(environment.iter_requirement_matrix(conf))
     expected = _sorted_dict_list([
         {'python': '2.6', 'a': '1'},
-        {'python': '3.4', 'b': '2'}
+        {'python': '3.4', 'b': '2'},
+        {'python': '2.7', 'b': '3'},
+        {'python': '2.7', 'b': '5'}
     ])
     assert combinations == expected
 

--- a/test/test_environment.py
+++ b/test/test_environment.py
@@ -61,8 +61,9 @@ def test_matrix_environments(tmpdir):
         env.create()
 
         output = env.run(
-            ['-c', 'import six, sys; sys.stdout.write(six.__version__)'])
-        if env._requirements['six'] is not None:
+            ['-c', 'import six, sys; sys.stdout.write(six.__version__)'],
+            valid_return_codes=None)
+        if 'six' in env._requirements:
             assert output.startswith(six.text_type(env._requirements['six']))
 
         output = env.run(
@@ -148,3 +149,122 @@ def test_presence_checks(tmpdir):
         env.create()
         assert os.path.isfile(pip_fn)
         env.run(['-c', 'import os'])
+
+
+def _sorted_dict_list(lst):
+    return list(sorted(lst, key=lambda x: list(sorted(x.items()))))
+
+
+def test_matrix_expand_basic():
+    conf = config.Config()
+    conf.environment_type = 'something'
+    conf.pythons = ["2.6", "2.7"]
+    conf.matrix = {
+        'pkg1': None,
+        'pkg2': '',
+        'pkg3': [''],
+        'pkg4': ['1.2', '3.4'],
+        'pkg5': []
+    }
+
+    combinations = _sorted_dict_list(environment.iter_requirement_matrix(conf))
+    expected = _sorted_dict_list([
+        {'python': '2.6', 'pkg2': '', 'pkg3': '', 'pkg4': '1.2', 'pkg5': ''},
+        {'python': '2.6', 'pkg2': '', 'pkg3': '', 'pkg4': '3.4', 'pkg5': ''},
+        {'python': '2.7', 'pkg2': '', 'pkg3': '', 'pkg4': '1.2', 'pkg5': ''},
+        {'python': '2.7', 'pkg2': '', 'pkg3': '', 'pkg4': '3.4', 'pkg5': ''},
+    ])
+    assert combinations == expected
+
+
+def test_matrix_expand_include():
+    conf = config.Config()
+    conf.environment_type = 'something'
+    conf.pythons = ["2.6"]
+    conf.matrix = {'a': '1'}
+    conf.include = [
+        {'python': '3.4', 'b': '2'}
+    ]
+
+    combinations = _sorted_dict_list(environment.iter_requirement_matrix(conf))
+    expected = _sorted_dict_list([
+        {'python': '2.6', 'a': '1'},
+        {'python': '3.4', 'b': '2'}
+    ])
+    assert combinations == expected
+
+    conf.include = [
+        {'b': '2'}
+    ]
+    with pytest.raises(util.UserError):
+        list(environment.iter_requirement_matrix(conf))
+
+
+def test_matrix_expand_exclude():
+    conf = config.Config()
+    conf.environment_type = 'something'
+    conf.pythons = ["2.6", "2.7"]
+    conf.matrix = {
+        'a': '1',
+        'b': ['1', None]
+    }
+    conf.include = [
+        {'python': '2.7', 'b': '2', 'c': None}
+    ]
+
+    # check basics
+    conf.exclude = [
+        {'python': '2.7', 'b': '2'},
+        {'python': '2.7', 'b': None},
+        {'python': '2.6', 'a': '1'},
+    ]
+    combinations = _sorted_dict_list(environment.iter_requirement_matrix(conf))
+    expected = _sorted_dict_list([
+        {'python': '2.7', 'a': '1', 'b': '1'},
+        {'python': '2.7', 'b': '2'}
+    ])
+    assert combinations == expected
+
+    # check regexp
+    conf.exclude = [
+        {'python': '.*', 'b': None},
+    ]
+    combinations = _sorted_dict_list(environment.iter_requirement_matrix(conf))
+    expected = _sorted_dict_list([
+        {'python': '2.6', 'a': '1', 'b': '1'},
+        {'python': '2.7', 'a': '1', 'b': '1'},
+        {'python': '2.7', 'b': '2'}
+    ])
+    assert combinations == expected
+
+    # check environment_type as key
+    conf.exclude = [
+        {'environment_type': 'some.*'},
+    ]
+    combinations = _sorted_dict_list(environment.iter_requirement_matrix(conf))
+    expected = [
+        {'python': '2.7', 'b': '2'}
+    ]
+    assert combinations == expected
+
+    # check sys_platform as key
+    conf.exclude = [
+        {'sys_platform': sys.platform},
+    ]
+    combinations = _sorted_dict_list(environment.iter_requirement_matrix(conf))
+    expected = [
+        {'python': '2.7', 'b': '2'}
+    ]
+    assert combinations == expected
+
+    # check inverted regex
+    conf.exclude = [
+        {'python': '(?!2.6).*'}
+    ]
+    combinations = _sorted_dict_list(environment.iter_requirement_matrix(conf))
+    expected = _sorted_dict_list([
+        {'python': '2.6', 'a': '1', 'b': '1'},
+        {'python': '2.6', 'a': '1'},
+        {'python': '2.7', 'b': '2'}
+    ])
+    assert combinations == expected

--- a/test/test_workflow.py
+++ b/test/test_workflow.py
@@ -64,7 +64,7 @@ def basic_conf(tmpdir):
         'dvcs': 'git',
         'project': 'asv',
         'matrix': {
-            "six": [None],
+            "six": [""],
             "colorama": ["0.3.1", "0.3.3"]
         }
     })


### PR DESCRIPTION
Exclude/include rules in configuration.

The present approach is sort of a ripoff from how Travis-CI does it.

Addresses gh-322

- [x] fix bugs
- [x] `environment_type` and `sys_platform` perhaps should be allowed in *include*, but act as filters, similarly as in *exclude*? This would allow easy specification of os/environment dependent rules.