### PR TITLE
Revised/additional summary page

### DIFF
--- a/asv/commands/publish.py
+++ b/asv/commands/publish.py
@@ -180,18 +180,18 @@ class Publish(Command):
         log.step()
         log.info("Generating graphs")
         with log.indent():
-            # Add summary graphs
-            graphs.make_summary_graphs(dots=log.dot)
             # Save files
             graphs.save(conf.html_dir, dots=log.dot)
 
-        extra_pages = []
-        for cls in util.iter_subclasses(OutputPublisher):
+        pages = []
+        classes = sorted(util.iter_subclasses(OutputPublisher),
+                         key=lambda cls: cls.order)
+        for cls in classes:
             log.step()
-            log.info("Generating output for {0}".format(cls.name))
+            log.info("Generating output for {0}".format(cls.__name__))
             with log.indent():
                 cls.publish(conf, repo, benchmarks, graphs, revisions)
-                extra_pages.append([cls.name, cls.button_label, cls.description])
+                pages.append([cls.name, cls.button_label, cls.description])
 
         log.step()
         log.info("Writing index")
@@ -216,5 +216,5 @@ class Publish(Command):
             'benchmarks': benchmark_map,
             'machines': machines,
             'tags': tags,
-            'extra_pages': extra_pages,
+            'pages': pages,
         })

--- a/asv/graph.py
+++ b/asv/graph.py
@@ -37,6 +37,9 @@ class GraphSet(object):
             self._groups.setdefault(benchmark_name, []).append(graph)
         return self._graphs[graph.path]
 
+    def get_graph_group(self, benchmark_name):
+        return self._groups.get(benchmark_name, [])
+
     def get_params(self):
         """Return all params used in graphs and their corresponding values set"""
         params = {}
@@ -104,10 +107,20 @@ class Graph(object):
         self.params = params
         self.data_points = {}
 
+        self.path = self.get_file_path(self.params, benchmark_name)
+        self.n_series = None
+        self.scalar_series = True
+        self._steps = None
+
+    @classmethod
+    def get_file_path(cls, params, benchmark_name):
+        """
+        Get a file path understood by the JS frontend, corresponding
+        on the given parameters and benchmark_name.
+        """
         # TODO: Make filename safe
         parts = ['graphs']
-
-        l = list(six.iteritems(self.params))
+        l = list(six.iteritems(params))
         l.sort()
         for key, val in l:
             if val is None:
@@ -117,11 +130,7 @@ class Graph(object):
             else:
                 parts.append('{0}'.format(key))
         parts.append(benchmark_name)
