### PR TITLE
Fix combinatorial explosion in graph selection

### DIFF
--- a/asv/commands/publish.py
+++ b/asv/commands/publish.py
@@ -159,6 +159,13 @@ class Publish(Command):
                         graph = graphs.get_graph(key, cur_params)
                         graph.add_data_point(revisions[results.commit_hash], result)
 
+            # Get the parameter sets for all graphs
+            graph_param_list = []
+            for path, graph in graphs:
+                if 'summary' not in graph.params:
+                    if graph.params not in graph_param_list:
+                        graph_param_list.append(graph.params)
+
         log.step()
         log.info("Generating graphs")
         with log.indent():
@@ -194,6 +201,7 @@ class Publish(Command):
             'revision_to_hash': revision_to_hash,
             'revision_to_date': revision_to_date,
             'params': params,
+            'graph_param_list': graph_param_list,
             'benchmarks': benchmark_map,
             'machines': machines,
             'tags': tags,

--- a/asv/www/graphdisplay.js
+++ b/asv/www/graphdisplay.js
@@ -807,7 +807,16 @@ $(document).ready(function() {
             if (current_benchmark) {
                 /* For the current set of enabled parameters, generate a
                    list of all the permutations we need to load. */
-                var state_permutations = permutations(state);
+                var state_permutations = $.grep($.asv.master_json.graph_param_list, function (params) {
+                    var ok = true;
+                    $.each(state, function (key, values) {
+                        if ($.inArray(params[key], values) == -1) {
+                            ok = false;
+                        }
+                    });
+                    return ok;
+                });
+
                 /* Find where the parameters are different. */
                 var different = find_different_properties(state_permutations);
                 /* For parameterized tests: names of benchmark parameters */
@@ -821,7 +830,7 @@ $(document).ready(function() {
                 /* Generate a master list of URLs and legend labels for
                    the graphs. */
                 var all = [];
-                $.each(state_permutations, function(i, perm) {
+                $.each(state_permutations, function (i, perm) {
                     var graph_contents = [];
                     $.each(param_permutations, function(k, param_perm) {
                         /* For each state value, there can be several

--- a/test/test_publish.py
+++ b/test/test_publish.py
@@ -125,6 +125,23 @@ def test_publish(tmpdir):
     assert index['params']['Cython'] == ['', None]
     assert index['params']['ram'] == ['8.2G', 8804682956.8]
 
+    expected_graph_list = [{'Cython': cython, 'arch': 'x86_64',
+                            'branch': branch,
+                            'cpu': 'Intel(R) Core(TM) i5-2520M CPU @ 2.50GHz (4 cores)',
+                            'machine': 'cheetah',
+                            'numpy': '1.8',
+                            'os': 'Linux (Fedora 20)',
+                            'python': '2.7',
+                            'ram': '8.2G'}
+                            for cython in ["", None] for branch in ["master", "some-branch"]]
+    d = dict(expected_graph_list[0])
+    d['ram'] = 8804682956.8
+    expected_graph_list.append(d)
+
+    assert len(index['graph_param_list']) == len(expected_graph_list)
+    for item in expected_graph_list:
+        assert item in index['graph_param_list']
+
 
 @pytest.fixture(params=[
     "git",


### PR DESCRIPTION
Previously, the JS UI loaded the graphs by generating all parameter
combinations and then tried to http GET files to see which ones exist.
This is bad for performance.  Instead, save the list of all available
parameter combinations to index.json and filter based on that.

The permutation generation is OK for parameterized benchmarks, since
for those the result set is not sparse.

Fixes #438 