### PR TITLE
Use git plumbing commands for more reliable machine readable output

### DIFF
--- a/asv/plugins/git.py
+++ b/asv/plugins/git.py
@@ -110,13 +110,12 @@ class Git(Repo):
             checkout_existing(display_error=True)
 
     def get_date(self, hash):
-        # TODO: This works on Linux, but should be extended for other platforms
         return int(self._run_git(
-            ['show', hash, '--quiet', '--format=format:%at'],
-            valid_return_codes=(0, 1), dots=False).strip().split()[0]) * 1000
+            ['rev-list', '-n', '1', '--format=%at', hash],
+            valid_return_codes=(0, 1), dots=False).strip().split()[-1]) * 1000
 
     def get_hashes_from_range(self, range_spec):
-        args = ['log', '--quiet', '--first-parent', '--format=format:%H']
+        args = ['rev-list', '--first-parent']
         if range_spec != "":
             args += range_spec.split()
         output = self._run_git(args, valid_return_codes=(0, 1), dots=False)

--- a/test/test_repo.py
+++ b/test/test_repo.py
@@ -129,6 +129,21 @@ def test_repo_git(tmpdir):
         Git.url_match = old_url_match
 
 
+def test_repo_git_annotated_tag_date(tmpdir):
+    tmpdir = six.text_type(tmpdir)
+
+    dvcs = tools.generate_test_repo(tmpdir, list(range(5)), dvcs_type='git')
+
+    conf = config.Config()
+    conf.project = 'sometest'
+    conf.repo = dvcs.path
+
+    r = repo.get_repo(conf)
+    d1 = r.get_date('tag1')
+    d2 = r.get_date(r.get_hash_from_name('tag1'))
+    assert d1 == d2
+
+
 @pytest.mark.skipif(hglib is None,
                     reason="needs hglib")
 def test_repo_hg(tmpdir):


### PR DESCRIPTION
Fixes gh-388

Checked the output is the same on git versions 1.7.10 (which exhibits the behavior that gh-358 attempted to fix previously) and 2.7.0