### PR TITLE
mercurial: close subrepo after checkout

### DIFF
--- a/asv/plugins/mercurial.py
+++ b/asv/plugins/mercurial.py
@@ -104,9 +104,9 @@ class Hg(Repo):
         # the repository data is not shared
 
         def checkout_existing():
-            subrepo = hglib.open(path)
-            subrepo.pull()
-            subrepo.update(commit_hash, clean=True)
+            with hglib.open(path) as subrepo:
+                subrepo.pull()
+                subrepo.update(commit_hash, clean=True)
             # TODO: Implement purge manually or call it on the command line
 
         if os.path.isdir(path):


### PR DESCRIPTION
hglib repo must be closed explicitely to stop the underlying "hg serve"
subprocess.

Also remove what looks like an outdated TODO