### PR TITLE
Fix util.which for quoted path names on Windows

### DIFF
--- a/asv/util.py
+++ b/asv/util.py
@@ -223,7 +223,12 @@ def which(filename):
     if os.path.sep in filename:
         locations = ['']
     else:
-        locations = os.environ.get("PATH").split(os.pathsep)
+        locations = os.environ.get("PATH", "").split(os.pathsep)
+
+        if WIN:
+            # On windows, an entry in %PATH% may be quoted
+            locations = [path[1:-1] if len(path) > 2 and path[0] == path[-1] == '"' else path
+                         for path in locations]
 
     candidates = []
     for location in locations:

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -8,6 +8,7 @@ import io
 import locale
 import os
 import sys
+import shutil
 import pickle
 import multiprocessing
 import traceback
@@ -91,3 +92,25 @@ def test_write_unicode_to_ascii():
         assert buff.getvalue() == b'us\n'
     finally:
         locale.getpreferredencoding = original_getpreferredencoding
+
+
+def test_which_path(tmpdir):
+    dirname = os.path.abspath(os.path.join(str(tmpdir), 'name with spaces'))
+    fn = 'asv_test_exe_1234.exe'
+
+    os.makedirs(dirname)
+    shutil.copyfile(sys.executable, os.path.join(dirname, fn))
+
+    old_path = os.environ.get('PATH', '')
+    try:
+        if WIN:
+            os.environ['PATH'] = old_path + os.pathsep + '"' + dirname + '"'
+            util.which('asv_test_exe_1234')
+            util.which('asv_test_exe_1234.exe')
+
+        os.environ['PATH'] = old_path + os.pathsep + dirname
+        util.which('asv_test_exe_1234.exe')
+        if WIN:
+            util.which('asv_test_exe_1234')
+    finally:
+        os.environ['PATH'] = old_path


### PR DESCRIPTION
Directory names in %PATH% on Windows may be quoted, so ensure `util.which` understands that.