### PR TITLE
Make Environments not store their own Repo objects

### DIFF
--- a/asv/benchmarks.py
+++ b/asv/benchmarks.py
@@ -267,7 +267,7 @@ class Benchmarks(dict):
     """
     api_version = 1
 
-    def __init__(self, conf, environments, benchmarks=None, regex=None):
+    def __init__(self, conf, repo, environments, benchmarks=None, regex=None):
         """
         Discover benchmarks in the given `benchmark_dir`.
 
@@ -275,6 +275,9 @@ class Benchmarks(dict):
         ----------
         conf : Config object
             The project's configuration
+
+        repo : Repo object
+            The project's repository
 
         environments : list of Environment
             List of environments available for benchmark discovery.
@@ -288,7 +291,7 @@ class Benchmarks(dict):
         self._benchmark_dir = conf.benchmark_dir
 
         if benchmarks is None:
-            benchmarks = self.disc_benchmarks(conf, environments)
+            benchmarks = self.disc_benchmarks(conf, repo, environments)
         else:
             benchmarks = six.itervalues(benchmarks)
 
@@ -304,7 +307,7 @@ class Benchmarks(dict):
                 self[benchmark['name']] = benchmark
 
     @classmethod
-    def disc_benchmarks(cls, conf, environments):
+    def disc_benchmarks(cls, conf, repo, environments):
         """
         Discover all benchmarks in a directory tree.
         """
@@ -329,7 +332,7 @@ class Benchmarks(dict):
         log.info("Discovering benchmarks")
         with log.indent():
             env.create()
-            env.install_project(conf)
+            env.install_project(conf, repo)
 
             result_file = tempfile.NamedTemporaryFile(delete=False)
             try:
@@ -404,7 +407,7 @@ class Benchmarks(dict):
         del self._all_benchmarks['version']
 
     @classmethod
-    def load(cls, conf, environments):
+    def load(cls, conf, repo, environments):
         """
         Load the benchmark descriptions from the `benchmarks.json` file.
         If the file is not found, one of the given `environments` will
@@ -414,13 +417,17 @@ class Benchmarks(dict):
         ----------
         conf : Config object
             The project's configuration
+        repo : Repo object
+            The project's repository (for benchmark discovery)
+        environments : list of Environment objects
+            Environments for benchmark discovery
 
         Returns
         -------
         benchmarks : Benchmarks object
         """
         def regenerate():
-            self = cls(conf, environments)
+            self = cls(conf, repo, environments)
             self.save()
             return self
 
@@ -436,7 +443,7 @@ class Benchmarks(dict):
             # version
             return regenerate()
 
-        return cls(conf, environments, benchmarks=d)
+        return cls(conf, repo, environments, benchmarks=d)
 
     def run_benchmarks(self, env, show_stderr=False, quick=False, profile=False,
                        skip=None):

--- a/asv/commands/find.py
+++ b/asv/commands/find.py
@@ -91,7 +91,7 @@ class Find(Command):
             log.error("No environments selected")
             return 1
 
-        benchmarks = Benchmarks(conf, environments, regex=bench)
+        benchmarks = Benchmarks(conf, repo, environments, regex=bench)
         if len(benchmarks) == 0:
             log.error("'{0}' benchmark not found".format(bench))
             return 1
@@ -119,7 +119,7 @@ class Find(Command):
                 "For {0} commit hash {1}:".format(
                     conf.project, commit_hash[:8]))
 
-            env.install_project(conf, commit_hash)
+            env.install_project(conf, repo, commit_hash)
             x = benchmarks.run_benchmarks(
                 env, show_stderr=show_stderr)
             result = list(x.values())[0]['result']

--- a/asv/commands/profiling.py
+++ b/asv/commands/profiling.py
@@ -141,7 +141,7 @@ class Profile(Command):
                                 # We need to checkout the correct commit so that
                                 # the line numbers in the profile data match up with
                                 # what's in the source tree.
-                                result.env.checkout_project(commit_hash)
+                                result.env.checkout_project(repo, commit_hash)
                                 checked_out.add(result.env.name)
                             profile_data = result.get_profile(benchmark)
                             break
@@ -165,7 +165,7 @@ class Profile(Command):
                     "Profiles must be run in the same version of Python as the "
                     "asv master process")
 
-            benchmarks = Benchmarks(conf, environments, regex='^{0}$'.format(benchmark))
+            benchmarks = Benchmarks(conf, repo, environments, regex='^{0}$'.format(benchmark))
             if len(benchmarks) != 1:
                 raise util.UserError(
                     "Could not find benchmark {0}".format(benchmark))
@@ -177,7 +177,7 @@ class Profile(Command):
             else:
                 log.info("Running profiler")
             with log.indent():
-                env.install_project(conf, commit_hash)
+                env.install_project(conf, repo, commit_hash)
 
                 results = benchmarks.run_benchmarks(
                     env, show_stderr=True, quick=False, profile=True)

--- a/asv/commands/publish.py
+++ b/asv/commands/publish.py
@@ -82,7 +82,8 @@ class Publish(Command):
             util.long_path_rmtree(conf.html_dir)
 
         environments = list(environment.get_environments(conf, env_spec))
-        benchmarks = Benchmarks.load(conf, environments)
+        repo = get_repo(conf)
+        benchmarks = Benchmarks.load(conf, repo, environments)
 
         template_dir = os.path.join(
             os.path.dirname(os.path.abspath(__file__)), '..', 'www')
