### PR TITLE
Add a command-line option for selecting environments

### DIFF
--- a/asv/commands/continuous.py
+++ b/asv/commands/continuous.py
@@ -37,6 +37,7 @@ class Continuous(Command):
         common_args.add_show_stderr(parser)
         common_args.add_bench(parser)
         common_args.add_machine(parser)
+        common_args.add_environment(parser)
         parser.set_defaults(func=cls.run_from_args)
 
         return parser
@@ -46,12 +47,12 @@ class Continuous(Command):
         return cls.run(
             conf=conf, branch=args.branch, base=args.base, factor=args.factor,
             show_stderr=args.show_stderr, bench=args.bench, machine=args.machine,
-            **kwargs
+            env_spec=args.env_spec, **kwargs
         )
 
     @classmethod
     def run(cls, conf, branch=None, base=None, factor=2.0, show_stderr=False, bench=None,
-            machine=None, _machine_file=None):
+            machine=None, env_spec=None, _machine_file=None):
         repo = get_repo(conf)
         repo.pull()
 
@@ -69,8 +70,8 @@ class Continuous(Command):
 
         result = Run.run(
             conf, range_spec=commit_hashes, bench=bench,
-            show_stderr=show_stderr, machine=machine, _returns=run_objs,
-            _machine_file=_machine_file)
+            show_stderr=show_stderr, machine=machine, env_spec=env_spec,
+            _returns=run_objs, _machine_file=_machine_file)
         if result:
             return result
 

--- a/asv/commands/dev.py
+++ b/asv/commands/dev.py
@@ -21,18 +21,20 @@ class Dev(Run):
 
         common_args.add_bench(parser)
         common_args.add_machine(parser)
-        common_args.add_python(parser, default="same")
+        common_args.add_environment(parser, default_same=True)
         parser.set_defaults(func=cls.run_from_args)
 
         return parser
 
     @classmethod
     def run_from_conf_args(cls, conf, args, **kwargs):
-        return cls.run(conf, bench=args.bench, machine=args.machine, python=args.python,
+        return cls.run(conf, bench=args.bench, machine=args.machine, env_spec=args.env_spec,
                        **kwargs)
 
     @classmethod
-    def run(cls, conf, bench=None, python="same", machine=None, _machine_file=None):
+    def run(cls, conf, bench=None, env_spec=None, machine=None, _machine_file=None):
+        if not env_spec:
+            env_spec = ["existing:same"]
         return super(cls, Dev).run(conf=conf, bench=bench, show_stderr=True, quick=True,
-                                   python=python, machine=machine, dry_run=True,
+                                   env_spec=env_spec, machine=machine, dry_run=True,
                                    _machine_file=_machine_file)

--- a/asv/commands/find.py
+++ b/asv/commands/find.py
@@ -52,6 +52,7 @@ class Find(Command):
             rather than an increase.""")
         common_args.add_show_stderr(parser)
         common_args.add_machine(parser)
+        common_args.add_environment(parser)
 
         parser.set_defaults(func=cls.run_from_args)
 
@@ -62,14 +63,12 @@ class Find(Command):
         return cls.run(
             conf, args.range, args.bench,
             invert=args.invert, show_stderr=args.show_stderr,
-            machine=args.machine, **kwargs
+            machine=args.machine, env_spec=args.env_spec, **kwargs
         )
 
     @classmethod
     def run(cls, conf, range_spec, bench, invert=False, show_stderr=False,
-            machine=None, _machine_file=None):
-        # TODO: Allow for choosing an environment
-
+            machine=None, env_spec=None, _machine_file=None):
         params = {}
         machine_params = Machine.load(
             machine_name=machine,
@@ -87,12 +86,12 @@ class Find(Command):
             log.error("No commit hashes selected")
             return 1
 
-        environments = Setup.run(conf=conf)
+        environments = Setup.run(conf=conf, env_spec=env_spec)
         if len(environments) == 0:
             log.error("No environments selected")
             return 1
 
-        benchmarks = Benchmarks(conf, regex=bench)
+        benchmarks = Benchmarks(conf, environments, regex=bench)
         if len(benchmarks) == 0:
             log.error("'{0}' benchmark not found".format(bench))
             return 1

--- a/asv/commands/publish.py
+++ b/asv/commands/publish.py
@@ -19,7 +19,10 @@ from ..repo import get_repo
 from ..results import iter_results, compatible_results
 from ..branch_cache import BranchCache
 from ..publishing import OutputPublisher
+from .. import environment
 from .. import util
+
+from . import common_args
 
 
 def check_benchmark_params(name, benchmark):
@@ -68,16 +71,18 @@ class Publish(Command):
             written to the ``html_dir`` given in the ``asv.conf.json``
             file, and may be served using any static web server.""")
 
