### PR TITLE
Drop Python 2.6 from appveyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,9 +10,6 @@ environment:
 
   matrix:
 
-      - PYTHON_VERSION: "2.6"
-        platform: x64
-        PYTHON_ARCH: "64"
       - PYTHON_VERSION: "2.7"
         platform: x64
         PYTHON_ARCH: "64"


### PR DESCRIPTION
Conda doesn't have colorama for py2.6 needed by tests.