### PR TITLE
BUG: do not rerun setup() when determining `number` in timing benchmarks

### DIFF
--- a/asv/benchmark.py
+++ b/asv/benchmark.py
@@ -276,7 +276,7 @@ class Benchmark(object):
         self.type = "base"
         self.unit = "unit"
 
-        self.__redo_setup_first = True
+        self._redo_setup_next = False
 
         self._params = _get_first_attr(attr_sources, "params", [])
         self.param_names = _get_first_attr(attr_sources, "param_names", [])
@@ -434,8 +434,8 @@ class Benchmark(object):
         return False
 
     def redo_setup(self):
-        if self.__redo_setup_first:
-            self.__redo_setup_first = False
+        if not self._redo_setup_next:
+            self._redo_setup_next = True
             return
         self.do_teardown()
         self.do_setup()
@@ -519,6 +519,11 @@ class TimeBenchmark(Benchmark):
             # goal_time / 10 <= total time < goal_time
             number = 1
             for i in range(1, 10):
+                if i > 1:
+                    # increase number (don't rerun setup)
+                    self._redo_setup_next = False
+                    number *= 10
+
                 timing = timer.timeit(number)
                 if timing >= 5*self.goal_time and number == 1 and self.repeat == 0:
                     # very slow benchmark: use a default repeat value of 1
@@ -526,7 +531,7 @@ class TimeBenchmark(Benchmark):
                     break
                 elif timing >= self.goal_time / 10.0:
                     break
-                number *= 10
+
             self.number = number
 
             # keep the timing from the run we already made

--- a/test/benchmark/time_examples.py
+++ b/test/benchmark/time_examples.py
@@ -69,3 +69,17 @@ class TimeWithRepeat(object):
         assert self.called is False
         self.called = True
         self.count += 1
+
+
+class TimeWithRepeatCalibrate(object):
+    # Check that setup is re-run on each repeat, apart from
+    # autodetection of suitable `number`
+    repeat = 1
+    number = 0
+    goal_time = 0.1
+
+    def setup(self):
+        print("setup")
+
+    def time_it(self):
+        pass

--- a/test/test_benchmarks.py
+++ b/test/test_benchmarks.py
@@ -46,7 +46,7 @@ def test_find_benchmarks(tmpdir):
     assert len(b) == 3
 
     b = benchmarks.Benchmarks(conf, regex='example')
-    assert len(b) == 21
+    assert len(b) == 22
 
     b = benchmarks.Benchmarks(conf, regex='time_example_benchmark_1')
     assert len(b) == 2
@@ -56,7 +56,7 @@ def test_find_benchmarks(tmpdir):
     assert len(b) == 2
 
     b = benchmarks.Benchmarks(conf)
-    assert len(b) == 25
+    assert len(b) == 26
 
     envs = list(environment.get_environments(conf))
     b = benchmarks.Benchmarks(conf)
@@ -116,6 +116,10 @@ def test_find_benchmarks(tmpdir):
     # The output would contain error messages if the asserts in the benchmark fail.
     expected = ["<%d>" % j for j in range(1, 12)]
     assert times['time_examples.TimeWithRepeat.time_it']['stderr'].split() == expected
+
+    # Calibration of iterations should not rerun setup
+    expected = ['setup']*2
+    assert times['time_examples.TimeWithRepeatCalibrate.time_it']['stderr'].split() == expected
 
 
 def test_invalid_benchmark_tree(tmpdir):


### PR DESCRIPTION
Do not re-run setup in the loop that determines what number of calls to
make without repeats.  This can be important in cases where setup()
takes a lot of time, but the timing routine itself if fast.

Also fix a logic bug for cases where the loop runs all iterations; in
this case, the `timing` corresponded to `number//10` resulting to wrong
reported timing for the first repeat.