### PR TITLE
Add benchmark-specific start/end timestamps in the result files

### DIFF
--- a/asv/benchmarks.py
+++ b/asv/benchmarks.py
@@ -13,6 +13,7 @@ import shutil
 import sys
 import tempfile
 import itertools
+import datetime
 import pstats
 
 import six
@@ -98,6 +99,8 @@ def run_benchmark(benchmark, root, env, show_stderr=False,
         bad_output = None
         failure_count = 0
         total_count = 0
+
+        result['started_at'] = datetime.datetime.utcnow()
 
         for param_idx, params in param_iter:
             success, data, profile_data, err, out, errcode = \
@@ -187,6 +190,8 @@ def run_benchmark(benchmark, root, env, show_stderr=False,
             result['result'] = bench_results[0]
             if profile and bench_profiles[0] is not None:
                 result['profile'] = bench_profiles[0]
+
+        result['ended_at'] = datetime.datetime.utcnow()
 
         return result
 
@@ -531,7 +536,10 @@ class Benchmarks(dict):
 
                             for name, benchmark in benchmark_set:
                                 # TODO: Store more information about failure
-                                times[name] = {'result': None, 'stderr': err}
+                                times[name] = {'result': None,
+                                               'stderr': err,
+                                               'started_at': datetime.datetime.utcnow(),
+                                               'ended_at': datetime.datetime.utcnow()}
                             continue
 
                     for name, benchmark in benchmark_set:

--- a/asv/commands/rm.py
+++ b/asv/commands/rm.py
@@ -91,6 +91,10 @@ class Rm(Command):
                         count += 1
                         files_to_remove.add(result)
                         del result.results[benchmark]
+
+                        # Remove run times (may be missing in old files)
+                        result.started_at.pop(benchmark, None)
+                        result.ended_at.pop(benchmark, None)
             else:
                 files_to_remove.add(result)
 

--- a/asv/commands/run.py
+++ b/asv/commands/run.py
@@ -238,6 +238,7 @@ class Run(Command):
                 for subenv in util.iter_chunks(environments, parallel):
                     log.info("Building for {0}".format(
                         ', '.join([x.name for x in subenv])))
+
                     with log.indent():
                         args = [(env, conf, repo, commit_hash) for env in subenv]
                         if parallel != 1:
@@ -273,7 +274,8 @@ class Run(Command):
                             env.name)
 
                         for benchmark_name, d in six.iteritems(results):
-                            result.add_time(benchmark_name, d['result'])
+                            result.add_result(benchmark_name, d['result'],
+                                              d['started_at'], d['ended_at'])
                             if 'profile' in d:
                                 result.add_profile(
                                     benchmark_name,

--- a/asv/util.py
+++ b/asv/util.py
@@ -834,6 +834,13 @@ def datetime_to_timestamp(dt):
     return int(total_seconds(dt - datetime.datetime(1970, 1, 1)))
 
 
+def datetime_to_js_timestamp(dt):
+    """
+    Convert a Python datetime object to a Javascript timestamp.
+    """
+    return 1000 * datetime_to_timestamp(dt)
+
+
 def is_nan(x):
     """
     Returns `True` if x is a NaN value.

--- a/docs/source/dev.rst
+++ b/docs/source/dev.rst
@@ -126,6 +126,12 @@ A benchmark suite directory has the following layout.  The
           including failures in installing the project version. ``NaN``
           indicates a benchmark explicitly skipped by the benchmark suite.
 
+      - ``started_at``: A dictionary from benchmark names to Javascript
+        time stamps indicating the start time of the benchmark run.
+
+      - ``ended_at``: A dictionary from benchmark names to Javascript
+        time stamps indicating the end time of the benchmark run.
+
 - ``$html_dir/``: The output of ``asv publish``, that turns the raw
   results in ``$results_dir/`` into something viewable in a web
   browser.  It is an important feature of ``asv`` that the results can

--- a/test/example_results/cheetah/13dd6571-py2.7-Cython-numpy1.8.json
+++ b/test/example_results/cheetah/13dd6571-py2.7-Cython-numpy1.8.json
@@ -30,5 +30,11 @@
         "time_units.time_unit_to": 4.817538261413574e-05, 
         "time_units.time_very_simple_unit_parse": 1.186216115951538e-05
     }, 
+    "started_at": {
+        "time_quantity.time_quantity_array_conversion": 1
+    },
+    "ended_at": {
+        "time_quantity.time_quantity_array_conversion": 2
+    },
     "version": 1
 }

--- a/test/test_benchmarks.py
+++ b/test/test_benchmarks.py
@@ -8,6 +8,7 @@ import os
 import shutil
 from os.path import join, dirname
 
+import datetime
 import pstats
 import pytest
 import six
@@ -63,8 +64,12 @@ def test_find_benchmarks(tmpdir):
     b = benchmarks.Benchmarks(conf, repo, envs)
     assert len(b) == 26
 
+    start_timestamp = datetime.datetime.utcnow()
+
     b = benchmarks.Benchmarks(conf, repo, envs)
     times = b.run_benchmarks(envs[0], profile=True, show_stderr=True)
+
+    end_timestamp = datetime.datetime.utcnow()
 
     assert len(times) == len(b)
     assert times[
@@ -125,6 +130,12 @@ def test_find_benchmarks(tmpdir):
     # Calibration of iterations should not rerun setup
     expected = ['setup']*2
     assert times['time_examples.TimeWithRepeatCalibrate.time_it']['stderr'].split() == expected
+
+    # Check run time timestamps
+    for name, result in times.items():
+        assert result['started_at'] >= start_timestamp
+        assert result['ended_at'] >= result['started_at']
+        assert result['ended_at'] <= end_timestamp
 
 
 def test_invalid_benchmark_tree(tmpdir):

--- a/test/test_rm.py
+++ b/test/test_rm.py
@@ -33,6 +33,10 @@ def test_rm(tmpdir):
     for result in results_a:
         for key in six.iterkeys(result.results):
             assert not key.startswith('time_quantity')
+        for key in six.iterkeys(result.started_at):
+            assert not key.startswith('time_quantity')
+        for key in six.iterkeys(result.ended_at):
+            assert not key.startswith('time_quantity')
 
     tools.run_asv_with_conf(conf, 'rm', '-y', 'commit_hash=05d283b9')
 

--- a/test/tools.py
+++ b/test/tools.py
@@ -357,13 +357,15 @@ def generate_result_dir(tmpdir, dvcs, values, branches=None):
         'machine': 'tarzan',
     })
 
+    timestamp = datetime.datetime.utcnow()
+
     params = None
     for commit, value in values.items():
         if isinstance(value, dict):
             params = value["params"]
         result = Results({"machine": "tarzan"}, {}, commit,
                          repo.get_date_from_name(commit), "2.7", None)
-        result.add_time("time_func", value)
+        result.add_result("time_func", value, timestamp, timestamp)
         result.save(result_dir)
 
     util.write_json(join(result_dir, "benchmarks.json"), {


### PR DESCRIPTION
Record the time when a benchmark was run, on a per-benchmark basis. Working on a per-benchmark basis addresses issues arising if specific benchmarks have been rerun, in which case having a single date range for the whole file may not be indicative.

Alternative to gh-400