+        common_args.add_environment(parser)
+
         parser.set_defaults(func=cls.run_from_args)
 
         return parser
 
     @classmethod
     def run_from_conf_args(cls, conf, args):
-        return cls.run(conf=conf)
+        return cls.run(conf=conf, env_spec=args.env_spec)
 
     @classmethod
-    def run(cls, conf):
+    def run(cls, conf, env_spec=None):
         params = {}
         graphs = {}
         date_to_hash = {}
@@ -90,7 +95,8 @@ class Publish(Command):
         if os.path.exists(conf.html_dir):
             util.long_path_rmtree(conf.html_dir)
 
-        benchmarks = Benchmarks.load(conf)
+        environments = list(environment.get_environments(conf, env_spec))
+        benchmarks = Benchmarks.load(conf, environments)
 
         template_dir = os.path.join(
             os.path.dirname(os.path.abspath(__file__)), '..', 'www')

--- a/asv/commands/run.py
+++ b/asv/commands/run.py
@@ -284,7 +284,8 @@ class Run(Command):
                             env.requirements,
                             commit_hash,
                             repo.get_date(commit_hash),
-                            env.python)
+                            env.python,
+                            env.name)
 
                         for benchmark_name, d in six.iteritems(results):
                             result.add_time(benchmark_name, d['result'])

--- a/asv/commands/run.py
+++ b/asv/commands/run.py
@@ -17,6 +17,7 @@ from ..repo import get_repo
 from ..results import (Results, find_latest_result_hash, get_existing_hashes,
                        iter_results_for_machine_and_hash)
 from ..branch_cache import BranchCache
+from .. import environment
 from .. import util
 
 from .setup import Setup
