### PR TITLE
Fix default branch name for mercurial

### DIFF
--- a/asv/commands/publish.py
+++ b/asv/commands/publish.py
@@ -46,18 +46,6 @@ def check_benchmark_params(name, benchmark):
             raise ValueError(msg)
 
 
-def safe_branch_name(branch):
-    """
-    Convert a branch name to a string, dealing with the None default value
-    """
-    if branch is None:
-        # Occurs only if no branch is set in the configuration, and is
-        # not visible to the user.
-        return "master"
-    else:
-        return branch
-
-
 class Publish(Command):
     @classmethod
     def setup_arguments(cls, subparsers):
@@ -151,7 +139,7 @@ class Publish(Command):
                         if results.commit_hash in commits
                     ]:
                         cur_params = dict(results.params)
-                        cur_params['branch'] = safe_branch_name(branch)
+                        cur_params['branch'] = repo.get_branch_name(branch)
 
                         # Backward compatibility, see above
                         for param_key, param_value in list(cur_params.items()):
@@ -193,7 +181,7 @@ class Publish(Command):
             val = list(val)
             val.sort(key=lambda x: '[none]' if x is None else str(x))
             params[key] = val
-        params['branch'] = [safe_branch_name(branch) for branch in conf.branches]
+        params['branch'] = [repo.get_branch_name(branch) for branch in conf.branches]
         util.write_json(os.path.join(conf.html_dir, "index.json"), {
             'project': conf.project,
             'project_url': conf.project_url,

--- a/asv/plugins/git.py
+++ b/asv/plugins/git.py
@@ -18,6 +18,7 @@ from .. import util
 
 class Git(Repo):
     dvcs = "git"
+    _default_branch = "master"
 
     def __init__(self, url, mirror_path):
         self._git = util.which("git")
@@ -66,10 +67,7 @@ class Git(Repo):
         return util.check_output([self._git] + args, **kwargs)
 
     def get_new_range_spec(self, latest_result, branch=None):
-        if branch is None:
-            return '{0}..master'.format(latest_result)
-        else:
-            return '{0}..{1}'.format(latest_result, branch)
+        return '{0}..{1}'.format(latest_result, self.get_branch_name(branch))
 
     def get_range_spec(self, commit_a, commit_b):
         return '{0}..{1}'.format(commit_a, commit_b)
@@ -119,9 +117,6 @@ class Git(Repo):
         return self._run_git(['rev-parse', name],
                              dots=False).strip().split()[0]
 
-    def get_hash_from_master(self):
-        return self.get_hash_from_name('master')
-
     def get_hash_from_parent(self, name):
         return self.get_hash_from_name(name + '^')
 
@@ -133,6 +128,4 @@ class Git(Repo):
         return self.get_date(name + "^{commit}")
 
     def get_branch_commits(self, branch):
-        if branch is None:
-            branch = "master"
-        return self.get_hashes_from_range(branch)
+        return self.get_hashes_from_range(self.get_branch_name(branch))

--- a/asv/plugins/mercurial.py
+++ b/asv/plugins/mercurial.py
@@ -22,6 +22,7 @@ from .. import util
 
 class Hg(Repo):
     dvcs = "hg"
+    _default_branch = "default"
 
     def __init__(self, url, mirror_path):
         # TODO: shared repositories in Mercurial are only possible
@@ -79,9 +80,7 @@ class Hg(Repo):
         return '{0}::{1} and not {0}'.format(commit_a, commit_b, commit_a)
 
     def get_new_range_spec(self, latest_result, branch=None):
-        if branch is None:
-            branch = "default"
-        return '{0}::{1}'.format(latest_result, branch)
+        return '{0}::{1}'.format(latest_result, self.get_branch_name(branch))
 
     def pull(self):
         # We assume the remote isn't updated during the run of asv
@@ -128,9 +127,6 @@ class Hg(Repo):
     def get_hash_from_name(self, name):
         return self._repo.log(name)[0].node
 
-    def get_hash_from_master(self):
-        return self.get_hash_from_name('default')
-
     def get_hash_from_parent(self, name):
         return self.get_hash_from_name('p1({0})'.format(name))
 
@@ -141,6 +137,4 @@ class Hg(Repo):
         return self.get_date(name)
 
     def get_branch_commits(self, branch):
-        if branch is None:
-            branch = "default"
-        return self.get_hashes_from_range("ancestors({0})".format(branch))
+        return self.get_hashes_from_range("ancestors({0})".format(self.get_branch_name(branch)))

--- a/asv/repo.py
+++ b/asv/repo.py
@@ -14,6 +14,10 @@ class Repo(object):
 
     There are no commands that modify the source repository.
     """
+
+    # The default branch name when no branch is configured in asv.conf.json
+    _default_branch = None
+
     def __init__(self, url, mirror_path):
         """
         Create a mirror of the repository at `url`, without a working tree.
@@ -66,6 +70,16 @@ class Repo(object):
         """
         raise NotImplementedError()
 
+    def get_branch_name(self, branch=None):
+        """
+        Returns the given branch name or the default branch name if branch is
+        None or not specified.
+        """
+        if branch is None:
+            return self._default_branch
+        else:
+            return branch
+
     def get_range_spec(self, commit_a, commit_b):
         """
         Returns a formatted string giving the results between
@@ -105,7 +119,7 @@ class Repo(object):
         """
         Get the hash of the current master branch commit.
         """
-        raise NotImplementedError()
+        return self.get_hash_from_name(self.get_branch_name())
 
     def get_hash_from_parent(self, name):
         """
@@ -152,6 +166,7 @@ class NoRepository(Repo):
     """
 
     dvcs = "none"
+    _default_branch = "master"
 
     def __init__(self, url=None, path=None):
         self.url = None
@@ -177,9 +192,6 @@ class NoRepository(Repo):
 
     def get_hashes_from_range(self, range):
         return [None]
-
-    def get_hash_from_master(self):
-        return None
 
     def get_hash_from_name(self, name):
         return None

--- a/test/test_publish.py
+++ b/test/test_publish.py
@@ -143,14 +143,18 @@ def generate_result_dir(request, tmpdir):
         return conf, repo, commits
     return _generate_result_dir
 
-GRAPH_PATH = join("graphs", "branch-master", "machine-tarzan", "time_func.json")
-
+def _graph_path(dvcs_type):
+    if dvcs_type == "git":
+        master = "master"
+    elif dvcs_type == "hg":
+        master = "default"
+    return join("graphs", "branch-{0}".format(master), "machine-tarzan", "time_func.json")
 
 def test_regression_simple(generate_result_dir):
     conf, repo, commits = generate_result_dir(5 * [1] + 5 * [10])
     tools.run_asv_with_conf(conf, "publish")
     regressions = util.load_json(join(conf.html_dir, "regressions.json"))
-    expected = {"regressions": [["time_func", GRAPH_PATH, {}, None, [
+    expected = {"regressions": [["time_func", _graph_path(repo.dvcs), {}, None, [
         [[None, repo.get_date_from_name(commits[5])]], 10.0, 1.0,
     ]]]}
     assert regressions == expected
@@ -160,7 +164,7 @@ def test_regression_range(generate_result_dir):
     conf, repo, commits = generate_result_dir(5 * [1] + 6 * [10], commits_without_result=[5])
     tools.run_asv_with_conf(conf, "publish")
     regressions = util.load_json(join(conf.html_dir, "regressions.json"))
-    expected = {"regressions": [["time_func", GRAPH_PATH, {}, None, [
+    expected = {"regressions": [["time_func", _graph_path(repo.dvcs), {}, None, [
         [[repo.get_date_from_name(commits[4]), repo.get_date_from_name(commits[6])]], 10.0, 1.0,
     ]]]}
     assert regressions == expected
@@ -178,7 +182,7 @@ def test_regression_double(generate_result_dir):
     conf, repo, commits = generate_result_dir(5 * [1] + 5 * [10] + 5 * [15])
     tools.run_asv_with_conf(conf, "publish")
     regressions = util.load_json(join(conf.html_dir, "regressions.json"))
-    expected = {"regressions": [["time_func", GRAPH_PATH, {}, None, [
+    expected = {"regressions": [["time_func", _graph_path(repo.dvcs), {}, None, [
         [[None, repo.get_date_from_name(commits[5])], [None, repo.get_date_from_name(commits[10])]], 15.0, 1.0,
     ]]]}
     assert regressions == expected
@@ -202,7 +206,7 @@ def test_regression_first_commits(generate_result_dir):
     conf.regressions_first_commits = {"^time_*": commits[2]}
     tools.run_asv_with_conf(conf, "publish")
     regressions = util.load_json(join(conf.html_dir, "regressions.json"))
-    expected = {"regressions": [["time_func", GRAPH_PATH, {}, None, [
+    expected = {"regressions": [["time_func", _graph_path(repo.dvcs), {}, None, [
         [[None, repo.get_date_from_name(commits[5])]], 10.0, 1.0,
     ]]]}
     assert regressions == expected
@@ -216,13 +220,13 @@ def test_regression_parameterized(generate_result_dir):
     regressions = util.load_json(join(conf.html_dir, "regressions.json"))
     expected = {'regressions': [[
         'time_func(a)',
-        GRAPH_PATH,
+        _graph_path(repo.dvcs),
         {},
         0,
         [[[None, repo.get_date_from_name(commits[5])]], 6.0, 5.0],
     ], [
         'time_func(c)',
-        GRAPH_PATH,
+        _graph_path(repo.dvcs),
         {},
         2,
         [[[None, repo.get_date_from_name(commits[5])]], 10.0, 1.0],


### PR DESCRIPTION
This avoid potential error when using graph.params['branch'] as input of
Repo methods.