### PR TITLE
Use pip install -v for installing requirements in virtualenv to avoid timeout

### DIFF
--- a/asv/plugins/virtualenv.py
+++ b/asv/plugins/virtualenv.py
@@ -112,10 +112,10 @@ class Virtualenv(environment.Environment):
         self._install_requirements()
 
     def _install_requirements(self):
-        self.run_executable('pip', ['install', 'wheel'])
+        self.run_executable('pip', ['install', '-v', 'wheel'])
 
         if self._requirements:
-            args = ['install', '--upgrade']
+            args = ['install', '-v', '--upgrade']
             for key, val in six.iteritems(self._requirements):
                 if val:
                     args.append("{0}=={1}".format(key, val))


### PR DESCRIPTION
Some requirement packages may take more than 10 minutes to build. This
should not trigger timeout in asv as long as the build progresses, so
tell pip to output the build log so that asv can see if it is stalled.

cf. gh-356