### PR TITLE
Change install_timeout default value back to 600s

### DIFF
--- a/asv/config.py
+++ b/asv/config.py
@@ -34,7 +34,7 @@ class Config(object):
         self.show_commit_url = "#"
         self.hash_length = 8
         self.environment_type = None
-        self.install_timeout = 120
+        self.install_timeout = 600
         self.dvcs = None
         self.regressions_first_commits = {}
         self.plugins = []

--- a/asv/template/asv.conf.json
+++ b/asv/template/asv.conf.json
@@ -32,8 +32,8 @@
     "environment_type": "virtualenv",
 
     // timeout in seconds for installing any dependencies in environment
-    // defaults to 120 secs
-    //"install_timeout": 120,
+    // defaults to 10 min
+    //"install_timeout": 600,
 
     // the base URL to show a commit for the project.
     // "show_commit_url": "http://github.com/owner/project/commit/",

--- a/test/test_conf.py
+++ b/test/test_conf.py
@@ -31,7 +31,7 @@ def test_config():
 def test_config_default_install_timeout():
     # GH391
     conf = config.Config()
-    assert conf.install_timeout == 120
+    assert conf.install_timeout == 600
 
 
 class CustomCommand(Command):


### PR DESCRIPTION
This was changed from 600s to 120s in gh-392 without comment, so change it back (travis-ci has 600).

I suspect the config variable is not fully necessary, however, as the issue may have been due to https://github.com/pypa/pip/issues/3486