### PR TITLE
Include autocorrelation to the noise model used in step detection

### DIFF
--- a/docs/source/_static/asv-doc.css
+++ b/docs/source/_static/asv-doc.css
@@ -1,0 +1,16 @@
+table.citation {
+    border: none;
+    margin-left: 2em;
+}
+
+table.citation td {
+    border: none !important;
+    padding: 0 !important;
+}
+
+table.citation td.label {
+    color: inherit;
+    vertical-align: baseline;
+    margin-right: 1em;
+    font: inherit;
+}

--- a/docs/source/_templates/layout.html
+++ b/docs/source/_templates/layout.html
@@ -8,3 +8,6 @@
     src="https://s3.amazonaws.com/github/ribbons/forkme_right_white_ffffff.png"
     alt="Fork me on GitHub"></a>
 {% endblock %}
+
+{# Custom CSS overrides #}
+{% set bootswatch_css_custom = ['_static/asv-doc.css'] %}

--- a/test/test_step_detect.py
+++ b/test/test_step_detect.py
@@ -85,6 +85,16 @@ def test_solve_potts():
 
 
 @pytest.mark.skipif(not HAVE_NUMPY, reason="test needs numpy")
+def test_autocorrelated():
+    # Check that a low-amplitude cosine signal is not intepreted as
+    # multiple steps
+    j = np.arange(1000)
+    y = 0.2 * np.cos(j/100.0) + 1.0 * (j >= 500)
+    right, values, dists, gamma = solve_potts_autogamma(y.tolist(), p=1)
+    assert right == [500, 1000]
+
+
+@pytest.mark.skipif(not HAVE_NUMPY, reason="test needs numpy")
 def test_detect_regressions():
     for seed in [1234, 5678, 8901, 2345]:
         np.random.seed(seed)


### PR DESCRIPTION
This is a simple-minded approach for accounting for some autocorrelation
in the benchmark result noise. It improves step detection quality
somewhat in cases where there is a smoothly varying background
superimposed on stepwise changes. This also allows using smaller
degrees-of-freedom counts.