### PR TITLE
BUG: fix graph file name generation for default requirement version

### DIFF
--- a/asv/www/graphdisplay.js
+++ b/asv/www/graphdisplay.js
@@ -682,7 +682,7 @@ $(document).ready(function() {
             function graph_to_path(benchmark_name, state) {
                 var parts = [];
                 $.each(state, function(key, value) {
-                    if (value !== null) {
+                    if (value) {
                         parts.push(key + "-" + value);
                     } else {
                         parts.push(key);

--- a/test/test_web.py
+++ b/test/test_web.py
@@ -47,7 +47,8 @@ def basic_html(request):
             'dvcs': 'git',
             'project': 'asv',
             'matrix': {
-                "six": [None],
+                "six": [""],
+                "asv": [None],
                 "colorama": ["0.3.1", "0.3.3"]
             }
         })


### PR DESCRIPTION
The meaning of requirement equal to "" and null was changed in
b9bdf379e5, but the Javascript code was not updated so graphs won't
load.

Sync the javascript side with Python.

Extend the web tests to run with null and "" requirements, to cover this.