### PR TITLE
Add Atom feed showing a list of regressions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -67,7 +67,7 @@ install:
     fi
     if [[ $TRAVIS_PYTHON_VERSION == 2* ]]; then $TRAVIS_PIP install mercurial ; fi;
     if [[ $TRAVIS_PYTHON_VERSION == 2* ]]; then $TRAVIS_PIP install python-hglib ; fi;
-    $TRAVIS_PIP install selenium six pytest;
+    $TRAVIS_PIP install selenium six pytest feedparser;
     if [[ $COVERAGE != '' ]]; then $TRAVIS_PIP install coverage pytest-coverage coveralls; fi;
 
 script:

--- a/asv/feed.py
+++ b/asv/feed.py
@@ -33,20 +33,31 @@ class FeedEntry(object):
         Link (alternate) for the entry
     content : str, optional
         Body HTML text for the entry.
+    id_context : list of str, optional
+        Material to generate unique IDs from. Feed readers show each id
+        as a separate entry, so if an entry is updated, it appears as
+        a new entry only if the id_context changes.
+        Default: [title, link, content]
 
     """
-    def __init__(self, title, updated, link=None, content=None):
+    def __init__(self, title, updated, link=None, content=None, id_context=None):
         self.title = title
         self.link = link
         self.updated = updated
         self.content = content
+        self.id_context = id_context
 
     def get_atom(self, id_prefix, language):
         item = etree.Element(ATOM_NS + 'entry')
 
+        id_context = ["entry"]
+        if self.id_context is None:
+            id_context += [self.title, self.link, self.content]
+        else:
+            id_context += list(self.id_context)
+
         el = etree.Element(ATOM_NS + 'id')
-        el.text = _get_id(id_prefix, self.updated,
-                          ["entry", self.title, self.link, self.content])
+        el.text = _get_id(id_prefix, self.updated, id_context)
         item.append(el)
 
         el = etree.Element(ATOM_NS + 'title')

--- a/asv/feed.py
+++ b/asv/feed.py
@@ -5,6 +5,7 @@ Minimal Atom feed writer.
 """
 from __future__ import absolute_import, division, unicode_literals, print_function
 
+import sys
 import datetime
 import hashlib
 import xml.etree.ElementTree as etree
