### PR TITLE
Upgrade virtualenv to pip>=8 because wheel>=0.29.0 generates incompatible wheels

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -58,7 +58,11 @@ install:
       chmod +x $HOME/miniconda2/bin/conda;
       if $TRAVIS_PYTHON -c 'import virtualenv'; then echo "ERROR: virtualenv package is installed"; exit 1; fi;
     else
-      $TRAVIS_PIP install virtualenv;
+      if [[ "$TRAVIS_PYTHON_VERSION" == "3.2" ]]; then
+        $TRAVIS_PIP install 'virtualenv<14';
+      else
+        $TRAVIS_PIP install virtualenv;
+      fi
     fi
     if [[ $TRAVIS_PYTHON_VERSION == 2* ]]; then $TRAVIS_PIP install mercurial ; fi;
     if [[ $TRAVIS_PYTHON_VERSION == 2* ]]; then $TRAVIS_PIP install python-hglib ; fi;

--- a/asv/plugins/virtualenv.py
+++ b/asv/plugins/virtualenv.py
@@ -112,7 +112,10 @@ class Virtualenv(environment.Environment):
         self._install_requirements()
 
     def _install_requirements(self):
-        self.run_executable('pip', ['install', '-v', 'wheel'])
+        if sys.version_info[:2] == (3, 2):
+            self.run_executable('pip', ['install', '-v', 'wheel<0.29.0', 'pip<8'])
+        else:
+            self.run_executable('pip', ['install', '-v', 'wheel', 'pip>=8'])
 
         if self._requirements:
             args = ['install', '-v', '--upgrade']


### PR DESCRIPTION
The platform python tag format apparently changed in wheel, making produced wheels incompatible with old pip versions.

pip 8 dropped support for Python 3.2, so require older wheel+pip combo there.