### PR TITLE
Refactor location of step detection in publish stage

### DIFF
--- a/asv/commands/publish.py
+++ b/asv/commands/publish.py
@@ -6,6 +6,7 @@ from __future__ import (absolute_import, division, print_function,
 
 import os
 import shutil
+import multiprocessing
 
 import six
 
@@ -74,7 +75,7 @@ class Publish(Command):
         machines = {}
         benchmark_names = set()
 
-        log.set_nitems(5 + len(list(util.iter_subclasses(OutputPublisher))))
+        log.set_nitems(6 + len(list(util.iter_subclasses(OutputPublisher))))
 
         if os.path.exists(conf.html_dir):
             util.long_path_rmtree(conf.html_dir)
@@ -165,6 +166,16 @@ class Publish(Command):
                 if 'summary' not in graph.params:
                     if graph.params not in graph_param_list:
                         graph_param_list.append(graph.params)
+
+        log.step()
+        log.info("Detecting steps")
+        with log.indent():
+            n_processes = multiprocessing.cpu_count()
+            pool = multiprocessing.Pool(n_processes)
+            try:
+                graphs.detect_steps(pool, dots=log.dot)
+            finally:
+                pool.terminate()
 
         log.step()
         log.info("Generating graphs")

--- a/asv/plugins/regressions.py
+++ b/asv/plugins/regressions.py
@@ -35,55 +35,37 @@ class Regressions(OutputPublisher):
         data_filter = _GraphDataFilter(conf, repo, revisions)
 
         all_params = graphs.get_params()
-        last_percentage_time = time.time()
 
-        n_processes = multiprocessing.cpu_count()
-        pool = multiprocessing.Pool(n_processes)
-        try:
-            results = []
-            for j, (file_name, graph) in enumerate(graphs):
-                if 'summary' in graph.params:
-                    continue
+        for j, (file_name, graph) in enumerate(graphs):
+            if 'summary' in graph.params:
+                continue
 
-                # Print progress status
-                log.add('.')
-                if time.time() - last_percentage_time > 5:
-                    log.add('{0:.0f}%'.format(100*j/len(graphs)))
-                    last_percentage_time = time.time()
+            benchmark_name = os.path.basename(file_name)
+            benchmark = benchmarks.get(benchmark_name)
+            if not benchmark:
+                continue
 
-                benchmark_name = os.path.basename(file_name)
-                benchmark = benchmarks.get(benchmark_name)
-                if not benchmark:
-                    continue
+            log.add('.')
 
-                graph_data = data_filter.get_graph_data(graph, benchmark)
-                for data in graph_data:
-                    results.append((pool.apply_async(_analyze_data, (data,), {}), graph))
-
-                while len(results) > n_processes:
-                    r, graph = results.pop(0)
-                    cls._insert_regression(regressions, seen, revision_to_hash, repo, all_params,
-                                           r.get(), graph)
-
-            while results:
-                r, graph = results.pop(0)
-                cls._insert_regression(regressions, seen, revision_to_hash, repo, all_params,
-                                       r.get(), graph)
-        finally:
-            pool.terminate()
+            for graph_data in data_filter.get_graph_data(graph, benchmark):
+                cls._process_regression(regressions, seen, revision_to_hash, repo, all_params,
+                                        graph_data, graph)
 
         cls._save(conf, {'regressions': regressions})
 
     @classmethod
-    def _insert_regression(cls, regressions, seen, revision_to_hash, repo, all_params,
-                           result_item, graph):
-        j, entry_name, result = result_item
+    def _process_regression(cls, regressions, seen, revision_to_hash, repo, all_params,
+                           graph_data, graph):
+        j, entry_name, steps = graph_data
 
-        if result is None:
+        v, best_v, jumps = detect_regressions(steps)
+
+        if v is None:
             return
 
+        result = (jumps, v, best_v)
+
         # Check which ranges are a single commit
-        jumps = result[0]
         for k, jump in enumerate(jumps):
             commit_a = revision_to_hash[jump[0]]
             commit_b = revision_to_hash[jump[1]]
@@ -120,43 +102,6 @@ class Regressions(OutputPublisher):
         util.write_json(fn, data)
 
 
-def _analyze_data(graph_data):
-    """
-    Analyze a single series
-
-    Returns
-    -------
-    jumps : list of (revision_a, revision_b)
-         List of revision pairs, between which there is an upward jump
-         in the value.
-    cur_value : int
-         Most recent value
-    best_value : int
-         Best value
-    """
-    try:
-        j, entry_name, revisions, values = graph_data
-
-        steps = detect_steps(values)
-        v, best_v, jump_pos = detect_regressions(steps)
-        if v is None:
-            return j, entry_name, None
-
-        jumps = []
-        for jump_r in jump_pos:
-            for r in range(jump_r + 1, len(values)):
-                if values[r] is not None:
-                    next_r = r
-                    break
-            else:
-                next_r = jump_r + 1
-            jumps.append((revisions[jump_r], revisions[next_r]))
-
-        return j, entry_name, (jumps, v, best_v)
-    except BaseException as exc:
-        raise util.ParallelFailure(str(exc), exc.__class__, traceback.format_exc())
-
-
 class _GraphDataFilter(object):
     """
     Obtain data sets from graphs, following configuration settings.
@@ -166,7 +111,7 @@ class _GraphDataFilter(object):
         self.conf = conf
         self.repo = repo
         self.revisions = revisions
-        self.revision_sets = {}
+        self._start_revisions = {}
 
     def get_graph_data(self, graph, benchmark):
         """
@@ -180,40 +125,41 @@ class _GraphDataFilter(object):
         entry_name
             Name for the data set. If benchmark is non-parameterized, this is the
             benchmark name.
-        revisions
-            List of revisions (ints)
-        values
-            List of benchmark values (floats or Nones)
+        steps
+            Steps to consider in regression detection.
 
         """
-        series = graph.get_data()
-
         if benchmark.get('params'):
-            param_iter = enumerate(itertools.product(*benchmark['params']))
+            param_iter = enumerate(zip(itertools.product(*benchmark['params']),
+                                           graph.get_steps()))
         else:
-            param_iter = [(None, None)]
+            param_iter = [(None, (None, graph.get_steps()))]
 
-        for j, param in param_iter:
+        for j, (param, steps) in param_iter:
             if param is None:
                 entry_name = benchmark['name']
             else:
                 entry_name = benchmark['name'] + '({0})'.format(', '.join(param))
 
-            revision_set = self._get_allowed_revisions(graph, benchmark, entry_name)
+            start_revision = self._get_start_revision(graph, benchmark, entry_name)
 
-            times = [item[0] for item in series if item[0] in revision_set]
-            if param is None:
-                values = [item[1] for item in series if item[0] in revision_set]
-            else:
-                values = [item[1][j] for item in series if item[0] in revision_set]
+            if start_revision is None:
+                # Skip detection
+                continue
 
-            yield j, entry_name, times, values
+            steps = [step for step in steps if step[1] >= start_revision]
 
-    def _get_allowed_revisions(self, graph, benchmark, entry_name):
+            yield j, entry_name, steps
+
+    def _get_start_revision(self, graph, benchmark, entry_name):
         """
-        Compute the set of revisions allowed by asv.conf.json.
+        Compute the first revision allowed by asv.conf.json.
+
+        Revisions correspond to linearized commit history and the
+        regression detection runs on this order --- the starting commit
+        thus corresponds to a specific starting revision.
         """
-        revision_set = set(self.revisions.values())
+        start_revision = min(six.itervalues(self.revisions))
 
         if graph.params.get('branch'):
             branch_suffix = '@' + graph.params.get('branch')
@@ -224,23 +170,28 @@ class _GraphDataFilter(object):
             if re.match(regex, entry_name + branch_suffix):
                 if start_commit is None:
                     # Disable regression detection completely
-                    return set()
+                    return None
 
                 if self.conf.branches == [None]:
                     key = (start_commit, None)
                 else:
                     key = (start_commit, graph.params.get('branch'))
 
-                if key not in self.revision_sets:
-                    revs = set()
+                if key not in self._start_revisions:
                     spec = self.repo.get_new_range_spec(*key)
                     start_hash = self.repo.get_hash_from_name(start_commit)
+
                     for commit in [start_hash] + self.repo.get_hashes_from_range(spec):
                         rev = self.revisions.get(commit)
                         if rev is not None:
-                            revs.add(rev)
-                    self.revision_sets[key] = revs
+                            self._start_revisions[key] = rev
+                            break
+                    else:
+                        # Commit not found in the branch --- warn and ignore.
+                        log.warn(("Commit {0} specified in `regressions_first_commits` "
+                                  "not found in branch").format(start_commit))
+                        self._start_revisions[key] = -1
 
-                revision_set = revision_set.intersection(self.revision_sets[key])
+                start_revision = max(start_revision, self._start_revisions[key] + 1)
 
-        return revision_set
+        return start_revision

--- a/asv/plugins/regressions.py
+++ b/asv/plugins/regressions.py
@@ -13,7 +13,7 @@ import six
 
 from ..console import log
 from ..publishing import OutputPublisher
-from ..step_detect import detect_regressions
+from ..step_detect import detect_regressions, detect_steps
 
 from .. import util
 
@@ -78,6 +78,7 @@ class Regressions(OutputPublisher):
     def _insert_regression(cls, regressions, seen, revision_to_hash, repo, all_params,
                            result_item, graph):
         j, entry_name, result = result_item
+
         if result is None:
             return
 
@@ -136,7 +137,8 @@ def _analyze_data(graph_data):
     try:
         j, entry_name, revisions, values = graph_data
 
-        v, jump_pos, best_v = detect_regressions(values)
+        steps = detect_steps(values)
+        v, best_v, jump_pos = detect_regressions(steps)
         if v is None:
             return j, entry_name, None
 

--- a/test/test_graph.py
+++ b/test/test_graph.py
@@ -191,5 +191,26 @@ def test_summary_graph_loop():
     assert abs(data[0][1] - 0.1) < 1e-7
 
 
+def test_graph_steps():
+    vals = [(1, 1), (5, 1), (6, 1), (7, 1), (8, 1),
+            (11, 2), (15, 2), (16, 2.001), (17, 2), (18, 2)]
+
+    g = Graph('foo', {})
+    for x, y in vals:
+        g.add_data_point(x, y)
+
+    steps = g.get_steps()
+    lastval = steps[1][4]
+    assert abs(lastval - 0.001/5.0) < 1e-10
+    assert steps == [(1, 8+1, 1.0, 1.0, 0), (11, 18+1, 2.0, 2.0, lastval)]
+
+    multi_g = Graph('foo', {})
+    for x, y in vals:
+        multi_g.add_data_point(x, [y, y, y])
+
+    for s in multi_g.get_steps():
+        assert s == steps
+
+
 def _sgn(x):
     return 1 if x >= 0 else -1

--- a/test/test_step_detect.py
+++ b/test/test_step_detect.py
@@ -120,8 +120,9 @@ def test_detect_regressions():
         assert np.allclose(steps_err, [0.7/4]*7, rtol=0.3)
 
         # Check detect_regressions
-        new_value, best_value, jump_pos = detect_regressions(steps)
-        assert jump_pos == [3233 + (seed % 123), 3499 + (seed % 71)]
+        new_value, best_value, regression_pos = detect_regressions(steps)
+        assert regression_pos == [(3233 + (seed % 123), (3233 + (seed % 123) + 1)),
+                                  (3499 + (seed % 71), 3499 + (seed % 71) + 1)]
         assert np.allclose(best_value, 0.7/2 - 0.3, rtol=0.3, atol=0)
         assert np.allclose(new_value, 0.7/2 - 0.3 + 2, rtol=0.3, atol=0)
 


### PR DESCRIPTION
Split regression detection to two stages: (i) fitting piecewise constant functions to graphs, and (ii) analyzing the results of the fit and producing output json files.  Also move stage (i) to be done inside the Graph objects, and move the computation earlier in the Publish command.

The motivation here is that the piecewise fits are in 1-1 correspondence with the graphs in any case, so associating the data directly with them clarifies the code somewhat. Also, other parts of Publish may also need to access the piecewise fit results, which are expensive to recompute --- for example if we e.g. want to revise the summary page to display some aggregate information of how benchmark results have changed lately.

I think this approach clarifies the code, but we can also postpone this until something actually needs this.