### PR TITLE
Fix two bugs in saving environment parameters in benchmarks

### DIFF
--- a/asv/benchmarks.py
+++ b/asv/benchmarks.py
@@ -409,7 +409,6 @@ class Benchmarks(dict):
         """
         path = self.get_benchmark_file_path(self._conf.results_dir)
         util.write_json(path, self._all_benchmarks, self.api_version)
-        del self._all_benchmarks['version']
 
     @classmethod
     def load(cls, conf, repo, environments):

--- a/asv/commands/run.py
+++ b/asv/commands/run.py
@@ -128,11 +128,9 @@ class Run(Command):
             show_stderr=False, quick=False, profile=False, env_spec=None,
             dry_run=False, machine=None, _machine_file=None, skip_successful=False,
             skip_failed=False, skip_existing_commits=False, _returns={}):
-        params = {}
         machine_params = Machine.load(
             machine_name=machine,
             _path=_machine_file, interactive=True)
-        params.update(machine_params.__dict__)
         machine_params.save(conf.results_dir)
 
         environments = list(environment.get_environments(conf, env_spec))
@@ -253,9 +251,11 @@ class Run(Command):
                             successes = map(_do_build, args)
 
                     for env, success in zip(subenv, successes):
+                        params = dict(machine_params.__dict__)
+                        params['python'] = env.python
+                        params.update(env.requirements)
+
                         if success:
-                            params['python'] = env.python
-                            params.update(env.requirements)
                             results = benchmarks.run_benchmarks(
                                 env, show_stderr=show_stderr, quick=quick,
                                 profile=profile, skip=skipped_benchmarks)

--- a/asv/util.py
+++ b/asv/util.py
@@ -539,6 +539,7 @@ def write_json(path, data, api_version=None):
         os.makedirs(dirname)
 
     if api_version is not None:
+        data = dict(data)
         data['version'] = api_version
 
     with long_path_open(path, 'w') as fd:

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -12,6 +12,7 @@ import shutil
 import pickle
 import multiprocessing
 import traceback
+import six
 import pytest
 
 from asv import console
@@ -114,3 +115,33 @@ def test_which_path(tmpdir):
             util.which('asv_test_exe_1234')
     finally:
         os.environ['PATH'] = old_path
+
+
+def test_write_load_json(tmpdir):
+    data = {
+        'a': 1,
+        'b': 2,
+        'c': 3
+    }
+    orig_data = dict(data)
+
+    filename = os.path.join(six.text_type(tmpdir), 'test.json')
+
+    util.write_json(filename, data)
+    data2 = util.load_json(filename)
+    assert data == orig_data
+    assert data2 == orig_data
+
+    util.write_json(filename, data, 3)
+    data2 = util.load_json(filename, 3)
+    assert data == orig_data
+    assert data2 == orig_data
+
+    # Wrong API version must fail to load
+    with pytest.raises(util.UserError):
+        util.load_json(filename, 2)
+    with pytest.raises(util.UserError):
+        util.load_json(filename, 4)
+    util.write_json(filename, data)
+    with pytest.raises(util.UserError):
+        util.load_json(filename, 3)

--- a/test/test_workflow.py
+++ b/test/test_workflow.py
@@ -267,10 +267,11 @@ def test_run_build_failure(basic_conf):
     timestamp = util.datetime_to_js_timestamp(datetime.datetime.utcnow())
 
     bench_name = 'time_secondary.track_value'
-    tools.run_asv_with_conf(conf, 'run', "master~2..",
-                            '--quick', '--show-stderr',
-                            '--bench', bench_name,
-                            _machine_file=machine_file)
+    for commit in ['master^!', 'master~1^!']:
+        tools.run_asv_with_conf(conf, 'run', commit,
+                                '--quick', '--show-stderr',
+                                '--bench', bench_name,
+                                _machine_file=machine_file)
 
     # Check results
     hashes = dvcs.get_branch_hashes()
@@ -290,3 +291,6 @@ def test_run_build_failure(basic_conf):
     assert len(data_ok['results']) == 1
     assert data_broken['results'][bench_name] is None
     assert data_ok['results'][bench_name] == 42.0
+
+    # Check that parameters were also saved
+    assert data_broken['params'] == data_ok['params']


### PR DESCRIPTION
Fix two bugs in saving environment parameters in benchmarks:

If build failed, the environment parameters were not saved. Also, since dict.update was called, parameters from previous environments could be mixed up in following results.

In practice, the wrong data causes e.g. spurious parameter combinations to appear in the UI.