-
-        self.path = os.path.join(*parts)
-        self.n_series = None
-        self.scalar_series = True
-        self._steps = None
+        return os.path.join(*parts)
 
     def add_data_point(self, revision, value):
         """
@@ -227,7 +236,7 @@ class Graph(object):
 
         if not val:
             # Nothing to compute
-            self._steps = [[]*self.n_series]
+            self._steps = [[]]*self.n_series
             return
 
         if self.scalar_series:

--- a/asv/graph.py
+++ b/asv/graph.py
@@ -59,10 +59,9 @@ class GraphSet(object):
             if dots is not None and pool is not None:
                 dots()
 
-    def make_summary_graphs(self, dots=None):
+    def get_summary_graphs(self, dots=None):
         for graphs in six.itervalues(self._groups):
-            graph = make_summary_graph(graphs)
-            self._graphs[graph.path] = graph
+            yield make_summary_graph(graphs)
             if dots is not None:
                 dots()
 

--- a/asv/plugins/regressions.py
+++ b/asv/plugins/regressions.py
@@ -27,6 +27,7 @@ class Regressions(OutputPublisher):
     name = "regressions"
     button_label = "Show regressions"
     description = "Display information about recent regressions"
+    order = 3
 
     @classmethod
     def publish(cls, conf, repo, benchmarks, graphs, revisions):

--- a/asv/plugins/summarygrid.py
+++ b/asv/plugins/summarygrid.py
@@ -1,0 +1,21 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+# -*- coding: utf-8 -*-
+
+from __future__ import absolute_import, division, unicode_literals, print_function
+
+from ..console import log
+from ..publishing import OutputPublisher
+
+
+class SummaryGrid(OutputPublisher):
+    name = ""
+    button_label = "Grid view"
+    description = "Display as a agrid"
+    order = 0
+
+    @classmethod
+    def publish(cls, conf, repo, benchmarks, graphs, revisions):
+        # Generate and save summary graphs
+        summaries = graphs.get_summary_graphs(dots=log.dot)
+        for graph in summaries:
+            graph.save(conf.html_dir)

--- a/asv/plugins/summarylist.py
+++ b/asv/plugins/summarylist.py
@@ -1,0 +1,116 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+# -*- coding: utf-8 -*-
+
+from __future__ import absolute_import, division, unicode_literals, print_function
+
+import os
+import re
+import itertools
+import multiprocessing
+import time
+import traceback
+import six
+
+from ..console import log
+from ..publishing import OutputPublisher
+from ..step_detect import detect_regressions, detect_steps
+from ..graph import Graph
+
+from .. import util
+
+
+
+def benchmark_param_iter(benchmark):
+    """
+    Iterate over all combinations of parameterized benchmark parameters.
+
+    Yields
+    ------
+    idx : int
+        Combination flat index. `None` if benchmark not parameterized.
+    params : tuple
+        Tuple of parameter values.
+
+    """
+    if not benchmark['params']:
+        yield None, ()
+    else:
+        for item in enumerate(itertools.product(*benchmark['params'])):
+            yield item
+
+
+class SummaryList(OutputPublisher):
+    name = "summarylist"
+    button_label = "List view"
+    description = "Display as a list"
+    order = 1
+
+    @classmethod
+    def publish(cls, conf, repo, benchmarks, graphs, revisions):
+        results = {}
+
+        # Investigate all benchmarks
+        for benchmark_name, benchmark in sorted(six.iteritems(benchmarks)):
+            benchmark_graphs = graphs.get_graph_group(benchmark_name)
+
+            # For parameterized benchmarks, consider each combination separately
+            for idx, benchmark_param in benchmark_param_iter(benchmark):
+                pretty_name = benchmark_name
+
+                if benchmark.get('pretty_name'):
+                    pretty_name = benchmark['pretty_name']
+
+                if idx is not None:
+                    pretty_name = '{0}({1})'.format(pretty_name,
+                                                    ", ".join(benchmark_param))
+
+                # Each environment parameter combination is reported
+                # separately on the summarylist page
+                benchmark_graphs = graphs.get_graph_group(benchmark_name)
+                for graph in benchmark_graphs:
+                    # Produce interesting information, based on
+                    # stepwise fit on the benchmark data (reduces noise)
+                    steps = graph.get_steps()
+                    if idx is not None and steps:
+                        steps = graph.get_steps()[idx]
+
+                    last_value = None
+                    last_err = None
+                    change = None
+                    change_rev = None
+                    last_rev = None
+                    prev_value = None
+
+                    if not steps:
+                        # No data
+                        pass
+                    else:
+                        last_piece = steps[-1]
+                        last_value = last_piece[3]
+                        last_err = last_piece[4]
+                        last_rev = last_piece[1] - 1
+
+                        if len(steps) > 1:
+                            prev_piece = steps[-2]
+                            prev_value = prev_piece[3]
+                            change_rev = last_piece[0]
+
+                    row = dict(name=benchmark_name,
+                               idx=idx,
+                               pretty_name=pretty_name,
+                               last_rev=last_rev,
+                               last_value=last_value,
+                               last_err=last_err,
+                               prev_value=prev_value,
+                               change_rev=change_rev)
+
+                    # Generate summary data filename.
+                    # Note that 'summary' is not a valid benchmark name, so that we can
+                    # be sure it can be always used.
+                    path = Graph.get_file_path(graph.params, 'summary') + ".json"
+                    results.setdefault(path, []).append(row)
+
+        # Write results to files
+        for path, data in six.iteritems(results):
+            filename = os.path.join(conf.html_dir, path)
+            util.write_json(filename, sorted(data, key=lambda x: (x['name'], x['idx'])))

--- a/asv/plugins/summarylist.py
+++ b/asv/plugins/summarylist.py
@@ -78,7 +78,6 @@ class SummaryList(OutputPublisher):
 
                     last_value = None
                     last_err = None
-                    change = None
                     change_rev = None
                     last_rev = None
                     prev_value = None
@@ -95,7 +94,12 @@ class SummaryList(OutputPublisher):
                         if len(steps) > 1:
                             prev_piece = steps[-2]
                             prev_value = prev_piece[2]
-                            change_rev = last_piece[0]
+                            if prev_piece[1] == last_piece[0]:
+                                # Single commit
+                                change_rev = [None, last_piece[0]]
+                            else:
+                                # Revision range (left-exclusive)
+                                change_rev = [prev_piece[1]-1, last_piece[0]]
 
                     row = dict(name=benchmark_name,
                                idx=idx,

--- a/asv/plugins/summarylist.py
+++ b/asv/plugins/summarylist.py
@@ -51,6 +51,8 @@ class SummaryList(OutputPublisher):
 
         # Investigate all benchmarks
         for benchmark_name, benchmark in sorted(six.iteritems(benchmarks)):
+            log.dot()
+
             benchmark_graphs = graphs.get_graph_group(benchmark_name)
 
             # For parameterized benchmarks, consider each combination separately
@@ -86,13 +88,13 @@ class SummaryList(OutputPublisher):
                         pass
                     else:
                         last_piece = steps[-1]
-                        last_value = last_piece[3]
+                        last_value = last_piece[2]
                         last_err = last_piece[4]
                         last_rev = last_piece[1] - 1
 
                         if len(steps) > 1:
                             prev_piece = steps[-2]
-                            prev_value = prev_piece[3]
+                            prev_value = prev_piece[2]
                             change_rev = last_piece[0]
 
                     row = dict(name=benchmark_name,

--- a/asv/publishing.py
+++ b/asv/publishing.py
@@ -12,6 +12,7 @@ class OutputPublisher(object):
     name = None
     button_label = None
     description = None
+    order = float('inf')
 
     @classmethod
     def publish(cls, conf, repo, benchmarks, graphs, revisions):

--- a/asv/www/asv.css
+++ b/asv/www/asv.css
@@ -4,6 +4,19 @@
     padding: 2px;
 }
 
+nav ul li.active a {
+    height: 52px;
+}
+
+nav li.active span.navbar-brand {
+    background-color: #e7e7e7;
+    height: 52px;
+}
+
+nav li.active span.navbar-brand:hover {
+    background-color: #e7e7e7;
+}
+
 .navbar-default .navbar-link {
     color: #2458D9;
 }

--- a/asv/www/asv.js
+++ b/asv/www/asv.js
@@ -287,9 +287,12 @@ $(document).ready(function() {
 
     function show_page(name, params) {
         if (loaded_pages[name] !== undefined) {
+	    $("#nav ul li.active").removeClass('active');
+	    $("#nav-li-" + name).addClass('active');
             $("#graph-display").hide();
-            $("#summary-display").hide();
+            $("#summarygrid-display").hide();
             $('#regressions-display').hide();
+            $('.tooltip').remove();
             loaded_pages[name](params);
             return true;
         }
@@ -365,7 +368,7 @@ $(document).ready(function() {
 
             $('#graph-display').hide();
             $('#regressions-display').hide();
-            $('#summary-display').hide();
+            $('#summarygrid-display').hide();
 
             hashchange();
         }).fail(function () {

--- a/asv/www/asv.js
+++ b/asv/www/asv.js
@@ -294,78 +294,6 @@ $(document).ready(function() {
     }
 
     /*
-     * UI helper functions
-     */
-    function make_panel(nav, heading) {
-        var panel = $('<div class="panel panel-default"/>');
-        nav.append(panel);
-        var panel_header = $(
-            '<div class="panel-heading">' + heading + '</div>');
-        panel.append(panel_header);
-        var panel_body = $('<div class="panel-body"/>');
-        panel.append(panel_body);
-        return panel_body;
-    }
-
-    function make_value_selector_panel(nav, heading, values, setup_callback) {
-        var panel_body = make_panel(nav, heading);
-        var vertical = false;
-        var buttons = $('<div class="btn-group" ' +
-                        'data-toggle="buttons"/>');
-
-        panel_body.append(buttons);
-
-        $.each(values, function (idx, value) {
-            var button = $(
-                '<a class="btn btn-default btn-xs active" role="button"/>');
-            setup_callback(idx, value, button);
-            buttons.append(button);
-        });
-
-        return panel_body;
-    }
-
-    function reflow_value_selector_panels() {
-        $('.panel').each(function (i, panel_obj) {
-            var panel = $(panel_obj);
-            panel.find('.btn-group').each(function (i, buttons_obj) {
-                var buttons = $(buttons_obj);
-                var width = 0;
-
-                if (buttons.hasClass('btn-group-vertical') ||
-                    buttons.hasClass('btn-group-justified')) {
-                    /* already processed */
-                    return;
-                }
-
-                $.each(buttons.children(), function(idx, value) {
-                    width += value.scrollWidth;
-                });
-
-                var vertical = (width >= panel_obj.clientWidth &&
-                                panel_obj.clientWidth > 0);
-
-                if (vertical) {
-                    buttons.addClass("btn-group-vertical");
-                    buttons.css("width", "100%");
-                    buttons.css("max-height", "20ex");
-                    buttons.css("overflow-y", "auto");
-                }
-                else {
-                    buttons.addClass("btn-group-justified");
-                }
-            });
-        });
-    }
-
-    function network_error(ajax, status, error) {
-        $("#error-message").text(
-            "Error fetching content. " +
-            "Perhaps web server has gone down.");
-        $("#error").modal('show');
-    }
-
-    /*
       Dealing with sub-pages
      */
 
@@ -458,7 +386,7 @@ $(document).ready(function() {
 
             hashchange();
         }).fail(function () {
-            network_error();
+            $.asv.ui.network_error();
         });
     }
 
@@ -481,11 +409,6 @@ $(document).ready(function() {
     this.load_graph_data = load_graph_data;
     this.get_commit_hash = get_commit_hash;
     this.get_revision = get_revision;
-
-    this.network_error = network_error;
-    this.make_panel = make_panel;
-    this.make_value_selector_panel = make_value_selector_panel;
-    this.reflow_value_selector_panels = reflow_value_selector_panels;
 
     this.master_json = master_json; /* Updated after index.json loads */
 

--- a/asv/www/asv_ui.js
+++ b/asv/www/asv_ui.js
@@ -70,6 +70,143 @@ $(document).ready(function() {
         $("#error").modal('show');
     }
 
+    function hover_graph(element, graph_url, benchmark_basename, parameter_idx, revisions) {
+        /* Show the summary graph as a popup */
+        var plot_div = $('<div/>');
+        plot_div.css('width', '11.8em');
+        plot_div.css('height', '7em');
+        plot_div.css('border', '2px solid black');
+        plot_div.css('background-color', 'white');
+
+        function update_plot() {
+            var markings = [];
+
+            if (revisions) {
+                $.each(revisions, function(i, revs) {
+                    var rev_a = revs[0];
+                    var rev_b = revs[1];
+
+                    if (rev_a !== null) {
+                        markings.push({ color: '#d00', lineWidth: 2, xaxis: { from: rev_a, to: rev_a }});
+                        markings.push({ color: "rgba(255,0,0,0.1)", xaxis: { from: rev_a, to: rev_b }});
+                    }
+                    markings.push({ color: '#d00', lineWidth: 2, xaxis: { from: rev_b, to: rev_b }});
+                });
+            }
+
+            $.asv.load_graph_data(
+                graph_url
+            ).done(function (data) {
+                var params = $.asv.master_json.benchmarks[benchmark_basename].params;
+                data = $.asv.filter_graph_data_idx(data, 0, parameter_idx, params);
+                var options = {
+                    colors: ['#000'],
+                    series: {
+                        lines: {
+                            show: true,
+                            lineWidth: 2
+                        },
+                        shadowSize: 0
+                    },
+                    grid: {
+                        borderWidth: 1,
+                        margin: 0,
+                        labelMargin: 0,
+                        axisMargin: 0,
+                        minBorderMargin: 0,
+                        markings: markings,
+                    },
+                    xaxis: {
+                        ticks: [],
+                    },
+                    yaxis: {
+                        ticks: [],
+                        min: 0
+                    },
+                    legend: {
+                        show: false
+                    }
+                };
+                var plot = $.plot(plot_div, [{data: data}], options);
+            }).fail(function () {
+                // TODO: Handle failure
+            });
+
+            return plot_div;
+        }
+
+        element.popover({
+            placement: 'left auto',
+            trigger: 'hover',
+            html: true,
+            delay: 50,
+            content: $('<div/>').append(plot_div)
+        });
+
+        element.on('show.bs.popover', update_plot);
+    }
+
+    function hover_summary_graph(element, benchmark_basename) {
+        /* Show the summary graph as a popup */
+        var plot_div = $('<div/>');
+        plot_div.css('width', '11.8em');
+        plot_div.css('height', '7em');
+        plot_div.css('border', '2px solid black');
+        plot_div.css('background-color', 'white');
+
+        function update_plot() {
+            var markings = [];
+
+            $.asv.load_graph_data(
+                'graphs/summary/' + benchmark_basename + '.json'
+            ).done(function (data) {
+                var options = {
+                    colors: $.asv.colors,
+                    series: {
+                        lines: {
+                            show: true,
+                            lineWidth: 2
+                        },
+                        shadowSize: 0
+                    },
+                    grid: {
+                        borderWidth: 1,
+                        margin: 0,
+                        labelMargin: 0,
+                        axisMargin: 0,
+                        minBorderMargin: 0,
+                        markings: markings,
+                    },
+                    xaxis: {
+                        ticks: [],
+                    },
+                    yaxis: {
+                        ticks: [],
+                        min: 0
+                    },
+                    legend: {
+                        show: false
+                    }
+                };
+                var plot = $.plot(plot_div, [{data: data}], options);
+            }).fail(function () {
+                // TODO: Handle failure
+            });
+
+            return plot_div;
+        }
+
+        element.popover({
+            placement: 'left auto',
+            trigger: 'hover',
+            html: true,
+            delay: 50,
+            content: $('<div/>').append(plot_div)
+        });
+
+        element.on('show.bs.popover', update_plot);
+    }
+
     /*
       Set up $.asv.ui
      */

--- a/asv/www/asv_ui.js
+++ b/asv/www/asv_ui.js
@@ -30,15 +30,14 @@ $(document).ready(function() {
         return panel_body;
     }
 
-    function reflow_value_selector_panels() {
+    function reflow_value_selector_panels(no_timeout) {
         $('.panel').each(function (i, panel_obj) {
             var panel = $(panel_obj);
             panel.find('.btn-group').each(function (i, buttons_obj) {
                 var buttons = $(buttons_obj);
                 var width = 0;
 
-                if (buttons.hasClass('btn-group-vertical') ||
-                    buttons.hasClass('btn-group-justified')) {
+                if (buttons.hasClass('reflow-done')) {
                     /* already processed */
                     return;
                 }
@@ -47,10 +46,9 @@ $(document).ready(function() {
                     width += value.scrollWidth;
                 });
 
-                var vertical = (width >= panel_obj.clientWidth &&
-                                panel_obj.clientWidth > 0);
+                var max_width = panel_obj.clientWidth;
 
-                if (vertical) {
+                if (width >= max_width) {
                     buttons.addClass("btn-group-vertical");
                     buttons.css("width", "100%");
                     buttons.css("max-height", "20ex");
@@ -59,8 +57,19 @@ $(document).ready(function() {
                 else {
                     buttons.addClass("btn-group-justified");
                 }
+
+                /* The widths can be zero if the UI is not fully layouted yet,
+                   so mark the adjustment complete only if this is not the case */
+                if (width > 0 && max_width > 0) {
+                    buttons.addClass("reflow-done");
+                }
             });
         });
+
+        if (!no_timeout) {
+            /* Call again asynchronously, in case the UI was not fully layouted yet */
+            setTimeout(function() { $.asv.ui.reflow_value_selector_panels(true); }, 0);
+        }
     }
 
     function network_error(ajax, status, error) {

--- a/asv/www/asv_ui.js
+++ b/asv/www/asv_ui.js
@@ -1,0 +1,85 @@
+'use strict';
+
+$(document).ready(function() {
+    function make_panel(nav, heading) {
+        var panel = $('<div class="panel panel-default"/>');
+        nav.append(panel);
+        var panel_header = $(
+            '<div class="panel-heading">' + heading + '</div>');
+        panel.append(panel_header);
+        var panel_body = $('<div class="panel-body"/>');
+        panel.append(panel_body);
+        return panel_body;
+    }
+
+    function make_value_selector_panel(nav, heading, values, setup_callback) {
+        var panel_body = make_panel(nav, heading);
+        var vertical = false;
+        var buttons = $('<div class="btn-group" ' +
+                        'data-toggle="buttons"/>');
+
+        panel_body.append(buttons);
+
+        $.each(values, function (idx, value) {
+            var button = $(
+                '<a class="btn btn-default btn-xs active" role="button"/>');
+            setup_callback(idx, value, button);
+            buttons.append(button);
+        });
+
+        return panel_body;
+    }
+
+    function reflow_value_selector_panels() {
+        $('.panel').each(function (i, panel_obj) {
+            var panel = $(panel_obj);
+            panel.find('.btn-group').each(function (i, buttons_obj) {
+                var buttons = $(buttons_obj);
+                var width = 0;
+
+                if (buttons.hasClass('btn-group-vertical') ||
+                    buttons.hasClass('btn-group-justified')) {
+                    /* already processed */
+                    return;
+                }
+
+                $.each(buttons.children(), function(idx, value) {
+                    width += value.scrollWidth;
+                });
+
+                var vertical = (width >= panel_obj.clientWidth &&
+                                panel_obj.clientWidth > 0);
+
+                if (vertical) {
+                    buttons.addClass("btn-group-vertical");
+                    buttons.css("width", "100%");
+                    buttons.css("max-height", "20ex");
+                    buttons.css("overflow-y", "auto");
+                }
+                else {
+                    buttons.addClass("btn-group-justified");
+                }
+            });
+        });
+    }
+
+    function network_error(ajax, status, error) {
+        $("#error-message").text(
+            "Error fetching content. " +
+            "Perhaps web server has gone down.");
+        $("#error").modal('show');
+    }
+
+    /*
+      Set up $.asv.ui
+     */
+
+    this.network_error = network_error;
+    this.make_panel = make_panel;
+    this.make_value_selector_panel = make_value_selector_panel;
+    this.reflow_value_selector_panels = reflow_value_selector_panels;
+    this.hover_graph = hover_graph;
+    this.hover_summary_graph = hover_summary_graph;
+
+    $.asv.ui = this;
+});

--- a/asv/www/graphdisplay.js
+++ b/asv/www/graphdisplay.js
@@ -100,7 +100,7 @@ $(document).ready(function() {
         setup_benchmark_graph_display();
 
         $('#graph-display').show();
-        $('#summary-display').hide();
+        $('#summarygrid-display').hide();
         $('#regressions-display').hide();
         $('.tooltip').remove();
 
@@ -116,68 +116,6 @@ $(document).ready(function() {
         replace_graphs();
     }
 
-    function make_panel(nav, heading) {
-        var panel = $('<div class="panel panel-default"/>');
-        nav.append(panel);
-        var panel_header = $(
-            '<div class="panel-heading">' + heading + '</div>');
-        panel.append(panel_header);
-        var panel_body = $('<div class="panel-body"/>');
-        panel.append(panel_body);
-        return panel_body;
-    }
-
-    function make_value_selector_panel(nav, heading, values, setup_callback) {
-        var panel_body = make_panel(nav, heading);
-        var vertical = false;
-        var buttons = $('<div class="btn-group" ' +
-                        'data-toggle="buttons"/>');
-
-        panel_body.append(buttons);
-
-        $.each(values, function (idx, value) {
-            var button = $(
-                '<a class="btn btn-default btn-xs active" role="button"/>');
-            setup_callback(idx, value, button);
-            buttons.append(button);
-        });
-
-        return panel_body;
-    }
-
-    function reflow_value_selector_panels() {
-        $('.panel').each(function (i, panel_obj) {
-            var panel = $(panel_obj);
-            panel.find('.btn-group').each(function (i, buttons_obj) {
-                var buttons = $(buttons_obj);
-                var width = 0;
-
-                if (buttons.hasClass('btn-group-vertical') ||
-                    buttons.hasClass('btn-group-justified')) {
-                    /* already processed */
-                    return;
-                }
-
-                $.each(buttons.children(), function(idx, value) {
-                    width += value.scrollWidth;
-                });
-
-                var vertical = (width >= panel_obj.clientWidth &&
-                                panel_obj.clientWidth > 0);
-
-                if (vertical) {
-                    buttons.addClass("btn-group-vertical");
-                    buttons.css("width", "100%");
-                    buttons.css("max-height", "20ex");
-                    buttons.css("overflow-y", "auto");
-                }
-                else {
-                    buttons.addClass("btn-group-justified");
-                }
-            });
-        });
-    }
-
     function setup_benchmark_graph_display() {
         if (benchmark_graph_display_ready) {
             return;
@@ -189,21 +127,21 @@ $(document).ready(function() {
             update_graphs();
         });
 
-        var nav = $("#navigation");
+        var nav = $("#graphdisplay-navigation");
 
         /* Make the static tooltips look correct */
         $('[data-toggle="tooltip"]').tooltip({container: 'body'});
 
         /* Add insertion point for benchmark parameters */
-        var state_params_nav = $("<div id='state-params'/>");
+        var state_params_nav = $("<div id='graphdisplay-state-params'/>");
         nav.append(state_params_nav);
 
         /* Add insertion point for benchmark parameters */
-        var bench_params_nav = $("<div id='navigation-params'/>");
+        var bench_params_nav = $("<div id='graphdisplay-navigation-params'/>");
         nav.append(bench_params_nav);
 
         /* Benchmark panel */
-        var panel_body = make_panel(nav, 'benchmark');
+        var panel_body = $.asv.make_panel(nav, 'benchmark');
 
         var tree = $('<ul class="nav nav-list" style="padding-left: 0px"/>');
         var cursor = [];
@@ -480,11 +418,11 @@ $(document).ready(function() {
     function replace_params_ui() {
         var index = $.asv.master_json;
 
-        var nav = $('#state-params');
+        var nav = $('#graphdisplay-state-params');
         nav.empty();
 
         /* Machine selection */
-        make_value_selector_panel(nav, 'machine', index.params.machine,  function(i, machine, button) {
+        $.asv.make_value_selector_panel(nav, 'machine', index.params.machine,  function(i, machine, button) {
             button.text(machine);
 
             if (index.params.machine.length > 1) {
@@ -522,7 +460,7 @@ $(document).ready(function() {
         /* Generic parameter selectors */
         $.each(index.params, function(param, values) {
             if (values.length > 1 && param != 'machine') {
-                make_value_selector_panel(nav, param, values, function(i, value, button) {
+                $.asv.make_value_selector_panel(nav, param, values, function(i, value, button) {
                     var value_display;
                     if (value === null)
                         value_display = '[none]';
@@ -558,12 +496,12 @@ $(document).ready(function() {
         var param_names = $.asv.master_json.benchmarks[current_benchmark].param_names;
 
         /* Parameter selection UI */
-        var nav = $('#navigation-params');
+        var nav = $('#graphdisplay-navigation-params');
         nav.empty();
 
         if (params.length == 0) {
             /* Simple time series: no need for parameter selection UI */
-            reflow_value_selector_panels();
+            $.asv.reflow_value_selector_panels();
             return;
         }
 
@@ -574,7 +512,7 @@ $(document).ready(function() {
                 axes.push(axis);
             }
 
-            make_value_selector_panel(nav, "x-axis", axes, function (idx, axis, button) {
+            $.asv.make_value_selector_panel(nav, "x-axis", axes, function (idx, axis, button) {
                 var text;
                 if (axis == 0) {
                     text = "commit";
@@ -607,7 +545,7 @@ $(document).ready(function() {
             revisions.reverse();
 
             /* Add buttons */
-            make_value_selector_panel(nav, "commit", revisions, function(idx, rev, button) {
+            $.asv.make_value_selector_panel(nav, "commit", revisions, function(idx, rev, button) {
                 if (rev === null) {
                     button.text("last");
                 } else {
@@ -650,7 +588,7 @@ $(document).ready(function() {
             name = param_names[param_idx];
 
             /* Add benchmark parameter selector */
-            make_value_selector_panel(nav, name, values, function(value_idx, value, button) {
+            $.asv.make_value_selector_panel(nav, name, values, function(value_idx, value, button) {
                 var value_display;
                 value_display = '' + $.asv.convert_benchmark_param_value(value);
 
@@ -684,7 +622,7 @@ $(document).ready(function() {
             });
         });
 
-        reflow_value_selector_panels();
+        $.asv.reflow_value_selector_panels();
     }
 
     /* Check if x-axis is a category axis */
@@ -710,25 +648,6 @@ $(document).ready(function() {
         /* Given the settings in the sidebar, generate a list of the
            graphs we need to load. */
         function collect_graphs(current_benchmark, state, param_selection) {
-            /* Given a specific group of parameters, generate the URL to
-               use to load that graph. */
-            function graph_to_path(benchmark_name, state) {
-                var parts = [];
-                $.each(state, function(key, value) {
-                    if (value === null) {
-                        parts.push(key + "-null");
-                    } else if (value) {
-                        parts.push(key + "-" + value);
-                    } else {
-                        parts.push(key);
-                    }
-                });
-                parts.sort();
-                parts.splice(0, 0, "graphs");
-                parts.push(benchmark_name);
-                return parts.join('/') + ".json";
-            }
-
             /* Given a specific group of parameters, generate the legend
                label to display for that line. Differences is an object of
                parameters that have different values across all graphs. */
@@ -863,7 +782,7 @@ $(document).ready(function() {
                         graph_contents.push([param_perm,
                                              graph_label(labels, different)]);
                     });
-                    all.push([graph_to_path(current_benchmark, perm),
+                    all.push([$.asv.graph_to_path(current_benchmark, perm),
                               graph_contents]);
                 });
                 return all;

--- a/asv/www/graphdisplay.js
+++ b/asv/www/graphdisplay.js
@@ -141,7 +141,7 @@ $(document).ready(function() {
         nav.append(bench_params_nav);
 
         /* Benchmark panel */
-        var panel_body = $.asv.make_panel(nav, 'benchmark');
+        var panel_body = $.asv.ui.make_panel(nav, 'benchmark');
 
         var tree = $('<ul class="nav nav-list" style="padding-left: 0px"/>');
         var cursor = [];
@@ -422,7 +422,7 @@ $(document).ready(function() {
         nav.empty();
 
         /* Machine selection */
-        $.asv.make_value_selector_panel(nav, 'machine', index.params.machine,  function(i, machine, button) {
+        $.asv.ui.make_value_selector_panel(nav, 'machine', index.params.machine,  function(i, machine, button) {
             button.text(machine);
 
             if (index.params.machine.length > 1) {
@@ -460,7 +460,7 @@ $(document).ready(function() {
         /* Generic parameter selectors */
         $.each(index.params, function(param, values) {
             if (values.length > 1 && param != 'machine') {
-                $.asv.make_value_selector_panel(nav, param, values, function(i, value, button) {
+                $.asv.ui.make_value_selector_panel(nav, param, values, function(i, value, button) {
                     var value_display;
                     if (value === null)
                         value_display = '[none]';
@@ -501,7 +501,7 @@ $(document).ready(function() {
 
         if (params.length == 0) {
             /* Simple time series: no need for parameter selection UI */
-            $.asv.reflow_value_selector_panels();
+            $.asv.ui.reflow_value_selector_panels();
             return;
         }
 
@@ -512,7 +512,7 @@ $(document).ready(function() {
                 axes.push(axis);
             }
 
-            $.asv.make_value_selector_panel(nav, "x-axis", axes, function (idx, axis, button) {
+            $.asv.ui.make_value_selector_panel(nav, "x-axis", axes, function (idx, axis, button) {
                 var text;
                 if (axis == 0) {
                     text = "commit";
@@ -545,7 +545,7 @@ $(document).ready(function() {
             revisions.reverse();
 
             /* Add buttons */
-            $.asv.make_value_selector_panel(nav, "commit", revisions, function(idx, rev, button) {
+            $.asv.ui.make_value_selector_panel(nav, "commit", revisions, function(idx, rev, button) {
                 if (rev === null) {
                     button.text("last");
                 } else {
@@ -588,7 +588,7 @@ $(document).ready(function() {
             name = param_names[param_idx];
 
             /* Add benchmark parameter selector */
-            $.asv.make_value_selector_panel(nav, name, values, function(value_idx, value, button) {
+            $.asv.ui.make_value_selector_panel(nav, name, values, function(value_idx, value, button) {
                 var value_display;
                 value_display = '' + $.asv.convert_benchmark_param_value(value);
 
@@ -622,7 +622,7 @@ $(document).ready(function() {
             });
         });
 
-        $.asv.reflow_value_selector_panels();
+        $.asv.ui.reflow_value_selector_panels();
     }
 
     /* Check if x-axis is a category axis */
@@ -839,7 +839,7 @@ $(document).ready(function() {
                         update_graphs();
                         no_data();
                     }).fail(function () {
-                        $.asv.network_error();
+                        $.asv.ui.network_error();
                     });
                 }
             });

--- a/asv/www/index.html
+++ b/asv/www/index.html
@@ -51,6 +51,9 @@
             src="asv.js">
     </script>
     <script language="javascript" type="text/javascript"
+            src="asv_ui.js">
+    </script>
+    <script language="javascript" type="text/javascript"
             src="summarygrid.js">
     </script>
     <script language="javascript" type="text/javascript"

--- a/asv/www/index.html
+++ b/asv/www/index.html
@@ -54,6 +54,9 @@
             src="summarygrid.js">
     </script>
     <script language="javascript" type="text/javascript"
+            src="summarylist.js">
+    </script>
+    <script language="javascript" type="text/javascript"
             src="graphdisplay.js">
     </script>
     <script language="javascript" type="text/javascript"
@@ -61,6 +64,7 @@
     </script>
     <link href="asv.css" rel="stylesheet" type="text/css"/>
     <link href="regressions.css" rel="stylesheet" type="text/css"/>
+    <link href="summarylist.css" rel="stylesheet" type="text/css"/>
     <link rel="shortcut icon" href="swallow.ico"/>
     <link rel="alternate" type="application/atom+xml" title="Regressions" href="regressions.xml"/>
   </head>
@@ -75,6 +79,7 @@
           </p>
         </li>
 	<li id="nav-li-" class="active"><a href="#/">Benchmark grid</a></li>
+	<li id="nav-li-summarylist"><a href="#/summarylist">Benchmark list</a></li>
 	<li id="nav-li-regressions"><a href="#/regressions">Regressions</a></li>
         <li id="nav-li-graphdisplay">
           <span class="navbar-brand" id="title">
@@ -85,8 +90,14 @@
     </nav>
     <div id="summarygrid-display" style="position: absolute; left: 0; top: 55px; width: 100%; height: 100%">
     </div>
+    <div id="summarylist-display" style="width: 100%; height: 100%">
+      <div id="summarylist-navigation" class="asv-navigation" style="position: absolute; left: 0; top: 55px; bottom: 0; width: 200px; overflow-y: scroll">
+      </div>
+      <div id="summarylist-body" style="position: absolute; left: 200px; top: 55px; bottom: 0px; right: 0px; overflow-y: scroll;">
+      </div>
+    </div>
     <div id="graph-display" style="width: 100%; height: 100%;">
-      <div id="navigation" class="asv-navigation" style="position: absolute; left: 0; top: 55px; bottom: 0; width: 200px; overflow-y: scroll">
+      <div id="graphdisplay-navigation" class="asv-navigation" style="position: absolute; left: 0; top: 55px; bottom: 0; width: 200px; overflow-y: scroll">
         <div class="panel panel-default">
           <div class="panel-heading">
             commits

--- a/asv/www/index.html
+++ b/asv/www/index.html
@@ -51,7 +51,7 @@
             src="asv.js">
     </script>
     <script language="javascript" type="text/javascript"
-            src="summary.js">
+            src="summarygrid.js">
     </script>
     <script language="javascript" type="text/javascript"
             src="graphdisplay.js">
@@ -74,25 +74,19 @@
             <a id="project-name" href="#" class="navbar-link" target="_blank">project</a>
           </p>
         </li>
-        <li>
+	<li id="nav-li-" class="active"><a href="#/">Benchmark grid</a></li>
+	<li id="nav-li-regressions"><a href="#/regressions">Regressions</a></li>
+        <li id="nav-li-graphdisplay">
           <span class="navbar-brand" id="title">
             benchmark
           </span>
         </li>
       </ul>
     </nav>
-    <div id="summary-display" style="position: absolute; left: 0; top: 55px; width: 100%; height: 100%">
+    <div id="summarygrid-display" style="position: absolute; left: 0; top: 55px; width: 100%; height: 100%">
     </div>
     <div id="graph-display" style="width: 100%; height: 100%;">
       <div id="navigation" class="asv-navigation" style="position: absolute; left: 0; top: 55px; bottom: 0; width: 200px; overflow-y: scroll">
-        <div class="panel panel-default">
-          <div class="panel-body">
-            <div class="btn-group-vertical" style="width: 100%">
-              <a href="#" id="summary-button" class="btn btn-default btn-xs" role="button">&lt;&lt; all benchmarks</a>
-            </div>
-          </div>
-        </div>
-
         <div class="panel panel-default">
           <div class="panel-heading">
             commits
@@ -149,17 +143,8 @@
       </div>
     </div>
 
-    <div id="regressions-display" style="width: 100%; height: 100%;">
-      <div id="navigation" class="asv-navigation" style="position: absolute; left: 0; top: 55px; bottom: 0; width: 200px; overflow-y: scroll">
-        <div class="panel panel-default">
-          <div class="panel-body">
-            <div class="btn-group-vertical" style="width: 100%">
-              <a href="#" id="regressions-summary-button" class="btn btn-default btn-xs" role="button">&lt;&lt; all benchmarks</a>
-            </div>
-          </div>
-        </div>
-      </div>
-      <div id="regressions-body" style="position: absolute; left: 220px; top: 60px; bottom: 10px; right: 20px;">
+    <div id="regressions-display" style="position: absolute; left: 0; top: 55px; width: 100%; height: 100%">
+      <div id="regressions-body">
       </div>
     </div>
 

--- a/asv/www/regressions.css
+++ b/asv/www/regressions.css
@@ -1,3 +1,10 @@
+#regressions-body {
+    margin-left: 2em;
+    margin-right: 2em;
+    margin-top: 1em;
+    margin-bottom: 2em;
+}
+
 #regressions-body table thead th {
     cursor: pointer;
     white-space: nowrap;

--- a/asv/www/regressions.js
+++ b/asv/www/regressions.js
@@ -284,75 +284,8 @@ $(document).ready(function() {
                 ignored_table_body.append(row);
             }
 
-            /* Show the summary graph as a popup */
-            var plot_div = $('<div/>');
-            plot_div.css('width', '11.8em');
-            plot_div.css('height', '7em');
-            plot_div.css('border', '2px solid black');
-            plot_div.css('background-color', 'white');
-
-            function update_plot() {
-                var markings = [];
-
-                $.each(revisions, function(i, revs) {
-                    var rev_a = revs[0];
-                    var rev_b = revs[1];
-
-                    if (rev_a !== null) {
-                        markings.push({ color: '#d00', lineWidth: 2, xaxis: { from: rev_a, to: rev_a }});
-                        markings.push({ color: "rgba(255,0,0,0.1)", xaxis: { from: rev_a, to: rev_b }});
-                    }
-                    markings.push({ color: '#d00', lineWidth: 2, xaxis: { from: rev_b, to: rev_b }});
-                });
-
-                $.asv.load_graph_data(
-                    graph_url
-                ).done(function (data) {
-                    var params = $.asv.master_json.benchmarks[benchmark_basename].params;
-                    data = $.asv.filter_graph_data_idx(data, 0, parameter_idx, params);
-                    var options = {
-                        colors: ['#000'],
-                        series: {
-                            lines: {
-                                show: true,
-                                lineWidth: 2
-                            },
-                            shadowSize: 0
-                        },
-                        grid: {
-                            borderWidth: 1,
-                            margin: 0,
-                            labelMargin: 0,
-                            axisMargin: 0,
-                            minBorderMargin: 0,
-                            markings: markings,
-                        },
-                        xaxis: {
-                            ticks: [],
-                        },
-                        yaxis: {
-                            ticks: [],
-                            min: 0
-                        },
-                        legend: {
-                            show: false
-                        }
-                    };
-                    var plot = $.plot(plot_div, [{data: data}], options);
-                }).fail(function () {
-                    // TODO: Handle failure
-                });
-
-                return plot_div;
-            }
-            benchmark_link.popover({
-                placement: 'left auto',
-                trigger: 'hover',
-                html: true,
-                delay: 50,
-                content: $('<div/>').append(plot_div)
-            });
-            benchmark_link.on('show.bs.popover', update_plot);
+            /* Show a graph as a popup */
+            $.asv.ui.hover_graph(benchmark_link, graph_url, benchmark_basename, parameter_idx, revisions);
         });
 
         display_table.append(table_body);

--- a/asv/www/regressions.js
+++ b/asv/www/regressions.js
@@ -467,7 +467,7 @@ $(document).ready(function() {
                 function key(s) {
                     for (var k = 0; k < $.asv.time_units.length; ++k) {
                         var entry = $.asv.time_units[k];
-                        m = s.match('^([0-9.]+)'+entry[0]+'$');
+                        var m = s.match('^([0-9.]+)'+entry[0]+'$');
                         if (m) {
                             return parseFloat(m[1]) * entry[2] * 1e-30;
                         }

--- a/asv/www/regressions.js
+++ b/asv/www/regressions.js
@@ -4,7 +4,7 @@ $(document).ready(function() {
     /* Cached contents of downloaded regressions.json */
     var regression_data = null;
     /* Current page title */
-    var current_title = "Regressions";
+    var current_title = "All regressions";
     /* Whether HTML5 local storage is available */
     var local_storage_available = false;
     /* Key prefix for ignored regressions. For each ignored regression,
@@ -78,7 +78,7 @@ $(document).ready(function() {
 
                 dropdown_menu.append($('<li role="presentation"/>').append(branch_link));
                 branch_link.on('click', function(evt) {
-                    current_title = "Regressions (" + branch + " branch)";
+                    current_title = "Regressions in " + branch + " branch";
                     $("#title").text(current_title);
                     $(".regression-div").hide();
                     $(".ignored").hide();
@@ -114,7 +114,7 @@ $(document).ready(function() {
         });
 
         if (branches && branches.length > 1) {
-            current_title = "Regressions (" + branches[0] + " branch)";
+            current_title = "Regressions in " + branches[0] + " branch";
         }
         $("#title").text(current_title);
         main_div.find("#regression-div-0").show();
@@ -346,7 +346,7 @@ $(document).ready(function() {
                 return plot_div;
             }
             benchmark_link.popover({
-                placement: 'right auto',
+                placement: 'left auto',
                 trigger: 'hover',
                 html: true,
                 delay: 50,

--- a/asv/www/summarygrid.js
+++ b/asv/www/summarygrid.js
@@ -7,7 +7,7 @@ $(document).ready(function() {
     function callback_in_view(element, func) {
         function handler(evt) {
             var visible = (
-                $('#summary-display').css('display') != 'none' &&
+                $('#summarygrid-display').css('display') != 'none' &&
                 (element.offset().top <= $(window).height() + $(window).scrollTop()) &&
                     (element.offset().top + element.height() >= $(window).scrollTop()));
             if (visible) {
@@ -19,7 +19,7 @@ $(document).ready(function() {
     }
 
     function make_summary() {
-        var summary_display = $('#summary-display');
+        var summary_display = $('#summarygrid-display');
         var master_json = $.asv.master_json;
         var summary_container = $('<div/>');
 
@@ -27,26 +27,12 @@ $(document).ready(function() {
             return;
         }
 
-        if (master_json.extra_pages) {
-            var pages_container = $('<div id="extra-buttons" class="btn-group" role="group" />');
-
-            $.each(master_json.extra_pages, function(j, item) {
-                var button = $('<a class="btn btn-default" role="button"/>');
-                button.attr('href', '#/' + item[0]);
-                button.text(item[1]);
-                button.tooltip({title: item[2], html: true});
-                pages_container.append(button);
-            });
-            pages_container.show();
-            summary_display.append(pages_container);
-        }
-
         $.each(master_json.benchmarks, function(bm_name, bm) {
             var container = $(
                 '<a class="btn benchmark-container" href="#' + bm_name +
                 '"/>');
             var plot_div = $(
-                '<div id="summary-' + bm_name + '" class="benchmark-plot"/>');
+                '<div id="summarygrid-' + bm_name + '" class="benchmark-plot"/>');
             var name = $('<div class="benchmark-text">' + bm_name + '</div>');
             name.tooltip({
                 title: bm_name,
@@ -115,7 +101,7 @@ $(document).ready(function() {
     }
 
     $.asv.register_page('', function(params) {
-        $('#summary-display').show();
+        $('#summarygrid-display').show();
         $("#title").text("All benchmarks");
         $('.tooltip').remove();
         make_summary();

--- a/asv/www/summarylist.css
+++ b/asv/www/summarylist.css
@@ -42,4 +42,9 @@
 
 #summarylist-body table tbody td.change a {
     color: black;
+    white-space: nowrap;
+}
+
+#summarylist-body table tbody td.change-date {
+    white-space: nowrap;
 }

--- a/asv/www/summarylist.css
+++ b/asv/www/summarylist.css
@@ -1,0 +1,45 @@
+#summarylist-body {
+    padding-left: 2em;
+    padding-right: 2em;
+    padding-top: 1em;
+    padding-bottom: 2em;
+}
+
+#summarylist-body table thead th {
+    cursor: pointer;
+    white-space: nowrap;
+}
+
+#summarylist-body table thead th.desc:after {
+    content: ' \2191';
+}
+
+#summarylist-body table thead th.asc:after {
+    content: ' \2193';
+}
+
+#summarylist-body table.ignored {
+    padding-top: 1em;
+    color: #ccc;
+    background-color: #eee;
+}
+
+#summarylist-body table.ignored a {
+    color: #82abda;
+}
+
+#summarylist-body table tbody td.positive-change {
+    background-color: #fdd;
+}
+
+#summarylist-body table tbody td.negative-change {
+    background-color: #dfd;
+}
+
+#summarylist-body table tbody td.value {
+    white-space: nowrap;
+}
+
+#summarylist-body table tbody td.change a {
+    color: black;
+}

--- a/asv/www/summarylist.js
+++ b/asv/www/summarylist.js
@@ -97,11 +97,13 @@ $(document).ready(function() {
         var best_hit = false;
 
         tmp_state = obj_copy(tmp_state);
-        tmp_state[wanted_key] = wanted_value;
+        if (wanted_key !== undefined) {
+            tmp_state[wanted_key] = wanted_value;
+        }
 
         $.each($.asv.master_json.graph_param_list, function(idx, params) {
             var diff = obj_diff(tmp_state, params);
-            var hit = (params[wanted_key] == wanted_value);
+            var hit = (wanted_key === undefined || params[wanted_key] == wanted_value);
 
             if ((!best_hit && hit) || (hit == best_hit && diff < best_diff)) {
                 best_params = params;
@@ -136,7 +138,7 @@ $(document).ready(function() {
             });
         }
 
-        return state;
+        return get_valid_state(state);
     }
 
     function replace_params_ui() {

--- a/asv/www/summarylist.js
+++ b/asv/www/summarylist.js
@@ -324,14 +324,19 @@ $(document).ready(function() {
                 }
                 text = text.replace('-', '\u2212');
 
-                var change_commit = $.asv.master_json.revision_to_hash[row.change_rev];
-                var change_link = $('<a/>').attr('href', benchmark_full_url
-                                                 + '&commits='
-                                                 + change_commit
-                                                ).text(text);
+                var change_commit_a = $.asv.master_json.revision_to_hash[row.change_rev[0]];
+                var change_commit_b = $.asv.master_json.revision_to_hash[row.change_rev[1]];
+                var change_q;
+                if (change_commit_a === undefined) {
+                    change_q = '&commits=' + change_commit_b;
+                }
+                else {
+                    change_q = '&commits=' + change_commit_a + '-' + change_commit_b;
+                }
+                var change_link = $('<a/>').attr('href', benchmark_full_url + change_q).text(text);
 
                 graph_url = $.asv.graph_to_path(row.name, state);
-                $.asv.ui.hover_graph(change_link, graph_url, row.name, row.idx, [[null, row.change_rev]]);
+                $.asv.ui.hover_graph(change_link, graph_url, row.name, row.idx, [row.change_rev]);
 
                 change_td.append(change_link);
 
@@ -349,16 +354,27 @@ $(document).ready(function() {
 
             var changed_at_td = $('<td class="change-date"/>');
             if (row.change_rev !== null) {
-                var date = new Date($.asv.master_json.revision_to_date[row.change_rev]);
-                var commit = $.asv.get_commit_hash(row.change_rev);
+                var date = new Date($.asv.master_json.revision_to_date[row.change_rev[1]]);
+                var commit_1 = $.asv.get_commit_hash(row.change_rev[0]);
+                var commit_2 = $.asv.get_commit_hash(row.change_rev[1]);
                 var commit_a = $('<a/>');
-                var last_commit = $.asv.get_commit_hash(row.last_rev);
-                var last_commit_a = $('<a/>');
                 var span = $('<span/>');
-                commit_a.attr('href', $.asv.master_json.show_commit_url + commit);
-                commit_a.text(commit);
-                last_commit_a.attr('href', $.asv.master_json.show_commit_url + commit);
-                last_commit_a.text(commit);
+                if (commit_1) {
+                    var commit_url;
+                    if ($.asv.master_json.show_commit_url.match(/.*\/\/github.com\//)) {
+                        commit_url = ($.asv.master_json.show_commit_url + '../compare/'
+                                      + commit_1 + '...' + commit_2);
+                    }
+                    else {
+                        commit_url = $.asv.master_json.show_commit_url + commit_2;
+                    }
+                    commit_a.attr('href', commit_url);
+                    commit_a.text(commit_1 + '...' + commit_2);
+                }
+                else {
+                    commit_a.attr('href', $.asv.master_json.show_commit_url + commit_2);
+                    commit_a.text(commit_2);
+                }
                 span.text(format_date_yyyymmdd(date) + ' ');
                 span.append(commit_a);
                 changed_at_td.append(span);

--- a/asv/www/summarylist.js
+++ b/asv/www/summarylist.js
@@ -1,0 +1,337 @@
+'use strict';
+
+$(document).ready(function() {
+    /* The state of the parameters in the sidebar.  Dictionary mapping
+       strings to values determining the "enabled" configurations. */
+    var state = null;
+
+    function setup_display(state_selection) {
+        var new_state = setup_state(state_selection);
+        var same_state = (state !== null);
+
+        /* Avoid needless UI updates, e.g., on table sort */
+
+        if (same_state) {
+            $.each(state, function (key, value) {
+                if (value != new_state[key]) {
+                    same_state = false;
+                }
+            });
+        }
+
+        if (!same_state) {
+            state = new_state;
+            replace_params_ui();
+
+            var filename = $.asv.graph_to_path('summary', state);
+            $.asv.load_graph_data(
+                filename
+            ).done(function (data) {
+                replace_benchmark_table(data);
+            });
+        }
+    }
+
+    function update_state_url(key, value) {
+        var info = $.asv.parse_hash_string(window.location.hash);
+        $.each($.asv.master_json.params, function(param, values) {
+            if (values.length > 1) {
+                info.params[param] = [state[param]];
+            }
+            else if (info.params[param]) {
+                delete info.params[param];
+            }
+        });
+        info.params[key] = [value];
+        window.location.hash = $.asv.format_hash_string(info);
+    }
+
+    function setup_state(state_selection) {
+        var index = $.asv.master_json;
+        var state = {};
+
+        state.machine = index.params.machine;
+
+        $.each(index.params, function(param, values) {
+            state[param] = values[0];
+        });
+
+        if (state_selection !== null) {
+            /* Select a specific generic parameter state */
+            $.each(index.params, function(param, values) {
+                if (state_selection[param]) {
+                    state[param] = state_selection[param][0];
+                }
+            });
+        }
+
+        return state;
+    }
+
+    function replace_params_ui() {
+        var index = $.asv.master_json;
+
+        var nav = $('#summarylist-navigation');
+        nav.empty();
+        
+        /* Machine selection */
+        $.asv.make_value_selector_panel(nav, 'machine', index.params.machine,  function(i, machine, button) {
+            button.text(machine);
+
+            button.on('click', function(evt) {
+                update_state_url('machine', machine);
+            });
+
+            if (state.machine != machine) {
+                button.removeClass('active');
+            }
+            button.removeAttr('data-toggle');
+
+            /* Create tooltips for each machine */
+            var details = [];
+            $.each(index.machines[machine], function(key, val) {
+                details.push(key + ': ' + val);
+            });
+            details = details.join('<br/>');
+
+            button.tooltip({
+                title: details,
+                html: true,
+                placement: 'right',
+                container: 'body',
+                animation: false
+            });
+        });
+
+        /* Generic parameter selectors */
+        $.each(index.params, function(param, values) {
+            if (values.length > 1 && param != 'machine') {
+                $.asv.make_value_selector_panel(nav, param, values, function(i, value, button) {
+                    var value_display;
+                    if (value === null)
+                        value_display = '[none]';
+                    else if (!value)
+                        value_display = '[default]';
+                    else
+                        value_display = value;
+
+                    button.text(value_display);
+
+                    if (state[param] != value) {
+                        button.removeClass('active');
+                    }
+
+                    button.on('click', function(evt) {
+                        update_state_url(param, value);
+                    });
+                });
+            }
+        });
+
+        $(nav).find(".btn-group").removeAttr("data-toggle");
+
+        $.asv.reflow_value_selector_panels();
+    }
+
+    function replace_benchmark_table(data) {
+        var index = $.asv.master_json;
+        var body = $("#summarylist-body");
+
+        body.empty();
+
+        /* Form a new table */
+
+        var table = $('<table class="table table-hover"/>');
+
+        var table_head = $('<thead><tr>' +
+                           '<th data-sort="string">Benchmark</th>' +
+                           '<th data-sort="value">Value</th>' +
+                           '<th data-sort="factor">Recent change</th>' +
+                           '<th data-sort="string">Changed at</th>' +
+                           '</tr></thead>');
+        table.append(table_head);
+
+        var table_body = $('<tbody/>');
+
+        $.each(data, function(row_idx, row) {
+            var tr = $('<tr/>');
+            var name_td = $('<td/>');
+            var name = $('<a/>');
+            var url = '#/' + row.name;
+	    var benchmark_full_url;
+
+            if (row.idx === null) {
+                name_td.append($('<a/>').attr('href', url).text(row.pretty_name));
+		benchmark_full_url = url + '?';
+            }
+            else {
+                var basename = row.pretty_name;
+                var args = null;
+                var m = row.pretty_name.match(/(.*)\(.*$/);
+                if (m) {
+                    basename = m[1];
+                    args = row.pretty_name.slice(basename.length);
+                }
+                name_td.append($('<a/>').attr('href', url).text(basename));
+                if (args) {
+                    name_td.append($('<a/>').attr('href', url + '?idx=' + row.idx).text(' ' + args));
+                }
+		benchmark_full_url = url + '?idx=' + row.idx;
+            }
+
+            var value_td = $('<td class="value"/>');
+            if (row.last_value !== null) {
+                var value, err, err_str;
+                if ($.asv.master_json.benchmarks[row.name].unit == "seconds") {
+                    value = $.asv.pretty_second(row.last_value);
+                }
+                else {
+                    value = row.last_value.toPrecision(3);
+                }
+                err = 100*row.last_err/row.last_value;
+                if (err == err) {
+                    err_str = " \u00b1 " + err.toFixed(0.1) + '%';
+                }
+                else {
+                    err_str = "";
+                }
+                value_td.append($('<span/>').text(value + err_str));
+            }
+
+            var change_td = $('<td class="change"/>');
+            if (row.prev_value !== null) {
+                var text, change_str, change = 0;
+                if ($.asv.master_json.benchmarks[row.name].unit == "seconds") {
+                    change_str = $.asv.pretty_second(row.last_value - row.prev_value);
+                }
+                else {
+                    change_str = '' + (row.last_value - row.prev_value).toPrecision(3);
+                }
+                if (!change_str.match(/^-/)) {
+                    change_str = '+' + change_str;
+                }
+                if (row.prev_value != 0) {
+                    change = 100 * (row.last_value / row.prev_value - 1);
+                    text = change.toFixed(1) + '%  (' + change_str + ')';
+                    if (change > 0) {
+                        text = '+' + text;
+                    }
+                }
+                else {
+                    text = ' (' + change_str + ')';
+                }
+                text = text.replace('-', '\u2212');
+                change_td.append($('<a/>').attr('href', benchmark_full_url
+						+ '&commits='
+						+ $.asv.master_json.revision_to_hash[row.change_rev]
+					       ).text(text));
+                if (change > 5) {
+                    change_td.addClass('positive-change');
+                }
+                else if (change < -5) {
+                    change_td.addClass('negative-change');
+                }
+            }
+
+            var changed_at_td = $("<td/>");
+            if (row.change_rev !== null) {
+                var date = new Date($.asv.master_json.revision_to_date[row.change_rev]);
+                var commit = $.asv.get_commit_hash(row.change_rev);
+                var commit_a = $('<a/>');
+                var last_commit = $.asv.get_commit_hash(row.last_rev);
+                var last_commit_a = $('<a/>');
+                var span = $('<span/>');
+                commit_a.attr('href', $.asv.master_json.show_commit_url + commit);
+                commit_a.text(commit);
+                last_commit_a.attr('href', $.asv.master_json.show_commit_url + commit);
+                last_commit_a.text(commit);
+                span.text(' (' + date.toISOString() + ')');
+                span.prepend(commit_a);
+                changed_at_td.append(span);
+            }
+
+            tr.append(name_td);
+            tr.append(value_td);
+            tr.append(change_td);
+            tr.append(changed_at_td);
+
+            table_body.append(tr);
+        });
+
+        /* Finalize */
+        table.append(table_body);
+        setup_sort(table);
+        body.append(table);
+    }
+
+    function setup_sort(table) {
+        var info = $.asv.parse_hash_string(window.location.hash);
+
+        table.stupidtable({
+            'value': function(a, b) {
+                function key(s) {
+                    for (var k = 0; k < $.asv.time_units.length; ++k) {
+                        var entry = $.asv.time_units[k];
+                        var m = s.match('^([0-9.]+)' + entry[0] + ' .*');
+                        if (m) {
+                            return parseFloat(m[1]) * entry[2] * 1e-30;
+                        }
+                    }
+                    return parseFloat(s.replace(/\u00b1.*/, ''));
+                }
+                return key(a) - key(b)
+            },
+            'factor': function(a, b) {
+                var val_a = a.replace(/x/, '').replace(/\u2212/, '-').replace(/\(.*/, '');
+                var val_b = b.replace(/x/, '').replace(/\u2212/, '-').replace(/\(.*/, '');
+                if (!val_a) {
+                    val_a = '0';
+                }
+                if (!val_b) {
+                    val_b = '0';
+                }
+                return parseFloat(val_a) - parseFloat(val_b);
+            }
+        });
+
+        table.bind('aftertablesort', function (event, data) {
+            var info = $.asv.parse_hash_string(window.location.hash);
+            info.params['sort'] = [data.column];
+            info.params['dir'] = [data.direction];
+            window.location.hash = $.asv.format_hash_string(info);
+
+            /* Update appearance */
+            table.find('thead th').removeClass('asc');
+            table.find('thead th').removeClass('desc');
+            var th_to_sort = table.find("thead th").eq(parseInt(data.column));
+            if (th_to_sort) {
+                th_to_sort.addClass(data.direction);
+            }
+        });
+
+        if (info.params.sort && info.params.dir) {
+            var th_to_sort = table.find("thead th").eq(parseInt(info.params.sort[0]));
+            th_to_sort.stupidsort(info.params.dir[0]);
+        }
+        else {
+            var th_to_sort = table.find("thead th").eq(0);
+            th_to_sort.stupidsort("asc");
+        }
+    }
+
+    /*
+     * Entry point
+     */
+    $.asv.register_page('summarylist', function(params) {
+        var state_selection = null;
+
+        if (Object.keys(params).length > 0) {
+            state_selection = params;
+        }
+
+        setup_display(state_selection);
+
+        $('#summarylist-display').show();
+        $("#title").text("List of benchmarks");
+    });
+});

--- a/asv/www/summarylist.js
+++ b/asv/www/summarylist.js
@@ -75,7 +75,7 @@ $(document).ready(function() {
         nav.empty();
         
         /* Machine selection */
-        $.asv.make_value_selector_panel(nav, 'machine', index.params.machine,  function(i, machine, button) {
+        $.asv.ui.make_value_selector_panel(nav, 'machine', index.params.machine,  function(i, machine, button) {
             button.text(machine);
 
             button.on('click', function(evt) {
@@ -106,7 +106,7 @@ $(document).ready(function() {
         /* Generic parameter selectors */
         $.each(index.params, function(param, values) {
             if (values.length > 1 && param != 'machine') {
-                $.asv.make_value_selector_panel(nav, param, values, function(i, value, button) {
+                $.asv.ui.make_value_selector_panel(nav, param, values, function(i, value, button) {
                     var value_display;
                     if (value === null)
                         value_display = '[none]';
@@ -130,7 +130,7 @@ $(document).ready(function() {
 
         $(nav).find(".btn-group").removeAttr("data-toggle");
 
-        $.asv.reflow_value_selector_panels();
+        $.asv.ui.reflow_value_selector_panels();
     }
 
     function replace_benchmark_table(data) {

--- a/test/test_web.py
+++ b/test/test_web.py
@@ -141,7 +141,7 @@ def test_web_regressions(browser, tmpdir):
     with tools.preview(conf.html_dir) as base_url:
         get_with_retry(browser, base_url)
 
-        regressions_btn = browser.find_element_by_link_text('Show regressions')
+        regressions_btn = browser.find_element_by_link_text('Regressions')
         regressions_btn.click()
 
         # Check that the expected links appear in the table

--- a/test/test_web.py
+++ b/test/test_web.py
@@ -89,7 +89,7 @@ def basic_html(request):
     return conf.html_dir, dvcs
 
 
-def test_web_smoketest(browser, basic_html):
+def test_web_summarygrid(browser, basic_html):
     html_dir, dvcs = basic_html
 
     with tools.preview(html_dir) as base_url:
@@ -216,3 +216,20 @@ def test_web_regressions(browser, basic_html):
 
         popover = browser.find_element_by_css_selector('div.popover-content')
         flotplot = browser.find_element_by_css_selector('canvas.flot-base')
+
+
+def test_web_summarylist(browser, basic_html):
+    html_dir, dvcs = basic_html
+
+    bad_commit_hash = dvcs.get_hash('master~9')
+
+    browser.set_window_size(1200, 900)
+
+    with tools.preview(html_dir) as base_url:
+        get_with_retry(browser, base_url)
+
+        summarylist_btn = browser.find_element_by_link_text('Benchmark list')
+        summarylist_btn.click()
+
+        # Check links in the table
+        base_link = browser.find_element_by_link_text('params_examples.track_find_test')

--- a/test/test_web.py
+++ b/test/test_web.py
@@ -138,6 +138,8 @@ def test_web_regressions(browser, tmpdir):
 
     bad_commit_hash = dvcs.get_hash('master~9')
 
+    browser.set_window_size(1200, 900)
+
     with tools.preview(conf.html_dir) as base_url:
         get_with_retry(browser, base_url)
 

--- a/test/test_web.py
+++ b/test/test_web.py
@@ -239,6 +239,9 @@ def test_web_summarylist(browser, basic_html):
     from selenium.webdriver.support.ui import WebDriverWait
     from selenium.webdriver.support import expected_conditions as EC
     from selenium.webdriver import ActionChains
+    from selenium.common.exceptions import NoSuchElementException, StaleElementReferenceException
+
+    ignore_exc = (NoSuchElementException, StaleElementReferenceException)
 
     html_dir, dvcs = basic_html
 
@@ -273,6 +276,10 @@ def test_web_summarylist(browser, basic_html):
 
         # For the other CPU, there is no recent change recorded, only
         # the latest result is available
-        base_link = browser.find_element_by_link_text('params_examples.track_find_test')
-        cur_row = base_link.find_element_by_xpath('../..')
-        assert cur_row.text == 'params_examples.track_find_test (1) 2.00'
+        def check(*args):
+            base_link = browser.find_element_by_link_text('params_examples.track_find_test')
+            cur_row = base_link.find_element_by_xpath('../..')
+            return cur_row.text in ('params_examples.track_find_test (1) 2.00',
+                                    'params_examples.track_find_test (2) 2.00')
+        WebDriverWait(browser, 5, ignored_exceptions=ignore_exc).until(check)
+

--- a/test/test_web.py
+++ b/test/test_web.py
@@ -81,7 +81,7 @@ def basic_html(request):
         })
 
         tools.run_asv_with_conf(conf, 'run', 'ALL',
-                                '--show-stderr', '--quick',
+                                '--show-stderr', '--quick', '--bench=params_examples.*track_.*',
                                 _machine_file=machine_file)
 
         # Swap CPU info and obtain some results
@@ -91,7 +91,7 @@ def basic_html(request):
         util.write_json(machine_file, info, api_version=1)
 
         tools.run_asv_with_conf(conf, 'run', 'master~10..', '--steps=3',
-                                '--show-stderr', '--quick', '--bench=time_examples',
+                                '--show-stderr', '--quick', '--bench=params_examples.*track_.*',
                                 _machine_file=machine_file)
 
         # Output


### PR DESCRIPTION
Add a second summary page, showing a list of benchmarks (instead of a grid).

The list shows benchmarks only for one choice of environment parameters (machine, cpu, packages, ...) at once.

Also show how the benchmark performance has evolved "recently", some ideas borrowed from http://speed.pypy.org/changes/

Some overlap with the Regressions display, with the exception that regressions shows regressions across all branches, and does not show improved results.

Demo: https://pv.github.io/numpy-bench/#summarylist
https://pv.github.io/scipy-bench/#summarylist

- [x] what information should it actually show?
- [x] what does "recently" mean? 1 month, 10 revisions, ...?
- [x] what to do with benchmarks with no results?
- [x] the param selector should deal sensibly if there are no results for some param combination
- [x] tests, etc. polish
- [x] a selector for the time/revision range that you want to consider (e.g. show the worst regression ever vs. the last one vs. benchmark-specific configuration in the config file)
- [x] maybe add expandable view to show all regressions?
- [x] the popup graphs