@@ -82,7 +83,7 @@ class Run(Command):
             run only once.  This is useful to find basic errors in the
             benchmark functions faster.  The results are unlikely to
             be useful, and thus are not saved.""")
-        common_args.add_python(parser)
+        common_args.add_environment(parser)
         parser.add_argument(
             "--dry-run", "-n", action="store_true",
             default=None,
@@ -115,7 +116,7 @@ class Run(Command):
             conf=conf, range_spec=args.range, steps=args.steps,
             bench=args.bench, parallel=args.parallel,
             show_stderr=args.show_stderr, quick=args.quick,
-            profile=args.profile, python=args.python,
+            profile=args.profile, env_spec=args.env_spec,
             dry_run=args.dry_run, machine=args.machine,
             skip_successful=args.skip_existing_successful or args.skip_existing,
             skip_failed=args.skip_existing_failed or args.skip_existing,
@@ -125,7 +126,7 @@ class Run(Command):
 
     @classmethod
     def run(cls, conf, range_spec=None, steps=None, bench=None, parallel=1,
-            show_stderr=False, quick=False, profile=False, python=None,
+            show_stderr=False, quick=False, profile=False, env_spec=None,
             dry_run=False, machine=None, _machine_file=None, skip_successful=False,
             skip_failed=False, skip_existing_commits=False, _returns={}):
         params = {}
@@ -135,17 +136,14 @@ class Run(Command):
         params.update(machine_params.__dict__)
         machine_params.save(conf.results_dir)
 
-        if python == "same":
+        environments = list(environment.get_environments(conf, env_spec))
+
+        if environment.is_existing_only(environments):
+            # No repository required, so skip using it
             conf.dvcs = "none"
-            conf.repo = ""
-            dry_run = True
 
         repo = get_repo(conf)
-
-        if python is not None:
-            conf.pythons = [python]
-        else:
-            repo.pull()
+        repo.pull()
 
         if range_spec is None:
             commit_hashes = [repo.get_hash_from_master()]
@@ -184,10 +182,11 @@ class Run(Command):
         if steps is not None:
             commit_hashes = util.pick_n(commit_hashes, steps)
 
-        environments = Setup.run(conf=conf, parallel=parallel)
+        Setup.perform_setup(environments, parallel=parallel)
         if len(environments) == 0:
             log.error("No environments selected")
             return 1
+
         if range_spec is not None:
             for env in environments:
                 if not env.can_install_project():
@@ -195,7 +194,7 @@ class Run(Command):
                         "No range spec may be specified if benchmarking in "
                         "an existing environment")
 
-        benchmarks = Benchmarks(conf, regex=bench)
+        benchmarks = Benchmarks(conf, environments, regex=bench)
         if len(benchmarks) == 0:
             log.error("No benchmarks selected")
             return 1
@@ -277,7 +276,7 @@ class Run(Command):
                         else:
                             results = benchmarks.skip_benchmarks(env)
 
-                        if dry_run:
+                        if dry_run or isinstance(env, environment.ExistingEnvironment):
                             continue
 
                         result = Results(

--- a/asv/commands/setup.py
+++ b/asv/commands/setup.py
@@ -40,19 +40,25 @@ class Setup(Command):
 
         common_args.add_parallel(parser)
 
+        common_args.add_environment(parser)
+
         parser.set_defaults(func=cls.run_from_args)
 
         return parser
 
     @classmethod
     def run_from_conf_args(cls, conf, args):
-        return cls.run(conf=conf, parallel=args.parallel)
+        return cls.run(conf=conf, parallel=args.parallel, env_spec=args.env_spec)
 
     @classmethod
-    def run(cls, conf, parallel=-1):
-        environments = list(environment.get_environments(conf))
+    def run(cls, conf, parallel=-1, env_spec=None):
+        environments = list(environment.get_environments(conf, env_spec))
+        cls.perform_setup(environments)
+        return environments
 
-        if all(isinstance(env, environment.ExistingEnvironment) for env in environments):
+    @classmethod
+    def perform_setup(cls, environments, parallel=-1):
+        if environment.is_existing_only(environments):
             # Nothing to do, so don't print anything
             return environments
 
@@ -70,5 +76,3 @@ class Setup(Command):
                     pool.close()
             else:
                 list(map(_create, environments))
-
-        return environments

--- a/asv/environment.py
+++ b/asv/environment.py
@@ -394,6 +394,7 @@ class Environment(object):
             return False
 
         expected_info = {
+            'tool_name': self.tool_name,
             'python': self._python,
             'requirements': self._requirements
         }
@@ -553,6 +554,7 @@ class Environment(object):
         """
         path = os.path.join(path, 'asv-env-info.json')
         content = {
+            'tool_name': self.tool_name,
             'python': self._python,
             'requirements': self._requirements
         }

--- a/asv/environment.py
+++ b/asv/environment.py
@@ -225,12 +225,12 @@ def get_environments(conf, env_specifiers):
         for requirements in iter_requirement_matrix(env_type, pythons, conf, process_includes):
             python = requirements.pop('python')
 
-            if env_type:
-                cls = get_environment_class_by_name(env_type)
-            else:
-                cls = get_environment_class(conf, python)
-
             try:
+                if env_type:
+                    cls = get_environment_class_by_name(env_type)
+                else:
+                    cls = get_environment_class(conf, python)
+
                 yield cls(conf, python, requirements)
             except EnvironmentUnavailable as err:
                 log.warn(str(err))
@@ -271,7 +271,7 @@ def get_environment_class(conf, python):
     for cls in classes:
         if cls.matches(python):
             return cls
