### PR TITLE
Use configured branches when no commit/range is specified

### DIFF
--- a/asv/commands/continuous.py
+++ b/asv/commands/continuous.py
@@ -32,7 +32,7 @@ class Continuous(Command):
             parent of the tested commit.""")
         parser.add_argument(
             'branch', default=None,
-            help="""The commit/branch to test. By default, the master branch.""")
+            help="""The commit/branch to test. By default, the first configured branch.""")
         common_args.add_factor(parser)
         common_args.add_show_stderr(parser)
         common_args.add_bench(parser)
@@ -57,9 +57,9 @@ class Continuous(Command):
         repo.pull()
 
         if branch is None:
-            head = repo.get_hash_from_master()
-        else:
-            head = repo.get_hash_from_name(branch)
+            branch = conf.branches[0]
+        head = repo.get_hash_from_name(branch)
+
         if base is None:
             parent = repo.get_hash_from_parent(head)
         else:

--- a/asv/commands/profiling.py
+++ b/asv/commands/profiling.py
@@ -120,9 +120,8 @@ class Profile(Command):
 
         machine_name = Machine.get_unique_machine_name()
         if revision is None:
-            commit_hash = repo.get_hash_from_master()
-        else:
-            commit_hash = repo.get_hash_from_name(revision)
+            revision = conf.branches[0]
+        commit_hash = repo.get_hash_from_name(revision)
 
         profile_data = None
         checked_out = set()

--- a/asv/commands/run.py
+++ b/asv/commands/run.py
@@ -63,7 +63,7 @@ class Run(Command):
             machine.  'ALL' will benchmark all commits in the project.
             'EXISTING' will benchmark against all commits for which
             there are existing benchmarks on any machine. By default,
-            will benchmark the head of the current master branch.""")
+            will benchmark the head each configured branches.""")
         parser.add_argument(
             "--steps", "-s", type=common_args.positive_int, default=None,
             help="""Maximum number of steps to benchmark.  This is
@@ -145,7 +145,7 @@ class Run(Command):
         repo.pull()
 
         if range_spec is None:
-            commit_hashes = [repo.get_hash_from_master()]
+            commit_hashes = set([repo.get_hash_from_name(branch) for branch in conf.branches])
         elif range_spec == 'EXISTING':
             commit_hashes = get_existing_hashes(conf.results_dir)
         elif range_spec == "NEW":

--- a/asv/environment.py
+++ b/asv/environment.py
@@ -487,12 +487,12 @@ class Environment(object):
         Uninstalls any installed copy of the project first.
         If no specific commit hash is given, one is chosen;
         either a choice that already exist in wheel cache,
-        or current master branch in the repository.
+        or first current branch configured.
         """
         if commit_hash is None:
             commit_hash = self._cache.get_existing_commit_hash()
             if commit_hash is None:
-                commit_hash = repo.get_hash_from_master()
+                commit_hash = repo.get_hash_from_name(conf.branches[0])
 
         self.uninstall(conf.project)
 

--- a/asv/plugins/git.py
+++ b/asv/plugins/git.py
@@ -114,6 +114,8 @@ class Git(Repo):
         return output.strip().split()
 
     def get_hash_from_name(self, name):
+        if name is None:
+            name = self.get_branch_name()
         return self._run_git(['rev-parse', name],
                              dots=False).strip().split()[0]
 

--- a/asv/plugins/mercurial.py
+++ b/asv/plugins/mercurial.py
@@ -125,6 +125,8 @@ class Hg(Repo):
                                                    followfirst=True)]
 
     def get_hash_from_name(self, name):
+        if name is None:
+            name = self.get_branch_name()
         return self._repo.log(name)[0].node
 
     def get_hash_from_parent(self, name):

--- a/asv/repo.py
+++ b/asv/repo.py
@@ -115,12 +115,6 @@ class Repo(object):
         """
         raise NotImplementedError()
 
-    def get_hash_from_master(self):
-        """
-        Get the hash of the current master branch commit.
-        """
-        return self.get_hash_from_name(self.get_branch_name())
-
     def get_hash_from_parent(self, name):
         """
         Checkout the parent of the currently checked out commit.


### PR DESCRIPTION
Fix behavior of run, profiling and continuous commands that were using
get_hash_from_master() instead of configured branches when no commit was
specified.

In particular when only one branch was configured and was not "master",
asv tried to use the "master" branch.

Add (and refactor) specific test.

Closes #364 
Alternative to #387