### PR TITLE
Fix hg branches

### DIFF
--- a/asv/plugins/mercurial.py
+++ b/asv/plugins/mercurial.py
@@ -80,13 +80,12 @@ class Hg(Repo):
 
     def get_new_range_spec(self, latest_result, branch=None):
         if branch is None:
-            return '{0}::tip'.format(latest_result)
-        else:
-            return '{0}::{1}'.format(latest_result, branch)
+            branch = "default"
+        return '{0}::{1}'.format(latest_result, branch)
 
     def get_branch_range_spec(self, branch):
         if branch is None:
-            branch = 'tip'
+            branch = 'default'
         return 'ancestors({0})'.format(branch)
 
     def pull(self):
@@ -132,7 +131,7 @@ class Hg(Repo):
         return self._repo.log(name)[0].node
 
     def get_hash_from_master(self):
-        return self.get_hash_from_name('tip')
+        return self.get_hash_from_name('default')
 
     def get_hash_from_parent(self, name):
         return self.get_hash_from_name('p1({0})'.format(name))

--- a/asv/plugins/mercurial.py
+++ b/asv/plugins/mercurial.py
@@ -125,7 +125,9 @@ class Hg(Repo):
         return int(rev.date.strftime("%s")) * 1000
 
     def get_hashes_from_range(self, range_spec):
-        return [rev.node for rev in self._repo.log(range_spec)]
+        range_spec = "sort({0}, -rev)".format(range_spec)
+        return [rev.node for rev in self._repo.log(range_spec,
+                                                   followfirst=True)]
 
     def get_hash_from_name(self, name):
         return self._repo.log(name)[0].node

--- a/asv/template/asv.conf.json
+++ b/asv/template/asv.conf.json
@@ -14,9 +14,9 @@
     "repo": "",
 
     // List of branches to benchmark. If not provided, defaults to "master"
-    // (for git) or "tip" (for mercurial).
+    // (for git) or "default" (for mercurial).
     // "branches": ["master"], // for git
-    // "branches": ["tip"],    // for mercurial
+    // "branches": ["default"],    // for mercurial
 
     // The DVCS being used.  If not set, it will be automatically
     // determined from "repo" by looking at the protocol in the URL

--- a/docs/source/asv.conf.json.rst
+++ b/docs/source/asv.conf.json.rst
@@ -53,7 +53,7 @@ Branches to generate benchmark results for.
 This controls how the benchmark results are displayed, and what
 benchmarks ``asv run ALL`` and ``asv run NEW`` run.
 
-If not provided, "master" (Git) or "tip" (Mercurial) is chosen.
+If not provided, "master" (Git) or "default" (Mercurial) is chosen.
 
 ``show_commit_url``
 -------------------

--- a/test/test_repo.py
+++ b/test/test_repo.py
@@ -144,8 +144,8 @@ def test_repo_hg(tmpdir):
     def test_it(is_remote=False):
         conf.project = mirror_dir
         conf.repo = dvcs.path
-        _test_generic_repo(conf, tmpdir, hash_range="tip:-4",
-                           master="tip", branch="tag5",
+        _test_generic_repo(conf, tmpdir, hash_range="reverse(default~3::default)",
+                           master="default", branch="tag5",
                            is_remote=is_remote)
 
         conf.branches = ['default', 'some-branch']


### PR DESCRIPTION
This is a series of fix to make the mercurial plugin behave like the git one.

  * Mercurial default branch is "default"
  * Only follow first parent on merges changesets

I added a test with merges that work for both mercurial & git backends.