-    raise util.UserError(
+    raise EnvironmentUnavailable(
         "No way to create environment for python='{0}'".format(python))
 
 
@@ -282,7 +282,7 @@ def get_environment_class_by_name(environment_type):
     for cls in util.iter_subclasses(Environment):
         if cls.tool_name == environment_type:
             return cls
-    raise ValueError(
+    raise EnvironmentUnavailable(
         "Unknown environment type '{0}'".format(environment_type))
 
 

--- a/asv/environment.py
+++ b/asv/environment.py
@@ -311,7 +311,8 @@ class Environment(object):
         """
         Get a hash to uniquely identify this environment.
         """
-        return hashlib.md5(self.name.encode('utf-8')).hexdigest()
+        full_name = "{0}-{1}".format(self.tool_name, self.name).encode('utf-8')
+        return hashlib.md5(full_name).hexdigest()
 
     @property
     def requirements(self):

--- a/asv/environment.py
+++ b/asv/environment.py
@@ -561,17 +561,19 @@ class ExistingEnvironment(Environment):
         if executable == 'same':
             executable = sys.executable
 
-        self._executable = executable
         try:
+            executable = os.path.abspath(util.which(executable))
+
             self._python = util.check_output(
                 [executable,
                  '-c',
                  'import sys; '
                  'print(str(sys.version_info[0]) + "." + str(sys.version_info[1]))'
                  ]).strip()
-        except (util.ProcessError, OSError):
+        except (util.ProcessError, OSError, IOError):
             raise EnvironmentUnavailable()
 
+        self._executable = executable
         self._requirements = {}
 
         super(ExistingEnvironment, self).__init__(conf, executable, requirements)

--- a/asv/environment.py
+++ b/asv/environment.py
@@ -155,11 +155,17 @@ def match_rule(target, rule):
     return True
 
 
-def get_env_name(python, requirements):
+def get_env_name(tool_name, python, requirements):
     """
     Get a name to uniquely identify an environment.
     """
-    name = ["py{0}".format(python)]
+    if tool_name:
+        name = [tool_name]
+    else:
+        # Backward compatibility vs. result file names
+        name = []
+
+    name.append("py{0}".format(python))
     reqs = list(six.iteritems(requirements))
     reqs.sort()
     for key, val in reqs:
@@ -352,15 +358,14 @@ class Environment(object):
         """
         Get a name to uniquely identify this environment.
         """
-        return get_env_name(self._python, self._requirements)
+        return get_env_name(self.tool_name, self._python, self._requirements)
 
     @property
     def hashname(self):
         """
         Get a hash to uniquely identify this environment.
         """
-        full_name = "{0}-{1}".format(self.tool_name, self.name).encode('utf-8')
-        return hashlib.md5(full_name).hexdigest()
+        return hashlib.md5(self.name.encode('utf-8')).hexdigest()
 
     @property
     def requirements(self):
@@ -592,7 +597,9 @@ class ExistingEnvironment(Environment):
 
     @property
     def name(self):
-        return self._executable
+        return get_env_name(self.tool_name,
+                            self._executable.replace(os.path.sep, '_'),
+                            {})
 
     def check_presence(self):
         return True

--- a/asv/plugins/conda.py
+++ b/asv/plugins/conda.py
@@ -3,6 +3,7 @@
 
 from __future__ import absolute_import, division, unicode_literals, print_function
 
+import re
 import os
 import tempfile
 import subprocess
@@ -46,6 +47,10 @@ class Conda(environment.Environment):
 
     @classmethod
     def matches(self, python):
+        if not re.match(r'^[0-9].*$', python):
+            # The python name should be a version number
+            return False
+
         try:
             conda = util.which('conda')
         except IOError:
@@ -64,7 +69,7 @@ class Conda(environment.Environment):
                     '-p',
                     path,
                     'python={0}'.format(python),
-                    '--dry-run'], display_error=False)
+                    '--dry-run'], display_error=False, dots=False)
             except util.ProcessError:
                 return False
             else:

--- a/asv/plugins/virtualenv.py
+++ b/asv/plugins/virtualenv.py
@@ -5,6 +5,7 @@ from __future__ import absolute_import, division, unicode_literals, print_functi
 
 from distutils.version import LooseVersion
 import sys
+import re
 import inspect
 import os
 import subprocess
@@ -79,6 +80,10 @@ class Virtualenv(environment.Environment):
 
     @classmethod
     def matches(self, python):
+        if not re.match(r'^[0-9].*$', python):
+            # The python name should be a version number
+            return False
+
         try:
             import virtualenv
         except ImportError:

--- a/asv/repo.py
+++ b/asv/repo.py
@@ -180,6 +180,9 @@ class NoRepository(Repo):
     def get_date_from_name(self, name):
         self._raise_error()
 
