### PR TITLE
For conda, install pip and wheel from conda so that they are compatible

### DIFF
--- a/asv/wheel_cache.py
+++ b/asv/wheel_cache.py
@@ -71,6 +71,9 @@ class WheelCache(object):
             if os.path.isdir(path):
                 util.long_path_rmtree(path)
 
+    def disable(self):
+        self._wheel_cache_size = 0
+
     def build_project_cached(self, env, package, commit_hash):
         if self._wheel_cache_size == 0:
             return None


### PR DESCRIPTION
This ensures the pip and wheel versions can work together; installing
`wheel` via pip can end up with pip/wheel combination that does not
work.

(Will merge asap, since currently the wheel cache on conda is broken because of incompatible wheel/pip versions.)