@@ -98,7 +99,6 @@ class Publish(Command):
         log.step()
         log.info("Getting tags and branches")
         with log.indent():
-            repo = get_repo(conf)
             repo.pull()
             tags = {}
             for tag in repo.get_tags():

--- a/asv/commands/run.py
+++ b/asv/commands/run.py
@@ -25,10 +25,10 @@ from . import common_args
 
 
 def _do_build(args):
-    env, conf, commit_hash = args
+    env, conf, repo, commit_hash = args
     try:
         with log.set_level(logging.WARN):
-            env.install_project(conf, commit_hash)
+            env.install_project(conf, repo, commit_hash)
     except util.ProcessError:
         return False
     return True
@@ -179,7 +179,7 @@ class Run(Command):
                         "No range spec may be specified if benchmarking in "
                         "an existing environment")
 
-        benchmarks = Benchmarks(conf, environments, regex=bench)
+        benchmarks = Benchmarks(conf, repo, environments, regex=bench)
         if len(benchmarks) == 0:
             log.error("No benchmarks selected")
             return 1
@@ -239,7 +239,7 @@ class Run(Command):
                     log.info("Building for {0}".format(
                         ', '.join([x.name for x in subenv])))
                     with log.indent():
-                        args = [(env, conf, commit_hash) for env in subenv]
+                        args = [(env, conf, repo, commit_hash) for env in subenv]
                         if parallel != 1:
                             pool = multiprocessing.Pool(parallel)
                             try:

--- a/asv/wheel_cache.py
+++ b/asv/wheel_cache.py
@@ -71,7 +71,7 @@ class WheelCache(object):
             if os.path.isdir(path):
                 util.long_path_rmtree(path)
 
-    def build_project_cached(self, env, package, commit_hash):
+    def build_project_cached(self, env, package, repo, commit_hash):
         if self._wheel_cache_size == 0:
             return None
 
@@ -81,7 +81,7 @@ class WheelCache(object):
 
         self._cleanup_wheel_cache()
 
-        build_root = env.build_project(commit_hash)
+        build_root = env.build_project(repo, commit_hash)
         cache_path = self._create_wheel_cache_path(commit_hash)
 
         try:

--- a/test/test_benchmarks.py
+++ b/test/test_benchmarks.py
@@ -16,6 +16,7 @@ from asv import benchmarks
 from asv import config
 from asv import environment
 from asv import util
+from asv.repo import get_repo
 
 from . import tools
 
@@ -42,25 +43,27 @@ def test_find_benchmarks(tmpdir):
     d['repo'] = tools.generate_test_repo(tmpdir, [0]).path
     conf = config.Config.from_json(d)
 
+    repo = get_repo(conf)
+
     envs = list(environment.get_environments(conf, None))
 
-    b = benchmarks.Benchmarks(conf, envs, regex='secondary')
+    b = benchmarks.Benchmarks(conf, repo, envs, regex='secondary')
     assert len(b) == 3
 
-    b = benchmarks.Benchmarks(conf, envs, regex='example')
+    b = benchmarks.Benchmarks(conf, repo, envs, regex='example')
     assert len(b) == 22
 
-    b = benchmarks.Benchmarks(conf, envs, regex='time_example_benchmark_1')
+    b = benchmarks.Benchmarks(conf, repo, envs, regex='time_example_benchmark_1')
     assert len(b) == 2
 
-    b = benchmarks.Benchmarks(conf, envs, regex=['time_example_benchmark_1',
-                                                 'some regexp that does not match anything'])
+    b = benchmarks.Benchmarks(conf, repo, envs, regex=['time_example_benchmark_1',
+                                                       'some regexp that does not match anything'])
     assert len(b) == 2
 
-    b = benchmarks.Benchmarks(conf, envs)
+    b = benchmarks.Benchmarks(conf, repo, envs)
     assert len(b) == 26
 
-    b = benchmarks.Benchmarks(conf, envs)
+    b = benchmarks.Benchmarks(conf, repo, envs)
     times = b.run_benchmarks(envs[0], profile=True, show_stderr=True)
 
     assert len(times) == len(b)
@@ -135,10 +138,11 @@ def test_invalid_benchmark_tree(tmpdir):
     d['repo'] = tools.generate_test_repo(tmpdir, [0]).path
     conf = config.Config.from_json(d)
 
+    repo = get_repo(conf)
     envs = list(environment.get_environments(conf, None))
 
     with pytest.raises(util.UserError):
-        b = benchmarks.Benchmarks(conf, envs)
+        b = benchmarks.Benchmarks(conf, repo, envs)
 
 
 def test_table_formatting():
@@ -220,7 +224,8 @@ def track_this():
     d['repo'] = tools.generate_test_repo(tmpdir, [0]).path
     conf = config.Config.from_json(d)
 
+    repo = get_repo(conf)
     envs = list(environment.get_environments(conf, None))
 
-    b = benchmarks.Benchmarks(conf, envs, regex='track_this')
+    b = benchmarks.Benchmarks(conf, repo, envs, regex='track_this')
     assert len(b) == 1


### PR DESCRIPTION
Environment only needs to know about a Repo when it is building a
project. Pass the repository in as an argument when needed.

The actual issue this fixes is to avoid cloning the repository when it
is not necessary, for example in 'asv run --python=same'.
(The cloning in this case is a regression introduced in gh-352)

- [x] WIP: may still need some testing