+    def pull(self):
+        # Nothing to do
+        pass
 
 def get_repo(conf):
     """

--- a/asv/results.py
+++ b/asv/results.py
@@ -182,7 +182,7 @@ class Results(object):
     """
     api_version = 1
 
-    def __init__(self, params, requirements, commit_hash, date, python):
+    def __init__(self, params, requirements, commit_hash, date, python, env_name):
         """
         Parameters
         ----------
@@ -202,6 +202,9 @@ class Results(object):
 
         python : str
             A Python version specifier.
+
+        env_name : str
+            Environment name
         """
         self._params = params
         self._requirements = requirements
@@ -210,10 +213,10 @@ class Results(object):
         self._results = {}
         self._profiles = {}
         self._python = python
+        self._env_name = env_name
 
         self._filename = get_filename(
-            params['machine'], self._commit_hash,
-            environment.get_env_name(python, requirements))
+            params['machine'], self._commit_hash, env_name)
 
     @property
     def commit_hash(self):
@@ -290,6 +293,7 @@ class Results(object):
             'requirements': self._requirements,
             'commit_hash': self._commit_hash,
             'date': self._date,
+            'env_name': self._env_name,
             'python': self._python,
             'profiles': self._profiles
         }, self.api_version)
@@ -328,7 +332,9 @@ class Results(object):
             d['requirements'],
             d['commit_hash'],
             d['date'],
-            d['python']
+            d['python'],
+            d.get('env_name',
+                  environment.get_env_name('', d['python'], d['requirements']))
         )
         obj._results = d['results']
         if 'profiles' in d:

--- a/asv/util.py
+++ b/asv/util.py
@@ -220,7 +220,11 @@ def which(filename):
         if not filename.endswith('.exe'):
             filename = filename + '.exe'
 
-    locations = os.environ.get("PATH").split(os.pathsep)
+    if os.path.sep in filename:
+        locations = ['']
+    else:
+        locations = os.environ.get("PATH").split(os.pathsep)
+
     candidates = []
     for location in locations:
         candidate = os.path.join(location, filename)

--- a/test/test_benchmarks.py
+++ b/test/test_benchmarks.py
@@ -42,24 +42,25 @@ def test_find_benchmarks(tmpdir):
     d['repo'] = tools.generate_test_repo(tmpdir, [0]).path
     conf = config.Config.from_json(d)
 
-    b = benchmarks.Benchmarks(conf, regex='secondary')
+    envs = list(environment.get_environments(conf, None))
+
+    b = benchmarks.Benchmarks(conf, envs, regex='secondary')
     assert len(b) == 3
 
-    b = benchmarks.Benchmarks(conf, regex='example')
+    b = benchmarks.Benchmarks(conf, envs, regex='example')
     assert len(b) == 22
 
-    b = benchmarks.Benchmarks(conf, regex='time_example_benchmark_1')
+    b = benchmarks.Benchmarks(conf, envs, regex='time_example_benchmark_1')
     assert len(b) == 2
 
-    b = benchmarks.Benchmarks(conf, regex=['time_example_benchmark_1',
-                                           'some regexp that does not match anything'])
+    b = benchmarks.Benchmarks(conf, envs, regex=['time_example_benchmark_1',
+                                                 'some regexp that does not match anything'])
     assert len(b) == 2
 
-    b = benchmarks.Benchmarks(conf)
+    b = benchmarks.Benchmarks(conf, envs)
     assert len(b) == 26
 
-    envs = list(environment.get_environments(conf))
-    b = benchmarks.Benchmarks(conf)
+    b = benchmarks.Benchmarks(conf, envs)
     times = b.run_benchmarks(envs[0], profile=True, show_stderr=True)
 
     assert len(times) == len(b)
@@ -134,8 +135,10 @@ def test_invalid_benchmark_tree(tmpdir):
     d['repo'] = tools.generate_test_repo(tmpdir, [0]).path
     conf = config.Config.from_json(d)
 
+    envs = list(environment.get_environments(conf, None))
+
     with pytest.raises(util.UserError):
