### PR TITLE
Handle benchmarks by commit revision instead of date

### DIFF
--- a/asv/plugins/git.py
+++ b/asv/plugins/git.py
@@ -128,11 +128,22 @@ class Git(Repo):
         return self.get_hash_from_name(name + '^')
 
     def get_tags(self):
-        return self._run_git(
-            ['tag', '-l']).strip().split()
+        tags = {}
+        for tag in self._run_git(["tag", "-l"]).splitlines():
+            tags[tag] = self._run_git(["rev-list", "-n", "1", tag]).strip()
+        return tags
 
     def get_date_from_name(self, name):
         return self.get_date(name + "^{commit}")
 
     def get_branch_commits(self, branch):
         return self.get_hashes_from_range(self.get_branch_name(branch))
+
+    def get_revisions(self, commits):
+        revisions = {}
+        for i, commit in enumerate(self._run_git([
+            "rev-list", "--all", "--date-order", "--reverse",
+        ]).splitlines()):
+            if commit in commits:
+                revisions[commit] = i
+        return revisions

--- a/asv/plugins/mercurial.py
+++ b/asv/plugins/mercurial.py
@@ -133,10 +133,20 @@ class Hg(Repo):
         return self.get_hash_from_name('p1({0})'.format(name))
 
     def get_tags(self):
-        return [item[0] for item in self._repo.tags()]
+        tags = {}
+        for item in self._repo.log("tag()"):
+            tags[item.tags] = item.node
+        return tags
 
     def get_date_from_name(self, name):
         return self.get_date(name)
 
     def get_branch_commits(self, branch):
         return self.get_hashes_from_range("ancestors({0})".format(self.get_branch_name(branch)))
+
+    def get_revisions(self, commits):
+        revisions = {}
+        for i, item in enumerate(self._repo.log("all()")):
+            if item.node in commits:
+                revisions[item.node] = i
+        return revisions

--- a/asv/publishing.py
+++ b/asv/publishing.py
@@ -14,5 +14,5 @@ class OutputPublisher(object):
     description = None
 
     @classmethod
-    def publish(cls, conf, repo, benchmarks, graphs, hash_to_date):
+    def publish(cls, conf, repo, benchmarks, graphs, revisions):
         pass

--- a/asv/repo.py
+++ b/asv/repo.py
@@ -123,7 +123,8 @@ class Repo(object):
 
     def get_tags(self):
         """
-        Get a list of all of the tags defined in the repo.
+        Get a dict of all of the tags defined in the repo and their
+        corresponding commit hash
         """
         raise NotImplementedError()
 
@@ -194,7 +195,7 @@ class NoRepository(Repo):
         self._raise_error()
 
     def get_tags(self):
-        return []
+        return {}
 
     def get_date_from_name(self, name):
         self._raise_error()

--- a/asv/www/asv.js
+++ b/asv/www/asv.js
@@ -322,13 +322,25 @@ $(document).ready(function() {
         }
     }
 
