### PR TITLE
Fix config file path

### DIFF
--- a/asv/main.py
+++ b/asv/main.py
@@ -27,9 +27,11 @@ def main():
 
     log.enable(args.verbose)
 
+    args.config = os.path.abspath(args.config)
+
     # Use the path to the config file as the cwd for the remainder of
     # the run
-    dirname = os.path.dirname(os.path.abspath(args.config))
+    dirname = os.path.dirname(args.config)
     os.chdir(dirname)
 
     try:


### PR DESCRIPTION
Since 92373df310b838b12b10a00be7a6b38be3e17ee2 it wasn't possible to specify a config file outside of the current directory.