-        b = benchmarks.Benchmarks(conf)
+        b = benchmarks.Benchmarks(conf, envs)
 
 
 def test_table_formatting():
@@ -217,5 +220,7 @@ def track_this():
     d['repo'] = tools.generate_test_repo(tmpdir, [0]).path
     conf = config.Config.from_json(d)
 
-    b = benchmarks.Benchmarks(conf, regex='track_this')
+    envs = list(environment.get_environments(conf, None))
+
+    b = benchmarks.Benchmarks(conf, envs, regex='track_this')
     assert len(b) == 1

--- a/test/test_compare.py
+++ b/test/test_compare.py
@@ -66,7 +66,8 @@ def test_compare(capsys, tmpdir):
     conf = config.Config.from_json(
         {'results_dir': RESULT_DIR,
          'repo': tools.generate_test_repo(tmpdir).path,
-         'project': 'asv'})
+         'project': 'asv',
+         'environment_type': "shouldn't matter what"})
 
     tools.run_asv_with_conf(conf, 'compare', '22b920c6', 'fcf8c079', '--machine=cheetah',
                             '--factor=2')

--- a/test/test_dev.py
+++ b/test/test_dev.py
@@ -108,6 +108,10 @@ def test_dev_python_arg():
     args = parser.parse_args(argv)
     assert args.env_spec == [':foo']
 
+    argv = ['dev', '-E', 'existing:foo']
+    args = parser.parse_args(argv)
+    assert args.env_spec == ['existing:foo']
+
     argv = ['run', 'ALL']
     args = parser.parse_args(argv)
     assert args.env_spec == []

--- a/test/test_dev.py
+++ b/test/test_dev.py
@@ -101,16 +101,16 @@ def test_dev_python_arg():
 
     argv = ['dev']
     args = parser.parse_args(argv)
-    assert args.python == 'same'
+    assert args.env_spec == []
     assert not args.verbose
 
     argv = ['dev', '--python=foo']
     args = parser.parse_args(argv)
-    assert args.python == 'foo'
+    assert args.env_spec == [':foo']
 
     argv = ['run', 'ALL']
     args = parser.parse_args(argv)
-    assert args.python is None
+    assert args.env_spec == []
 
     argv = ['--verbose', '--config=foo', 'dev']
     args = parser.parse_args(argv)

--- a/test/test_environment.py
+++ b/test/test_environment.py
@@ -380,7 +380,7 @@ def test_environment_select():
     for env in environments:
         assert env.tool_name == "existing"
         assert env.python == "{0[0]}.{0[1]}".format(sys.version_info)
-        assert os.path.abspath(env._executable) == os.path.abspath(sys.executable)
+        assert os.path.normcase(os.path.abspath(env._executable)) == os.path.normcase(os.path.abspath(sys.executable))
 
     # Select by environment name
     environments = list(environment.get_environments(conf, ["conda-py2.7-six1.4"]))

--- a/test/test_environment.py
+++ b/test/test_environment.py
@@ -51,7 +51,7 @@ def test_matrix_environments(tmpdir):
         "six": ["1.4", None],
         "colorama": ["0.3.1", "0.3.3"]
     }
-    environments = list(environment.get_environments(conf))
+    environments = list(environment.get_environments(conf, None))
 
     assert len(environments) == 2 * 2 * 2
 
@@ -85,7 +85,7 @@ def test_large_environment_matrix(tmpdir):
     for i in range(25):
         conf.matrix['foo{0}'.format(i)] = []
 
-    environments = list(environment.get_environments(conf))
+    environments = list(environment.get_environments(conf, None))
 
     for env in environments:
         # Since *actually* installing all the dependencies would make
@@ -110,7 +110,7 @@ def test_presence_checks(tmpdir):
 
     conf.pythons = ["2.7"]
     conf.matrix = {}
-    environments = list(environment.get_environments(conf))
+    environments = list(environment.get_environments(conf, None))
 
     for env in environments:
         env.create()
@@ -167,7 +167,8 @@ def test_matrix_expand_basic():
         'pkg5': []
     }
 
