### PR TITLE
BUG: fix two issues with asv publish

### DIFF
--- a/asv/commands/publish.py
+++ b/asv/commands/publish.py
@@ -177,8 +177,12 @@ class Publish(Command):
         for key in six.iterkeys(benchmark_map):
             check_benchmark_params(key, benchmark_map[key])
         for key, val in six.iteritems(params):
-            val = list(val)
-            val.sort(key=lambda x: x or '')
+            # Values can be stored as strings, integers, floating point values,
+            # or None, so we now convert to a list of strings. We also make 
+            # sure that we convert to a set to remove duplicate items (for 
+            # instance, some files might contain "" and some None, but we need 
+            # to treat them as one).
+            val = sorted(set(str(x) if x is not None else '' for x in val))
             params[key] = val
         params['branch'] = [safe_branch_name(branch) for branch in conf.branches]
         util.write_json(os.path.join(conf.html_dir, "index.json"), {

--- a/test/example_results/cheetah/05d283b9-py2.7-Cython-numpy1.8.json
+++ b/test/example_results/cheetah/05d283b9-py2.7-Cython-numpy1.8.json
@@ -9,11 +9,11 @@
         "numpy": "1.8", 
         "os": "Linux (Fedora 20)", 
         "python": "2.7", 
-        "ram": "8.2G"
+        "ram": 8804682956.8
     }, 
     "python": "2.7", 
     "requirements": {
-        "Cython": null, 
+        "Cython": "", 
         "numpy": "1.8"
     }, 
     "results": {

--- a/test/test_publish.py
+++ b/test/test_publish.py
@@ -106,3 +106,5 @@ def test_publish(tmpdir):
 
     index = util.load_json(join(tmpdir, 'html', 'index.json'))
     assert index['params']['branch'] == ['master', 'some-branch']
+    assert index['params']['Cython'] == ['']
+    assert sorted(index['params']['ram']) == ['8.2G', '8804682956.8']


### PR DESCRIPTION
The first issue occurred if a JSON file contained an integer and another contained a string, for the same parameter (for instance, for RAM, a file might contain “8G” and another file 104727291):

```
Traceback (most recent call last):
  File "/Users/tom/miniconda3/bin/asv", line 9, in <module>
    load_entry_point('asv', 'console_scripts', 'asv')()
  File "/Users/tom/tmp/asv/asv/main.py", line 36, in main
    result = args.func(args)
  File "/Users/tom/tmp/asv/asv/commands/__init__.py", line 48, in run_from_args
    return cls.run_from_conf_args(conf, args)
  File "/Users/tom/tmp/asv/asv/commands/publish.py", line 77, in run_from_conf_args
    return cls.run(conf=conf)
  File "/Users/tom/tmp/asv/asv/commands/publish.py", line 182, in run
    val.sort(key=lambda x: x or '')
TypeError: unorderable types: str() < int()
```

The second issue occurred if one file contained an empty string and another contained None, for the same parameter, since this would result in two empty strings in the final list and would then create too many entries in the generated website:

**Before**

<img width="309" alt="screen shot 2016-03-05 at 10 14 01 am" src="https://cloud.githubusercontent.com/assets/314716/13547107/eac1e52e-e2bb-11e5-8cd6-813472f114aa.png">

**After**

<img width="303" alt="screen shot 2016-03-05 at 10 15 00 am" src="https://cloud.githubusercontent.com/assets/314716/13547109/efc9058e-e2bb-11e5-9cb1-cdef20e5ce9f.png">