-    function get_commit_hash(date) {
-        var commit_hash = master_json.date_to_hash[date];
+    function get_commit_hash(revision) {
+        var commit_hash = master_json.revision_to_hash[revision];
         if (commit_hash) {
             // Return printable commit hash
             commit_hash = commit_hash.slice(0, master_json.hash_length);
         }
         return commit_hash;
+    }
+
+    function get_revision(commit_hash) {
+        var rev = null;
+        $.each(master_json.revision_to_hash, function(revision, full_commit_hash) {
+            if (full_commit_hash.startsWith(commit_hash)) {
+                rev = revision;
+                // break the $.each loop
+                return false;
+            }
+        });
+        return rev;
     }
 
     function init() {
@@ -378,6 +390,7 @@ $(document).ready(function() {
     this.param_selection_from_flat_idx = param_selection_from_flat_idx;
     this.load_graph_data = load_graph_data;
     this.get_commit_hash = get_commit_hash;
+    this.get_revision = get_revision;
 
     this.network_error = network_error;
 

--- a/asv/www/index.html
+++ b/asv/www/index.html
@@ -124,8 +124,13 @@
               </a>
               <a id="even-spacing" class="btn btn-default btn-xs" role="button"
                  data-toggle="tooltip" data-placement="right"
-                 title="Space commits evenly, rather than by date, along the x-axis">
+                 title="Space commits evenly, rather than by revision, along the x-axis">
                 even commit spacing
+              </a>
+              <a id="date-scale" class="btn btn-default btn-xs" role="button"
+                 data-toggle="tooltip" data-placement="right"
+                 title="Space commits by commit date along the x-axis">
+                date scale
               </a>
             </div>
           </div>

--- a/docs/source/dev.rst
+++ b/docs/source/dev.rst
@@ -147,8 +147,12 @@ A benchmark suite directory has the following layout.  The
     - ``benchmarks``: A dictionary of benchmarks.  At the moment, this
       is identical to the content in ``$results_dir/benchmarks.json``.
 
-    - ``date_to_hash``: A dictionary mapping Javascript date stamps to
-      commit hashes.  This allows the x-scale of a plot to be scaled
+    - ``revision_to_hash``: A dictionary mapping revision number to commit
+      hash. This allows to show commits tooltip in graph and commits involved
+      in a regression.
+
+    - ``revision_to_date``: A dictionary mapping Javascript date stamps to
+      revisions (including tags).  This allows the x-scale of a plot to be scaled
       by date.
 
     - ``machines``: Describes the machines used for testing.
@@ -157,7 +161,7 @@ A benchmark suite directory has the following layout.  The
       results can be selected.  Each entry is a list of valid values
       for that parameter.
 
-    - ``tags``: A dictionary of git tags and their dates, so this
+    - ``tags``: A dictionary of git tags and their revisions, so this
       information can be displayed in the plot.
 
   - ``graphs/``: This is a nested tree of directories where each level

--- a/test/test_graph.py
+++ b/test/test_graph.py
@@ -163,6 +163,20 @@ def test_nan():
     assert data == [(1, [1, None]), (2, [2, 2])]
 
 
+def test_summary_graph():
+    n = 2 * int(RESAMPLED_POINTS)
+    g = Graph('foo', {})
+    for i in range(n):
+        g.add_data_point(i, 0.1)
+        g.add_data_point(n + i, 0.2)
+    g = make_summary_graph([g])
+    data = g.get_data()
+    assert len(data) == 512
+    for i in range(256):
+        assert abs(data[i][1] - 0.1) < 1e-7
+        assert abs(data[256 + i][1] - 0.2) < 1e-7
+
+
 def test_summary_graph_loop():
     n = int(RESAMPLED_POINTS)
 
@@ -175,14 +189,6 @@ def test_summary_graph_loop():
     assert len(data) == 1
     assert data[0][0] == n
     assert abs(data[0][1] - 0.1) < 1e-7
-
-    # Resampling should work with long integers
-    g = Graph('foo', {})
-    k0 = 2**80
-    for j in range(2*int(RESAMPLED_POINTS)):
-        g.add_data_point(k0 + j, 0.1)
-    g = make_summary_graph([g])
-    g.get_data()
 
 
 def _sgn(x):

--- a/test/test_web.py
+++ b/test/test_web.py
@@ -151,7 +151,7 @@ def test_web_regressions(browser, tmpdir):
 
         href = regression_1.get_attribute('href')
         assert '/#params_examples.track_find_test?' in href
-        assert 'time=' in href
+        assert 'commits=' in href
 
         # Sort the tables vs. benchmark name (PhantomJS doesn't allow doing it via actionchains)
         browser.execute_script("$('thead th').eq(0).stupidsort('asc')")

--- a/test/test_workflow.py
+++ b/test/test_workflow.py
@@ -107,7 +107,7 @@ def test_run_publish(capfd, basic_conf):
     with open(filename, 'r') as fp:
         data = json.load(fp)
         assert len(data) == 2
-        assert isinstance(data[0][0], six.integer_types)  # date
+        assert isinstance(data[0][0], six.integer_types)  # revision
         assert len(data[0][1]) == 3
         assert len(data[1][1]) == 3
         assert isinstance(data[0][1][0], float)


### PR DESCRIPTION
Commits date are not necessary monotonic along the commit log,
especially if working with rebase workflow (instead of merge), this
generate false positive or missed regression detection and unwanted
peaks in the web UI.

This patch introduce a revision number as a drop-in replacement of
commit date. This revision number is an incremental number representing
the number of ancestors commits.

In the web UI the distance between commits is the number of commits
between them. Commits can still be displayed by date using the date
selector.

Closes #390