@@ -144,8 +145,11 @@ def write_atom(dest, entries, author, title, address, updated=None, link=None,
     tree = etree.ElementTree(root)
 
     def write(f):
-        tree.write(f, xml_declaration=True, default_namespace=ATOM_NS[1:-1],
-                   encoding=str('utf-8'))
+        if sys.version_info[:2] < (2, 7):
+            _etree_py26_write(f, tree)
+        else:
+            tree.write(f, xml_declaration=True, default_namespace=ATOM_NS[1:-1],
+                       encoding=str('utf-8'))
 
     if hasattr(dest, 'write'):
         write(dest)
@@ -154,13 +158,48 @@ def write_atom(dest, entries, author, title, address, updated=None, link=None,
             write(f)
 
 
+def _etree_py26_write(f, tree):
+    """
+    Compatibility workaround for ElementTree shipped with py2.6
+    """
+    f.write("<?xml version='1.0' encoding='utf-8'?>\n".encode('utf-8'))
+
+    if etree.VERSION[:3] == '1.2':
+        def fixtag(tag, namespaces):
+            if tag == XML_NS + 'lang':
+                return 'xml:lang', ""
+            if '}' in tag:
+                j = tag.index('}') + 1
+                tag = tag[j:]
+                xmlns = ''
+            if tag == 'feed':
+                xmlns = ('xmlns', str('http://www.w3.org/2005/Atom'))
+                namespaces['http://www.w3.org/2005/Atom'] = 'xmlns'
+            return tag, xmlns
+    else:
+        fixtag = etree.fixtag
+
+    old_fixtag = etree.fixtag
+    etree.fixtag = fixtag
+    try:
+        tree.write(f, encoding=str('utf-8'))
+    finally:
+        etree.fixtag = old_fixtag
+
+
 def _get_id(owner, date, content):
     """
     Generate an unique Atom id for the given content
     """
     h = hashlib.sha256()
     h.update("github.com/spacetelescope/asv".encode('utf-8'))
-    h.update(repr(tuple(content)).encode('utf-8'))
+    for x in content:
+        if x is None:
+            h.update(",".encode('utf-8'))
+        else:
+            h.update(x.encode('utf-8'))
+        h.update(",".encode('utf-8'))
+
     if date is None:
         date = datetime.datetime(1970, 1, 1)
     return "tag:{0},{1}:/{2}".format(owner, date.strftime('%Y-%m-%d'), h.hexdigest())

--- a/asv/feed.py
+++ b/asv/feed.py
@@ -1,0 +1,166 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+# -*- coding: utf-8 -*-
+"""
+Minimal Atom feed writer.
+"""
+from __future__ import absolute_import, division, unicode_literals, print_function
+
+import datetime
+import hashlib
+import xml.etree.ElementTree as etree
+
+from . import util
+
+__all__ = ['FeedEntry', 'write_atom']
+
+
+ATOM_NS = "{http://www.w3.org/2005/Atom}"
+XML_NS = "{http://www.w3.org/XML/1998/namespace}"
+
+
+class FeedEntry(object):
+    """
+    Atom feed entry.
+
+    Parameters
+    ----------
+    title : str
+        Title of the entry
+    updated : datetime
+        Update date
+    link : str, optional
+        Link (alternate) for the entry
+    content : str, optional
+        Body HTML text for the entry.
+
+    """
+    def __init__(self, title, updated, link=None, content=None):
+        self.title = title
+        self.link = link
+        self.updated = updated
+        self.content = content
+
+    def get_atom(self, id_prefix, language):
+        item = etree.Element(ATOM_NS + 'entry')
+
+        el = etree.Element(ATOM_NS + 'id')
+        el.text = _get_id(id_prefix, self.updated,
+                          ["entry", self.title, self.link, self.content])
+        item.append(el)
+
+        el = etree.Element(ATOM_NS + 'title')
+        el.attrib[XML_NS + 'lang'] = language
+        el.text = self.title
+        item.append(el)
+
+        el = etree.Element(ATOM_NS + 'updated')
+        el.text = self.updated.strftime('%Y-%m-%dT%H:%M:%SZ')
+        item.append(el)
+
+        if self.link:
+            el = etree.Element(ATOM_NS + 'link')
+            el.attrib[ATOM_NS + 'href'] = self.link
+            item.append(el)
+
+        el = etree.Element(ATOM_NS + 'content')
+        el.attrib[XML_NS + 'lang'] = language
+        if self.content:
+            el.text = self.content
+            el.attrib[ATOM_NS + 'type'] = 'html'
+        else:
+            el.text = ' '
+        item.append(el)
+
+        return item
+
+
+def write_atom(dest, entries, author, title, address, updated=None, link=None,
+               language="en"):
+    """
+    Write an atom feed to a file.
+
+    Parameters
+    ----------
+    dest : str
+        Destination file path, or a file-like object
+    entries : list of FeedEntry
+        Feed entries.
+    author : str
+        Author of the feed.
+    title : str
+        Title for the feed.
+    address : str
+        Address (domain name or email) to be used in building unique IDs.
+    updated : datetime, optional
+        Time stamp for the feed. If not given, take from the newest entry.
+    link : str, optional
+        Link for the feed.
+    language : str, optional
+        Language of the feed. Default is 'en'.
+
+    """
+
+    if updated is None:
+        if entries:
+            updated = max(entry.updated for entry in entries)
+        else:
+            updated = datetime.datetime.utcnow()
+
+    root = etree.Element(ATOM_NS + 'feed')
+
+    # id (obligatory)
+    el = etree.Element(ATOM_NS + 'id')
+    el.text = _get_id(address, None, ["feed", author, title])
+    root.append(el)
+
+    # author (obligatory)
+    el = etree.Element(ATOM_NS + 'author')
+    el2 = etree.Element(ATOM_NS + 'name')
+    el2.text = author
+    el.append(el2)
+    root.append(el)
+
+    # title (obligatory)
+    el = etree.Element(ATOM_NS + 'title')
+    el.attrib[XML_NS + 'lang'] = language
+    el.text = title
+    root.append(el)
+
+    # updated (obligatory)
+    el = etree.Element(ATOM_NS + 'updated')
+    el.text = updated.strftime('%Y-%m-%dT%H:%M:%SZ')
+    root.append(el)
+
+    # link
+    if link is not None:
+        el = etree.Element(ATOM_NS + 'link')
+        el.attrib[ATOM_NS + 'href'] = link
+        root.append(el)
+
+    # entries
+    for entry in entries:
+        root.append(entry.get_atom(address, language))
+
+    tree = etree.ElementTree(root)
+
+    def write(f):
+        tree.write(f, xml_declaration=True, default_namespace=ATOM_NS[1:-1],
+                   encoding=str('utf-8'))
+
+    if hasattr(dest, 'write'):
+        write(dest)
+    else:
+        with util.long_path_open(dest, 'wb') as f:
+            write(f)
+
+
+def _get_id(owner, date, content):
+    """
+    Generate an unique Atom id for the given content
+    """
+    h = hashlib.sha256()
+    h.update("github.com/spacetelescope/asv".encode('utf-8'))
+    h.update(repr(tuple(content)).encode('utf-8'))
+    if date is None:
+        date = datetime.datetime(1970, 1, 1)
+    return "tag:{0},{1}:/{2}".format(owner, date.strftime('%Y-%m-%d'), h.hexdigest())

--- a/asv/plugins/regressions.py
+++ b/asv/plugins/regressions.py
@@ -219,7 +219,14 @@ class Regressions(OutputPublisher):
                 Latest value: {last_value_str} ({best_percentage} worse than best value {best_value_str}).
                 """.format(**locals()).strip()
 
-                entries.append(feed.FeedEntry(title, updated, link, summary))
+                # Information that uniquely identifies a regression
+                # --- if the values and the texts change on later
+                # runs, feed readers should is identify the regression
+                # as the same one, as long as the benchmark name and
+                # commits match.
+                id_context = [name, revision_to_hash.get(rev1, ""), revision_to_hash.get(rev2, "")]
+
+                entries.append(feed.FeedEntry(title, updated, link, summary, id_context))
 
         entries.sort(key=lambda x: x.updated, reverse=True)
 

--- a/asv/plugins/regressions.py
+++ b/asv/plugins/regressions.py
@@ -11,7 +11,8 @@ import multiprocessing
 import time
 import traceback
 import six
-import urllib
+
+from six.moves.urllib.parse import urlencode
 
 from ..results import iter_results
 from ..console import log
@@ -167,14 +168,15 @@ class Regressions(OutputPublisher):
                 updated = datetime.datetime.fromtimestamp(last_timestamp/1000)
 
                 params = dict(graph_params)
-                params['idx'] = idx
+                if idx is not None:
+                    params['idx'] = idx
                 if rev1 is None:
                     params['commits'] = '{0}'.format(revision_to_hash[rev2])
                 else:
                     params['commits'] = '{0}-{1}'.format(revision_to_hash[rev1],
                                                          revision_to_hash[rev2])
 
-                link = 'index.html#{0}?{1}'.format(benchmark_name, urllib.urlencode(params))
+                link = 'index.html#{0}?{1}'.format(benchmark_name, urlencode(params))
 
                 try:
                     best_percentage = "{0:.2f}%".format(100 * (last_value - best_value) / best_value)

--- a/asv/plugins/regressions.py
+++ b/asv/plugins/regressions.py
@@ -6,16 +6,20 @@ from __future__ import absolute_import, division, unicode_literals, print_functi
 import os
 import re
 import itertools
+import datetime
 import multiprocessing
 import time
 import traceback
 import six
+import urllib
 
+from ..results import iter_results
 from ..console import log
 from ..publishing import OutputPublisher
 from ..step_detect import detect_regressions
 
 from .. import util
+from .. import feed
 
 
 class Regressions(OutputPublisher):
@@ -73,6 +77,7 @@ class Regressions(OutputPublisher):
             pool.terminate()
 
         cls._save(conf, {'regressions': regressions})
+        cls._save_feed(conf, benchmarks, regressions, revisions, revision_to_hash)
 
     @classmethod
     def _insert_regression(cls, regressions, seen, revision_to_hash, repo, all_params,
@@ -89,7 +94,7 @@ class Regressions(OutputPublisher):
             spec = repo.get_range_spec(commit_a, commit_b)
             commits = repo.get_hashes_from_range(spec)
             if len(commits) == 1:
-                jumps[k] = (None, jump[1])
+                jumps[k] = (None, jump[1], jump[2], jump[3])
 
         # Select unique graph params
         graph_params = {}
@@ -118,6 +123,109 @@ class Regressions(OutputPublisher):
         fn = os.path.join(conf.html_dir, 'regressions.json')
         util.write_json(fn, data)
 
+    @classmethod
+    def _save_feed(cls, conf, benchmarks, data, revisions, revision_to_hash):
+        """
+        Save the results as an Atom feed
+        """
+
+        filename = os.path.join(conf.html_dir, 'regressions.xml')
+
+        # Determine publication date as the date when the benchmark
+        # was run --- if it is missing, use the date of the commit
+        run_timestamps = {}
+        revision_timestamps = {}
+        for results in iter_results(conf.results_dir):
+            revision = revisions[results.commit_hash]
+            revision_timestamps[revision] = results.date
+
+            # Time when the benchmark was run
+            for benchmark_name, timestamp in six.iteritems(results.ended_at):
+                key = (benchmark_name, revision)
+                run_timestamps[key] = timestamp
+
+            # Fallback to commit date
+            for benchmark_name in six.iterkeys(results.results):
+                key = (benchmark_name, revision)
+                run_timestamps.setdefault(key, results.date)
+
+        # Generate feed entries
+        entries = []
+
+        for name, graph_path, graph_params, idx, info in data:
+            if '(' in name:
+                benchmark_name = name[:name.index('(')]
+            else:
+                benchmark_name = name
+
+            jumps, last_value, best_value = info
+
+            for rev1, rev2, value1, value2 in jumps:
+                timestamps = (run_timestamps[benchmark_name, t] for t in (rev1, rev2) if t is not None)
+                last_timestamp = max(timestamps)
+
+                updated = datetime.datetime.fromtimestamp(last_timestamp/1000)
+
+                params = dict(graph_params)
+                params['idx'] = idx
+                if rev1 is None:
+                    params['commits'] = '{0}'.format(revision_to_hash[rev2])
+                else:
+                    params['commits'] = '{0}-{1}'.format(revision_to_hash[rev1],
+                                                         revision_to_hash[rev2])
+
+                link = 'index.html#{0}?{1}'.format(benchmark_name, urllib.urlencode(params))
+
+                try:
+                    best_percentage = "{0:.2f}%".format(100 * (last_value - best_value) / best_value)
+                except ZeroDivisionError:
+                    best_percentage = "{0:.2g} units".format(last_value - best_value)
+
+                try:
+                    percentage = "{0:.2f}%".format(100 * (value2 - value1) / value1)
+                except ZeroDivisionError:
+                    percentage = "{0:.2g} units".format(value2 - value1)
+
+                jump_date = datetime.datetime.fromtimestamp(revision_timestamps[rev2]/1000)
+                jump_date_str = jump_date.strftime('%Y-%m-%d %H:%M:%S')
+
+                if rev1 is not None:
+                    commit_a = revision_to_hash[rev1]
+                    commit_b = revision_to_hash[rev2]
+                    if 'github.com' in conf.show_commit_url:
+                        commit_url = conf.show_commit_url + '../compare/' + commit_a + "..." + commit_b
+                    else:
+                        commit_url = conf.show_commit_url + commit_a
+                    commit_ref = 'in commits <a href="{0}">{1}...{2}</a>'.format(commit_url,
+                                                                                 commit_a[:8],
+                                                                                 commit_b[:8])
+                else:
+                    commit_a = revision_to_hash[rev2]
+                    commit_url = conf.show_commit_url + commit_a
+                    commit_ref = 'in commit <a href="{0}">{1}</a>'.format(commit_url, commit_a[:8])
+
+                unit = benchmarks[benchmark_name].get('unit', '')
+                best_value_str = util.human_value(best_value, unit)
+                last_value_str = util.human_value(last_value, unit)
+                value1_str = util.human_value(value1, unit)
+                value2_str = util.human_value(value2, unit)
+
+                title = "{percentage} {name}".format(**locals())
+                summary = """
+                <a href="{link}">{percentage} regression</a> on {jump_date_str} {commit_ref}.<br>
+                New value: {value2_str}, old value: {value1_str}.<br>
+                Latest value: {last_value_str} ({best_percentage} worse than best value {best_value_str}).
+                """.format(**locals()).strip()
+
+                entries.append(feed.FeedEntry(title, updated, link, summary))
+
+        entries.sort(key=lambda x: x.updated, reverse=True)
+
+        feed.write_atom(filename, entries,
+                        title='{0} performance regressions'.format(conf.project),
+                        author='Airspeed Velocity',
+                        address='{0}.asv'.format(conf.project))
+
 
 def _analyze_data(graph_data):
     """
@@ -125,12 +233,12 @@ def _analyze_data(graph_data):
 
     Returns
     -------
-    jumps : list of (revision_a, revision_b)
+    jumps : list of (revision_a, revision_b, prev_value, next_value)
          List of revision pairs, between which there is an upward jump
-         in the value.
-    cur_value : int
+         in the value, and the preceding and following values.
+    cur_value : float
          Most recent value
-    best_value : int
+    best_value : float
          Best value
     """
     try:
@@ -145,10 +253,14 @@ def _analyze_data(graph_data):
             for r in range(jump_r + 1, len(values)):
                 if values[r] is not None:
                     next_r = r
+                    next_value = values[r]
                     break
             else:
                 next_r = jump_r + 1
-            jumps.append((revisions[jump_r], revisions[next_r]))
+                next_value = v
+            prev_value = values[jump_r]
+            jumps.append((revisions[jump_r], revisions[next_r],
+                          prev_value, next_value))
 
         return j, entry_name, (jumps, v, best_v)
     except BaseException as exc:
@@ -242,3 +354,4 @@ class _GraphDataFilter(object):
                 revision_set = revision_set.intersection(self.revision_sets[key])
 
         return revision_set
+

--- a/asv/www/index.html
+++ b/asv/www/index.html
@@ -62,6 +62,7 @@
     <link href="asv.css" rel="stylesheet" type="text/css"/>
     <link href="regressions.css" rel="stylesheet" type="text/css"/>
     <link rel="shortcut icon" href="swallow.ico"/>
+    <link rel="alternate" type="application/atom+xml" title="Regressions" href="regressions.xml"/>
   </head>
   <body>
     <nav id="nav" class="navbar navbar-left navbar-default navbar-fixed-top" role="navigation">

--- a/asv/www/regressions.css
+++ b/asv/www/regressions.css
@@ -20,3 +20,7 @@
 #regressions-body table.ignored a {
     color: #82abda;
 }
+
+#regressions-body .feed-div {
+    float: right;
+}

--- a/asv/www/regressions.js
+++ b/asv/www/regressions.js
@@ -61,6 +61,9 @@ $(document).ready(function() {
             main_div.append(dropdown_div);
         }
 
+        var feed_div = $('<div class="feed-div"><a class="btn" href="regressions.xml">Feed (Atom)</a></div>');
+        main_div.append(feed_div);
+
         $.each(branches, function(i, branch) {
             var branch_div = $('<div class="regression-div"/>')
 

--- a/test/test_feed.py
+++ b/test/test_feed.py
@@ -5,6 +5,7 @@ from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
 import io
+import sys
 import datetime
 import xml.etree.ElementTree as etree
 import xml.dom.minidom
@@ -33,7 +34,7 @@ def prettify_xml(text):
 
 
 def dummy_feed_xml():
-    entry_1 = feed.FeedEntry(title='Some title', updated=datetime.datetime.utcnow())
+    entry_1 = feed.FeedEntry(title='Some title', updated=datetime.datetime(1993, 1, 1))
     entry_2 = feed.FeedEntry(title='Another title', updated=datetime.datetime(1990, 1, 1),
                              link='http://foo', content='More text')
 
@@ -44,12 +45,48 @@ def dummy_feed_xml():
     return stream.getvalue()
 
 
-def test_smoketest():
-    # Check the result is valid XML and has sensible content
+def test_dummy_xml():
     xml = dummy_feed_xml()
-    root = etree.fromstring(xml)
-    entries = root.findall('{http://www.w3.org/2005/Atom}entry')
-    assert len(entries) == 2
+    text = xml.decode('utf-8').replace('>', '>\n')
+
+    expected = """\
+<?xml version='1.0' encoding='utf-8'?>
+
+<feed xmlns="http://www.w3.org/2005/Atom">
+<id>
+tag:baz.com,1970-01-01:/82438e6f2527536e1271ba04e05f31b7fcbef238753fb5069b1fd52a9242173a</id>
+<author>
+<name>
+Me</name>
+</author>
+<title xml:lang="en">
+Feed title</title>
+<updated>
+1993-01-01T00:00:00Z</updated>
+<entry>
+<id>
+tag:baz.com,1993-01-01:/9c12e06399d193907df13570525d9887b7f8e8f5ff23ddd7e9938416d490ff78</id>
+<title xml:lang="en">
+Some title</title>
+<updated>
+1993-01-01T00:00:00Z</updated>
+<content xml:lang="en">
+ </content>
+</entry>
+<entry>
+<id>
+tag:baz.com,1990-01-01:/a413675aef85f04bef68c6ec832563e56cff679bcdbb210a1f7dd797dddc844e</id>
+<title xml:lang="en">
+Another title</title>
+<updated>
+1990-01-01T00:00:00Z</updated>
+<link href="http://foo" />
+<content type="html" xml:lang="en">
+More text</content>
+</entry>
+</feed>
+"""
+    assert text == expected
 
 
 @pytest.mark.skipif(not HAVE_FEEDPARSER, reason="test requires feedparser module")
@@ -61,9 +98,9 @@ def test_feedparser():
     assert feed['entries'][0]['title'] == 'Some title'
     assert feed['entries'][1]['content'][0]['type'] == 'text/html'
     assert feed['entries'][1]['content'][0]['value'] == 'More text'
-    assert feed['entries'][1]['links'] == [{'href': u'http://foo',
-                                            'type': u'text/html',
-                                            'rel': u'alternate'}]
+    assert feed['entries'][1]['links'] == [{'href': 'http://foo',
+                                            'type': 'text/html',
+                                            'rel': 'alternate'}]
 
 
 @pytest.mark.skipif(not HAVE_FEEDVALIDATOR, reason="test requires feedvalidator module")

--- a/test/test_feed.py
+++ b/test/test_feed.py
@@ -36,7 +36,7 @@ def prettify_xml(text):
 def dummy_feed_xml():
     entry_1 = feed.FeedEntry(title='Some title', updated=datetime.datetime(1993, 1, 1))
     entry_2 = feed.FeedEntry(title='Another title', updated=datetime.datetime(1990, 1, 1),
-                             link='http://foo', content='More text')
+                             link='http://foo', content='More text', id_context=['something'])
 
     stream = io.BytesIO()
     feed.write_atom(stream, [entry_1, entry_2], author='Me', title='Feed title',
@@ -75,7 +75,7 @@ Some title</title>
 </entry>
 <entry>
 <id>
-tag:baz.com,1990-01-01:/a413675aef85f04bef68c6ec832563e56cff679bcdbb210a1f7dd797dddc844e</id>
+tag:baz.com,1990-01-01:/abd78e0420c232c75f3e7582946dac13e18a54b0b5542fbc3159458f8b16fd4f</id>
 <title xml:lang="en">
 Another title</title>
 <updated>

--- a/test/test_feed.py
+++ b/test/test_feed.py
@@ -1,0 +1,82 @@
+# -*- coding: utf-8 -*-
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+
+from __future__ import (absolute_import, division, print_function,
+                        unicode_literals)
+
+import io
+import datetime
+import xml.etree.ElementTree as etree
+import xml.dom.minidom
+
+import pytest
+
+from asv import feed
+
+
+try:
+    import feedparser
+    HAVE_FEEDPARSER = True
+except ImportError:
+    HAVE_FEEDPARSER = False
+
+
+try:
+    import feedvalidator
+    HAVE_FEEDVALIDATOR = True
+except ImportError:
+    HAVE_FEEDVALIDATOR = False
+
+
+def prettify_xml(text):
+    return xml.dom.minidom.parseString(text).toprettyxml()
+
+
+def dummy_feed_xml():
+    entry_1 = feed.FeedEntry(title='Some title', updated=datetime.datetime.utcnow())
+    entry_2 = feed.FeedEntry(title='Another title', updated=datetime.datetime(1990, 1, 1),
+                             link='http://foo', content='More text')
+
+    stream = io.BytesIO()
+    feed.write_atom(stream, [entry_1, entry_2], author='Me', title='Feed title',
+                    address='baz.com')
+
+    return stream.getvalue()
+
+
+def test_smoketest():
+    # Check the result is valid XML and has sensible content
+    xml = dummy_feed_xml()
+    root = etree.fromstring(xml)
+    entries = root.findall('{http://www.w3.org/2005/Atom}entry')
+    assert len(entries) == 2
+
+
+@pytest.mark.skipif(not HAVE_FEEDPARSER, reason="test requires feedparser module")
+def test_feedparser():
+    # Check the result parses as a feed
+    xml = dummy_feed_xml()
+    feed = feedparser.parse(xml)
+
+    assert feed['entries'][0]['title'] == 'Some title'
+    assert feed['entries'][1]['content'][0]['type'] == 'text/html'
+    assert feed['entries'][1]['content'][0]['value'] == 'More text'
+    assert feed['entries'][1]['links'] == [{'href': u'http://foo',
+                                            'type': u'text/html',
+                                            'rel': u'alternate'}]
+
+
+@pytest.mark.skipif(not HAVE_FEEDVALIDATOR, reason="test requires feedvalidator module")
+def test_feedvalidator():
+    xml = prettify_xml(dummy_feed_xml())
+    result = feedvalidator.validateString(xml)
+
+    ok_messages = (feedvalidator.ValidValue, feedvalidator.MissingSelf)
+
+    assert result['feedType'] == feedvalidator.TYPE_ATOM
+
+    for message in result['loggedEvents']:
+        if not isinstance(message, ok_messages):
+            print(xml)
+            print(message.params)
+        assert isinstance(message, ok_messages), message

--- a/test/test_publish.py
+++ b/test/test_publish.py
@@ -11,6 +11,7 @@ import shutil
 
 import six
 import pytest
+import xml.etree.ElementTree as etree
 try:
     import hglib
 except ImportError:
@@ -177,7 +178,7 @@ def test_regression_simple(generate_result_dir):
     tools.run_asv_with_conf(conf, "publish")
     regressions = util.load_json(join(conf.html_dir, "regressions.json"))
     expected = {"regressions": [["time_func", _graph_path(repo.dvcs), {}, None, [
-        [[None, 5]], 10.0, 1.0,
+        [[None, 5, 1.0, 10.0]], 10.0, 1.0,
     ]]]}
     assert regressions == expected
 
@@ -187,7 +188,7 @@ def test_regression_range(generate_result_dir):
     tools.run_asv_with_conf(conf, "publish")
     regressions = util.load_json(join(conf.html_dir, "regressions.json"))
     expected = {"regressions": [["time_func", _graph_path(repo.dvcs), {}, None, [
-        [[4, 6]], 10.0, 1.0,
+        [[4, 6, 1.0, 10.0]], 10.0, 1.0,
     ]]]}
     assert regressions == expected
 
@@ -205,7 +206,7 @@ def test_regression_double(generate_result_dir):
     tools.run_asv_with_conf(conf, "publish")
     regressions = util.load_json(join(conf.html_dir, "regressions.json"))
     expected = {"regressions": [["time_func", _graph_path(repo.dvcs), {}, None, [
-        [[None, 5], [None, 10]], 15.0, 1.0,
+        [[None, 5, 1.0, 10.0], [None, 10, 10.0, 15.0]], 15.0, 1.0,
     ]]]}
     assert regressions == expected
 
@@ -229,7 +230,7 @@ def test_regression_first_commits(generate_result_dir):
     tools.run_asv_with_conf(conf, "publish")
     regressions = util.load_json(join(conf.html_dir, "regressions.json"))
     expected = {"regressions": [["time_func", _graph_path(repo.dvcs), {}, None, [
-        [[None, 5]], 10.0, 1.0,
+        [[None, 5, 1.0, 10.0]], 10.0, 1.0,
     ]]]}
     assert regressions == expected
 
@@ -245,13 +246,13 @@ def test_regression_parameterized(generate_result_dir):
         _graph_path(repo.dvcs),
         {},
         0,
-        [[[None, 5]], 6.0, 5.0],
+        [[[None, 5, 5.0, 6.0]], 6.0, 5.0],
     ], [
         'time_func(c)',
         _graph_path(repo.dvcs),
         {},
         2,
-        [[[None, 5]], 10.0, 1.0],
+        [[[None, 5, 1.0, 10.0]], 10.0, 1.0],
     ]]}
     assert regressions == expected
 
@@ -304,7 +305,7 @@ def test_regression_multiple_branches(dvcs_type, tmpdir):
     # Regression occur on 5th commit of stable branch
     revision = repo.get_revisions(commit_values.keys())[branches["stable"][5]]
     expected = {'regressions': [['time_func', graph_path, {'branch': 'stable'}, None,
-                                 [[[None, revision]], 2.0, 1.0]]]}
+                                 [[[None, revision, 1.0, 2.0]], 2.0, 1.0]]]}
     assert regressions == expected
 
 
@@ -329,5 +330,31 @@ def test_regression_non_monotonic(dvcs_type, tmpdir):
     tools.run_asv_with_conf(conf, "publish")
     regressions = util.load_json(join(conf.html_dir, "regressions.json"))
     expected = {'regressions': [['time_func', _graph_path(dvcs_type), {}, None,
-                                 [[[None, 5]], 2.0, 1.0]]]}
+                                 [[[None, 5, 1.0, 2.0]], 2.0, 1.0]]]}
     assert regressions == expected
+
+
+def test_regression_atom_feed(generate_result_dir):
+    conf, repo, commits = generate_result_dir(5 * [1] + 5 * [10] + 5 * [15])
+    tools.run_asv_with_conf(conf, "publish")
+
+    commits = list(reversed(repo.get_branch_commits(None)))
+
+    tree = etree.parse(join(conf.html_dir, "regressions.xml"))
+    root = tree.getroot()
+
+    assert root.tag == '{http://www.w3.org/2005/Atom}feed'
+    entries = root.findall('{http://www.w3.org/2005/Atom}entry')
+
+    # Check entry titles
+    assert len(entries) == 2
+    title = entries[0].find('{http://www.w3.org/2005/Atom}title')
+    assert title.text == '900.00% time_func'
+    title = entries[1].find('{http://www.w3.org/2005/Atom}title')
+    assert title.text == '50.00% time_func'
+
+    # Check there's a link of some sort to the website in the content
+    content = entries[0].find('{http://www.w3.org/2005/Atom}content')
+    assert ('<a href="index.html#time_func?commits=' + commits[5]) in content.text
+    content = entries[1].find('{http://www.w3.org/2005/Atom}content')
+    assert ('<a href="index.html#time_func?commits=' + commits[10]) in content.text


### PR DESCRIPTION
Implement an Atom feed displaying a list of regressions.

Each feed entry contains the magnitude of change and benchmark name in the title. The body contains benchmark values and information when and on what commit the regression occurred, and the new and old benchmark result values. The publication date of an entry is determined by the date when the benchmark was run (if not recorded in old results, falls back to commit date).

Demo (link on upper right): https://pav.iki.fi/tmp/asv-feed/html-numpy/#regressions
https://pav.iki.fi/tmp/asv-feed/html-scipy/#regressions

Discussed in #397