### PR TITLE
ENH: fallback to pip if matrix dependency is not available with conda

### DIFF
--- a/asv/plugins/virtualenv.py
+++ b/asv/plugins/virtualenv.py
@@ -117,10 +117,14 @@ class Virtualenv(environment.Environment):
         if self._requirements:
             args = ['install', '-v', '--upgrade']
             for key, val in six.iteritems(self._requirements):
+                pkg = key
+                if key.startswith('pip+'):
+                    pkg = key[4:]
+
                 if val:
-                    args.append("{0}=={1}".format(key, val))
+                    args.append("{0}=={1}".format(pkg, val))
                 else:
-                    args.append(key)
+                    args.append(pkg)
             self.run_executable('pip', args)
 
     def install(self, package):

--- a/asv/template/asv.conf.json
+++ b/asv/template/asv.conf.json
@@ -42,11 +42,16 @@
     // package (in PyPI) and the values are version numbers.  An empty
     // list or empty string indicates to just test against the default
     // (latest) version. null indicates that the package is to not be
-    // installed.
+    // installed. If the package to be tested is only available from
+    // PyPi, and the 'environment_type' is conda, then you can preface
+    // the package name by 'pip+', and the package will be installed via
+    // pip (with all the conda available packages installed first,
+    // followed by the pip installed packages).
     //
     // "matrix": {
     //     "numpy": ["1.6", "1.7"],
     //     "six": ["", null],        // test with and without six installed
+    //     "pip+emcee": [""],   // emcee is only available for install with pip.
     // },
 
     // Combinations of libraries/python versions can be excluded/included

--- a/docs/source/asv.conf.json.rst
+++ b/docs/source/asv.conf.json.rst
@@ -124,7 +124,10 @@ the project being benchmarked may specify in its ``setup.py`` file.
 
     At present, this functionality only supports dependencies that are
     installable via ``pip`` or ``conda`` (depending on which
-    environment is used).
+    environment is used). If ``conda`` is specified as ``environment_type``
+    and you wish to install the package via ``pip``, then preface the package
+    name with ``pip+``. For example, ``emcee`` is only available from ``pip``,
+    so the package name to be used is ``pip+emcee``.
 
 ``exclude``
 -----------

--- a/test/test_environment.py
+++ b/test/test_environment.py
@@ -293,3 +293,27 @@ def test_matrix_expand_exclude():
         {'python': '2.7', 'b': '2'}
     ])
     assert combinations == expected
+
+
+@pytest.mark.skipif((not HAS_CONDA),
+                    reason="Requires conda")
+def test_conda_pip_install(tmpdir):
+    # test that we can install with pip into a conda environment.
+    conf = config.Config()
+
+    conf.env_dir = six.text_type(tmpdir.join("env"))
+
+    conf.pythons = ["3.4"]
+    conf.matrix = {
+        "pip+colorama": ["0.3.1"]
+    }
+    environments = list(environment.get_environments(conf))
+
+    assert len(environments) == 1 * 1 * 1
+
+    for env in environments:
+        env.create()
+
+        output = env.run(
+            ['-c', 'import colorama, sys; sys.stdout.write(colorama.__version__)'])
+        assert output.startswith(six.text_type(env._requirements['pip+colorama']))


### PR DESCRIPTION
If the `environment_type` is `conda`, then the only matrix dependencies that can be examined are those available via `conda install`.  This is annoying if some, or all, packages are only available via `pip`.
This PR examines all the matrix dependencies. It will install all packages available on `conda` via `conda install`. For packages not available this way, it will try to install via `pip`.