### PR TITLE
Fix missing key handling in graph generation + parameter handling

### DIFF
--- a/asv/graph.py
+++ b/asv/graph.py
@@ -27,7 +27,7 @@ class Graph(object):
     Unlike "results", which contain the timings for a single commit,
     these contain the timings for a single benchmark.
     """
-    def __init__(self, benchmark_name, params, all_params):
+    def __init__(self, benchmark_name, params):
         """
         Initially the graph contains no data.  It must be added using
         multiple calls to `add_data_point`.
@@ -41,18 +41,7 @@ class Graph(object):
         params : dict of str -> str
             A dictionary of parameters describing the benchmark.
 
-        all_params : dict of str -> str
-            A dictionary of all parameters that were found amongst all
-            benchmark results.  This is used to fill in blanks for
-            parameters that might not have been recorded for a
-            particular result.
-
         """
-        # Fill in missing parameters
-        for key in six.iterkeys(all_params):
-            if key not in params:
-                params[key] = None
-
         self.benchmark_name = benchmark_name
         self.params = params
         self.data_points = {}
@@ -63,10 +52,12 @@ class Graph(object):
         l = list(six.iteritems(self.params))
         l.sort()
         for key, val in l:
-            if val:
+            if val is None:
+                parts.append('{0}-null'.format(key))
+            elif val:
                 parts.append('{0}-{1}'.format(key, val))
             else:
-                parts.append(key)
+                parts.append('{0}'.format(key))
         parts.append(benchmark_name)
 
         self.path = os.path.join(*parts)
@@ -218,7 +209,7 @@ def make_summary_graph(graphs):
     val = resample_data(val)
 
     # Return as a graph
-    graph = Graph(graphs[0].benchmark_name, {'summary': None}, {})
+    graph = Graph(graphs[0].benchmark_name, {'summary': ''})
     for x, y in val:
         graph.add_data_point(x, y)
     return graph

--- a/asv/www/asv.js
+++ b/asv/www/asv.js
@@ -238,6 +238,9 @@ $(document).ready(function() {
                 }
                 var key = part[0];
                 var value = decodeURIComponent(part[1].replace(/\+/g, " "));
+                if (value == '[none]') {
+                    value = null;
+                }
                 if (info['params'][key] === undefined) {
                     info['params'][key] = [value];
                 }
@@ -266,6 +269,9 @@ $(document).ready(function() {
                 $.each(values, function (idx, value) {
                     if (!first) {
                         str = str + '&';
+                    }
+                    if (value === null) {
+                        value = '[none]';
                     }
                     str = str + key + '=' + encodeURIComponent(value);
                     first = false;

--- a/asv/www/graphdisplay.js
+++ b/asv/www/graphdisplay.js
@@ -490,11 +490,13 @@ $(document).ready(function() {
 
         /* Generic parameter selectors */
         $.each(index.params, function(param, values) {
-            if (values.length > 1 && param !== 'machine') {
+            if (values.length > 1 && param != 'machine') {
                 make_value_selector_panel(nav, param, values, function(i, value, button) {
                     var value_display;
-                    if (!value)
+                    if (value === null)
                         value_display = '[none]';
+                    else if (!value)
+                        value_display = '[default]';
                     else
                         value_display = value;
 
@@ -682,7 +684,9 @@ $(document).ready(function() {
             function graph_to_path(benchmark_name, state) {
                 var parts = [];
                 $.each(state, function(key, value) {
-                    if (value) {
+                    if (value === null) {
+                        parts.push(key + "-null");
+                    } else if (value) {
                         parts.push(key + "-" + value);
                     } else {
                         parts.push(key);
@@ -709,7 +713,9 @@ $(document).ready(function() {
                 $.each(state, function(key, value) {
                     if (!ignore.hasOwnProperty(key) &&
                         differences.hasOwnProperty(key)) {
-                        if (value) {
+                        if (value === null) {
+                            // missing key, skip
+                        } else if (value) {
                             parts.push(key + "-" + value);
                         } else {
                             parts.push(key);

--- a/test/example_results/cheetah/05d283b9-py2.7-Cython-numpy1.8.json
+++ b/test/example_results/cheetah/05d283b9-py2.7-Cython-numpy1.8.json
@@ -2,18 +2,18 @@
     "commit_hash": "05d283b9694ed6db6e3f2df3f21d832e78bded7f", 
     "date": 1386688801000, 
     "params": {
-        "Cython": null, 
+        "Cython": "", 
         "arch": "x86_64", 
         "cpu": "Intel(R) Core(TM) i5-2520M CPU @ 2.50GHz (4 cores)", 
         "machine": "cheetah", 
         "numpy": "1.8", 
         "os": "Linux (Fedora 20)", 
         "python": "2.7", 
-        "ram": "8.2G"
+        "ram": 8804682956.8
     }, 
     "python": "2.7", 
     "requirements": {
-        "Cython": null, 
+        "Cython": "", 
         "numpy": "1.8"
     }, 
     "results": {

--- a/test/example_results/cheetah/22b920c6-py2.7-Cython-numpy1.8.json
+++ b/test/example_results/cheetah/22b920c6-py2.7-Cython-numpy1.8.json
@@ -2,7 +2,6 @@
     "commit_hash": "22b920c6d0d54112ccbc020eddba9ea7a2d204f3", 
     "date": 1378902176000, 
     "params": {
-        "Cython": null, 
         "arch": "x86_64", 
         "cpu": "Intel(R) Core(TM) i5-2520M CPU @ 2.50GHz (4 cores)", 
         "machine": "cheetah", 
@@ -13,7 +12,6 @@
     }, 
     "python": "2.7", 
     "requirements": {
-        "Cython": null, 
         "numpy": "1.8"
     }, 
     "results": {

--- a/test/example_results/cheetah/e8679b2e-py2.7-Cython-numpy1.8.json
+++ b/test/example_results/cheetah/e8679b2e-py2.7-Cython-numpy1.8.json
@@ -2,7 +2,6 @@
     "commit_hash": "e8679b2e7660a137504094f99785665bbc38df98", 
     "date": 1360617029000, 
     "params": {
-        "Cython": null, 
         "arch": "x86_64", 
         "cpu": "Intel(R) Core(TM) i5-2520M CPU @ 2.50GHz (4 cores)", 
         "machine": "cheetah", 
@@ -13,11 +12,10 @@
     }, 
     "python": "2.7", 
     "requirements": {
-        "Cython": null, 
         "numpy": "1.8"
     }, 
     "results": {
-        "time_coordinates.time_latitude": null, 
+        "time_coordinates.time_latitude": 0.10822079181671143,
         "time_quantity.time_quantity_array_conversion": 0.0017406461238861084, 
         "time_quantity.time_quantity_init_array": 0.0008062648773193359, 
         "time_quantity.time_quantity_init_scalar": 3.75032901763916e-05, 

--- a/test/test_graph.py
+++ b/test/test_graph.py
@@ -13,14 +13,14 @@ def test_graph_single():
     ]
 
     # Should give same data back, excluding missing values at edges
-    g = Graph('foo', {}, {})
+    g = Graph('foo', {})
     for k, v in vals:
         g.add_data_point(k, v)
     data = g.get_data()
     assert data == vals[:-2]
 
     # Should average duplicate values
-    g = Graph('foo', {}, {})
+    g = Graph('foo', {})
     g.add_data_point(4, 3)
     for k, v in vals:
         g.add_data_point(k, v)
@@ -30,7 +30,7 @@ def test_graph_single():
     assert abs(data[3][1] - (3 + 4 + 5)/3.) < 1e-10
 
     # Summary graph should be the same as the main graph
-    g = Graph('foo', {}, {})
+    g = Graph('foo', {})
     for k, v in vals:
         g.add_data_point(k, v)
     g = make_summary_graph([g])
@@ -64,7 +64,7 @@ def test_graph_multi():
     ]
 
     # Should give same data back, with missing data at edges removed
-    g = Graph('foo', {}, {})
+    g = Graph('foo', {})
     for k, v in vals:
         g.add_data_point(k, v)
     data = g.get_data()
@@ -72,7 +72,7 @@ def test_graph_multi():
     assert data[1:] == vals[2:]
 
     # Should average duplicate values
-    g = Graph('foo', {}, {})
+    g = Graph('foo', {})
     g.add_data_point(4, [1, 2, 3])
     for k, v in vals:
         g.add_data_point(k, v)
@@ -84,7 +84,7 @@ def test_graph_multi():
     assert abs(data[3][1][2] - (3 + 2 + 1)/3.) < 1e-10
 
     # The summary graph is obtained by geometric mean of filled data
-    g = Graph('foo', {}, {})
+    g = Graph('foo', {})
     for k, v in vals:
         g.add_data_point(k, v)
     g = make_summary_graph([g])
@@ -101,9 +101,9 @@ def test_graph_multi():
 
     # Test summary over separate graphs -- should behave as if the
     # data was in a single graph
-    g0 = Graph('foo', {}, {})
-    g1 = Graph('foo', {}, {})
-    g2 = Graph('foo', {}, {})
+    g0 = Graph('foo', {})
+    g1 = Graph('foo', {})
+    g2 = Graph('foo', {})
     for k, v in vals:
         g0.add_data_point(k, v)
         g1.add_data_point(k, v[0])
@@ -126,14 +126,14 @@ def test_graph_multi():
 
 
 def test_empty_graph():
-    g = Graph('foo', {}, {})
+    g = Graph('foo', {})
     g.add_data_point(1, None)
     g.add_data_point(2, None)
     g.add_data_point(3, None)
     data = g.get_data()
     assert data == []
 
-    g = Graph('foo', {}, {})
+    g = Graph('foo', {})
     g.add_data_point(1, None)
     g.add_data_point(1, [None, None])
     g.add_data_point(2, [None, None])
@@ -144,7 +144,7 @@ def test_empty_graph():
 
 
 def test_nan():
-    g = Graph('foo', {}, {})
+    g = Graph('foo', {})
     g.add_data_point(1, 1)
     g.add_data_point(2, 2)
     g.add_data_point(2, float('nan'))
@@ -153,7 +153,7 @@ def test_nan():
     data = g.get_data()
     assert data == [(1, 1), (2, 2), (3, 3)]
 
-    g = Graph('foo', {}, {})
+    g = Graph('foo', {})
     g.add_data_point(1, None)
     g.add_data_point(1, [1, float('nan')])
     g.add_data_point(2, [2, 2])
@@ -167,7 +167,7 @@ def test_summary_graph_loop():
     n = int(RESAMPLED_POINTS)
 
     # Resampling shouldn't get stuck in an infinite loop
-    g = Graph('foo', {}, {})
+    g = Graph('foo', {})
     for j in range(n):
         g.add_data_point(j, 0.1)
     g = make_summary_graph([g])
@@ -177,7 +177,7 @@ def test_summary_graph_loop():
     assert abs(data[0][1] - 0.1) < 1e-7
 
     # Resampling should work with long integers
-    g = Graph('foo', {}, {})
+    g = Graph('foo', {})
     k0 = 2**80
     for j in range(2*int(RESAMPLED_POINTS)):
         g.add_data_point(k0 + j, 0.1)

--- a/test/test_publish.py
+++ b/test/test_publish.py
@@ -113,4 +113,4 @@ def test_publish(tmpdir):
     index = util.load_json(join(tmpdir, 'html', 'index.json'))
     assert index['params']['branch'] == ['master', 'some-branch']
     assert index['params']['Cython'] == ['', None]
-    assert sorted(index['params']['ram']) == [8804682956.8, '8.2G']
+    assert index['params']['ram'] == ['8.2G', 8804682956.8]

--- a/test/test_publish.py
+++ b/test/test_publish.py
@@ -32,6 +32,7 @@ def test_publish(tmpdir):
     # Synthesize history with two branches that both have commits
     result_files = [fn for fn in os.listdir(join(RESULT_DIR, 'cheetah'))
                     if fn.endswith('.json') and fn != 'machine.json']
+    result_files.sort()
     master_values = list(range(len(result_files)*2//3))
     branch_values = list(range(len(master_values), len(result_files)))
     dvcs = tools.generate_test_repo(tmpdir, master_values, 'git',
@@ -78,11 +79,13 @@ def test_publish(tmpdir):
     assert isfile(join(tmpdir, 'html', 'asv.css'))
     assert not isdir(join(tmpdir, 'html', 'graphs', 'Cython', 'arch-x86_64',
                           'branch-some-branch'))
+    assert not isdir(join(tmpdir, 'html', 'graphs', 'Cython-null', 'arch-x86_64',
+                          'branch-some-branch'))
     index = util.load_json(join(tmpdir, 'html', 'index.json'))
     assert index['params']['branch'] == ['master']
 
-    def check_file(branch):
-        fn = join(tmpdir, 'html', 'graphs', 'Cython', 'arch-x86_64', 'branch-' + branch,
+    def check_file(branch, cython):
+        fn = join(tmpdir, 'html', 'graphs', cython, 'arch-x86_64', 'branch-' + branch,
                   'cpu-Intel(R) Core(TM) i5-2520M CPU @ 2.50GHz (4 cores)',
                   'machine-cheetah', 'numpy-1.8', 'os-Linux (Fedora 20)', 'python-2.7', 'ram-8.2G',
                   'time_coordinates.time_latitude.json')
@@ -94,15 +97,20 @@ def test_publish(tmpdir):
             # we set some dates negative for some-branch above
             assert any(x[0] < 0 for x in data) and any(x[0] >= 0 for x in data)
 
-    check_file("master")
+    check_file("master", "Cython")
+    check_file("master", "Cython-null")
 
     # Publish with branches set in the config
     conf.branches = ['master', 'some-branch']
     tools.run_asv_with_conf(conf, 'publish')
 
     # Check output
-    check_file("master")
-    check_file("some-branch")
+    check_file("master", "Cython")
+    check_file("master", "Cython-null")
+    check_file("some-branch", "Cython")
+    check_file("some-branch", "Cython-null")
 
     index = util.load_json(join(tmpdir, 'html', 'index.json'))
     assert index['params']['branch'] == ['master', 'some-branch']
+    assert index['params']['Cython'] == ['', None]
+    assert sorted(index['params']['ram']) == [8804682956.8, '8.2G']


### PR DESCRIPTION
Graph parameter handling needs to take into account that some parameter
keys can be missing in some of the result files. (E.g. as a result of
null entries in requirement matrix, or some requirements having been
added after some result files had already been generated.)

Deal with this as follows:

- In `asv publish`, for each missing key, assign None value in
  the corresponding graph.

- Make None translate to "null" in the graph file path.

- Fix parameter value sorting on Py3

- Update the JS side accordingly.

- Fix the JS parameter selector to deal with null

- Add additional tests

Fixes gh-385