-    combinations = _sorted_dict_list(environment.iter_requirement_matrix(conf))
+    combinations = _sorted_dict_list(environment.iter_requirement_matrix(
+        conf.environment_type, conf.pythons, conf))
     expected = _sorted_dict_list([
         {'python': '2.6', 'pkg2': '', 'pkg3': '', 'pkg4': '1.2', 'pkg5': ''},
         {'python': '2.6', 'pkg2': '', 'pkg3': '', 'pkg4': '3.4', 'pkg5': ''},
@@ -190,7 +191,8 @@ def test_matrix_expand_include():
         {'environment_type': 'something', 'python': '2.7', 'b': '5'},
     ]
 
-    combinations = _sorted_dict_list(environment.iter_requirement_matrix(conf))
+    combinations = _sorted_dict_list(environment.iter_requirement_matrix(
+        conf.environment_type, conf.pythons, conf))
     expected = _sorted_dict_list([
         {'python': '2.6', 'a': '1'},
         {'python': '3.4', 'b': '2'},
@@ -203,7 +205,7 @@ def test_matrix_expand_include():
         {'b': '2'}
     ]
     with pytest.raises(util.UserError):
-        list(environment.iter_requirement_matrix(conf))
+        list(environment.iter_requirement_matrix(conf.environment_type, conf.pythons, conf))
 
 
 @pytest.mark.skipif(not (HAS_PYTHON_27 or HAS_CONDA),
@@ -218,7 +220,8 @@ def test_matrix_expand_include_detect_env_type():
         {'sys_platform': sys.platform, 'python': '2.7'},
     ]
 
-    combinations = _sorted_dict_list(environment.iter_requirement_matrix(conf))
+    combinations = _sorted_dict_list(environment.iter_requirement_matrix(
+        conf.environment_type, conf.pythons, conf))
     expected = _sorted_dict_list([
         {'python': '2.7'},
     ])
@@ -243,7 +246,8 @@ def test_matrix_expand_exclude():
         {'python': '2.7', 'b': None},
         {'python': '2.6', 'a': '1'},
     ]
-    combinations = _sorted_dict_list(environment.iter_requirement_matrix(conf))
+    combinations = _sorted_dict_list(environment.iter_requirement_matrix(
+        conf.environment_type, conf.pythons, conf))
     expected = _sorted_dict_list([
         {'python': '2.7', 'a': '1', 'b': '1'},
         {'python': '2.7', 'b': '2'}
@@ -254,7 +258,8 @@ def test_matrix_expand_exclude():
     conf.exclude = [
         {'python': '.*', 'b': None},
     ]
-    combinations = _sorted_dict_list(environment.iter_requirement_matrix(conf))
+    combinations = _sorted_dict_list(environment.iter_requirement_matrix(
+        conf.environment_type, conf.pythons, conf))
     expected = _sorted_dict_list([
         {'python': '2.6', 'a': '1', 'b': '1'},
         {'python': '2.7', 'a': '1', 'b': '1'},
@@ -266,7 +271,8 @@ def test_matrix_expand_exclude():
     conf.exclude = [
         {'environment_type': 'some.*'},
     ]
-    combinations = _sorted_dict_list(environment.iter_requirement_matrix(conf))
+    combinations = _sorted_dict_list(environment.iter_requirement_matrix(
+        conf.environment_type, conf.pythons, conf))
     expected = [
         {'python': '2.7', 'b': '2'}
     ]
@@ -276,7 +282,8 @@ def test_matrix_expand_exclude():
     conf.exclude = [
         {'sys_platform': sys.platform},
     ]
-    combinations = _sorted_dict_list(environment.iter_requirement_matrix(conf))
+    combinations = _sorted_dict_list(environment.iter_requirement_matrix(
+        conf.environment_type, conf.pythons, conf))
     expected = [
         {'python': '2.7', 'b': '2'}
     ]
@@ -286,7 +293,8 @@ def test_matrix_expand_exclude():
     conf.exclude = [
         {'python': '(?!2.6).*'}
     ]
-    combinations = _sorted_dict_list(environment.iter_requirement_matrix(conf))
+    combinations = _sorted_dict_list(environment.iter_requirement_matrix(
+        conf.environment_type, conf.pythons, conf))
     expected = _sorted_dict_list([
         {'python': '2.6', 'a': '1', 'b': '1'},
         {'python': '2.6', 'a': '1'},

--- a/test/test_environment.py
+++ b/test/test_environment.py
@@ -372,9 +372,10 @@ def test_environment_select():
     assert items == ['existing', 'existing', 'existing']
 
     # Check autodetect existing
+    executable = os.path.relpath(os.path.abspath(sys.executable))
     environments = list(environment.get_environments(conf, ["existing",
                                                             ":same",
-                                                            ":" + os.path.abspath(sys.executable)]))
+                                                            ":" + executable]))
     assert len(environments) == 3
     for env in environments:
         assert env.tool_name == "existing"

--- a/test/test_environment.py
+++ b/test/test_environment.py
@@ -383,7 +383,7 @@ def test_environment_select():
         assert os.path.abspath(env._executable) == os.path.abspath(sys.executable)
 
     # Select by environment name
-    environments = list(environment.get_environments(conf, ["py2.7-six1.4"]))
+    environments = list(environment.get_environments(conf, ["conda-py2.7-six1.4"]))
     assert len(environments) == 1
     assert environments[0].python == "2.7"
     assert environments[0].tool_name == "conda"

--- a/test/test_results.py
+++ b/test/test_results.py
@@ -24,7 +24,8 @@ def test_results(tmpdir):
             {},
             hex(i),
             i * 1000000,
-            '2.7')
+            '2.7',
+            'some-environment-name')
         for key, val in {
             'suite1.benchmark1': float(i * 0.001),
             'suite1.benchmark2': float(i * i * 0.001),
@@ -37,6 +38,7 @@ def test_results(tmpdir):
         assert r2._results == r._results
         assert r2.date == r.date
         assert r2.commit_hash == r.commit_hash
+        assert r2._filename == r._filename
 
 
 def test_get_result_hash_from_prefix(tmpdir):
@@ -59,3 +61,12 @@ def test_get_result_hash_from_prefix(tmpdir):
         results.get_result_hash_from_prefix(str(results_dir), 'machine', 'e')
 
     assert 'one of multiple commits' in str(excinfo.value)
+
+
+def test_backward_compat_load():
+    resultsdir = join(os.path.dirname(__file__), 'example_results')
+    filename = join('cheetah', '624da0aa-py2.7-Cython-numpy1.8.json')
+
+    r = results.Results.load(join(resultsdir, filename))
+    assert r._filename == filename
+    assert r._env_name == 'py2.7-Cython-numpy1.8'

--- a/test/test_workflow.py
+++ b/test/test_workflow.py
@@ -14,7 +14,7 @@ import six
 import json
 import pytest
 
-from asv import config
+from asv import config, environment
 from asv.util import check_output, which
 
 from . import tools
@@ -194,11 +194,14 @@ def _test_run_branches(tmpdir, dvcs, conf, machine_file, range_spec,
                             _machine_file=machine_file)
 
     # Check that files for all commits expected were generated
+    envs = list(environment.get_environments(conf, None))
+    tool_name = envs[0].tool_name
+
     expected = set(['machine.json'])
     for commit in commits:
         for psver in ['0.3.1', '0.3.3']:
-            expected.add('{0}-py{1[0]}.{1[1]}-colorama{2}-six.json'.format(
-                commit[:8], sys.version_info, psver))
+            expected.add('{0}-{1}-py{2[0]}.{2[1]}-colorama{3}-six.json'.format(
+                commit[:8], tool_name, sys.version_info, psver))
 
     result_files = os.listdir(join(tmpdir, 'results_workflow', 'orangutan'))
 


### PR DESCRIPTION
Add a command-line option `--environment` (or `-E`) for selecting what environment type and Python version to run, overriding what is specified in the configuration file.

- This is useful e.g. when the configuration file is checked in a repository, and run by multiple users, some of which have conda and some not.
- Supercedes the `--python` option, and makes it possible to specify what Python executable to run using ExistingEnvironment (which was not possible previously).
- Add `tool_name` to the hash-name of the environments, so that it's possible to have conda and virtualenv at the same time without conflicts.
- Move calls to `environment.get_environments` to the top-level command classes. (Previously, environments were instantiated in `Benchmarks` for benchmark discovery.)

Some fine tuning may still be needed (although this is in principle complete)