### PR TITLE
Fix bug if git outputs more than the intended timestamp

### DIFF
--- a/asv/plugins/git.py
+++ b/asv/plugins/git.py
@@ -113,7 +113,7 @@ class Git(Repo):
         # TODO: This works on Linux, but should be extended for other platforms
         return int(self._run_git(
             ['show', hash, '--quiet', '--format=format:%at'],
-            valid_return_codes=(0, 1), dots=False).strip().split()[-1]) * 1000
+            valid_return_codes=(0, 1), dots=False).strip().split()[0]) * 1000
 
     def get_hashes_from_range(self, range_spec):
         args = ['log', '--quiet', '--first-parent', '--format=format:%H']


### PR DESCRIPTION
older git versions do not correctly recognize the --quiet option and still
output the diff of the commit in addition to the timestamp.
Reading the first value produces consistent behavior also for older versions.

This would fix #355