### PR TITLE
Fix documentation for the --python option

### DIFF
--- a/asv/commands/common_args.py
+++ b/asv/commands/common_args.py
@@ -66,21 +66,28 @@ def add_machine(parser):
 
 
 def add_python(parser, default=None):
+    if default == 'same':
+        help = """Specify a Python interpreter in which to run the
+        benchmarks.  By default, uses the same Python interpreter that
+        asv is using. """
+    else:
+        help = """Specify a Python interpreter in which to run the
+        benchmarks.  By default, uses the Python interpreters specified
+        in the configuration file. """
+
+    help += """It may be a string accepted by any of the environment
+        plugins. For example, the conda plugin accepts "2.7" to mean
+        create a new Conda environment with Python version 2.7.
+        In addition, there is a special value "same" which
+        will use the same Python interpreter that asv is using.  This
+        "same" interpreter must have the benchmarked project already
+        installed, including its dependencies.
+        """
+
     parser.add_argument(
         "--python", type=str,
         default=default,
-        help="""Specify a Python interpreter in which to run the
-        benchmarks.  By default, uses the same Python interpreter that
-        asv is using.  It may be an executable to be searched for on
-        the $PATH, an absolute path, or the special value "same" which
-        will use the same Python interpreter that asv is using.  This
-        "same" interpreter must have the benchmarked project already
-        installed, including its dependencies.  A specific revision
-        may not be provided when --python is provided.
-
-        It may also be any string accepted by any of the environment
-        plugins.  For example, the conda plugin accepts "2.7" to mean
-        create a new Conda environment with Python version 2.7.""")
+        help=help)
 
 
 def add_parallel(parser):


### PR DESCRIPTION
The default value differs for asv run and asv dev.  Moreover, currently
only python=same results to use of ExistingEnvironment, so it's not
possible to pass in python executable names any more.