### PR TITLE
Fail early if mirror directory is needed, but exists and is not a repository

### DIFF
--- a/asv/plugins/git.py
+++ b/asv/plugins/git.py
@@ -28,7 +28,10 @@ class Git(Repo):
             # Local repository, no need for mirror
             self._path = os.path.abspath(url)
             self._pulled = True
-        elif not os.path.isdir(self._path):
+        elif not self.is_local_repo(self._path):
+            if os.path.exists(self._path):
+                self._raise_bad_mirror_error(self._path)
+
             # Clone is missing
             log.info("Cloning project")
             self._run_git(['clone', '--mirror', url, self._path],

--- a/asv/plugins/mercurial.py
+++ b/asv/plugins/mercurial.py
@@ -38,7 +38,10 @@ class Hg(Repo):
             # Local repository, no need for mirror
             self._path = os.path.abspath(url)
             self._pulled = True
-        elif not os.path.exists(self._path):
+        elif not self.is_local_repo(self._path):
+            if os.path.exists(self._path):
+                self._raise_bad_mirror_error(self._path)
+
             # Clone is missing
             log.info("Cloning project")
             if url.startswith("hg+"):

--- a/asv/repo.py
+++ b/asv/repo.py
@@ -31,6 +31,18 @@ class Repo(object):
         """
         raise NotImplementedError()
 
+    def _raise_bad_mirror_error(self, path):
+        """
+        Internal routine for raising an error message if mirror directory already exists,
+        but appears incorrect.
+        """
+        raise util.UserError("Directory '{0}' already exists, but is not a mirror "
+                             "of the project repository. Please remove it and try again. "
+                             "If the benchmark suite is in the project repository, you can "
+                             "also adjust the configuration to use the current "
+                             "repository (e.g. \"repo\": \".\") instead of a remote URL "
+                             "as the source.".format(path))
+
     def checkout(self, path, commit_hash):
         """
         Check out a clean working tree from the current repository


### PR DESCRIPTION
Print a friendlier error message if the mirror directory already exists.

One very common case where this occurs is when user puts asv.conf.json on the project top level but uses a remote URL in *repo*. Python packages usually have a directory called *project* on the top level.