### PR TITLE
Implement "pretty_name" attribute on benchmark func

### DIFF
--- a/asv/benchmark.py
+++ b/asv/benchmark.py
@@ -266,6 +266,7 @@ class Benchmark(object):
         name = name.split('.', 1)[1]
         self.name = name
         self.func = func
+        self.pretty_name = getattr(func, "pretty_name", name)
         self._attr_sources = attr_sources
         self._setups = list(_get_all_attrs(attr_sources, 'setup', True))[::-1]
         self._teardowns = list(_get_all_attrs(attr_sources, 'teardown', True))

--- a/asv/www/graphdisplay.js
+++ b/asv/www/graphdisplay.js
@@ -225,7 +225,8 @@ $(document).ready(function() {
                 });
             }
 
-            var top = $('<li><a href="#' + bm_name + '">' + parts[parts.length - 1] + '</li>');
+            var name = bm.pretty_name || bm.name || parts[parts.length - 1];
+            var top = $('<li><a href="#' + bm_name + '">' + name + '</li>');
             stack[stack.length - 1].append(top);
 
             top.tooltip({

--- a/docs/source/writing_benchmarks.rst
+++ b/docs/source/writing_benchmarks.rst
@@ -187,6 +187,9 @@ The following attributes are applicable to all benchmark types:
 - ``timeout``: The amount of time, in seconds, to give the benchmark
   to run before forcibly killing it.  Defaults to 60 seconds.
 
+- ``pretty_name``: If given, used to display the benchmark name instead of the
+  benchmark function name.
+
 Parameterized benchmarks
 ------------------------
 


### PR DESCRIPTION
This optional parameter is printed in web UI instead of function name
allowing to use all characters set that would be avoided for a python
function name.

Closes #424