### PR TITLE
Add a configurable threshold to regression reporting

### DIFF
--- a/asv/commands/publish.py
+++ b/asv/commands/publish.py
@@ -6,6 +6,7 @@ from __future__ import (absolute_import, division, print_function,
 
 import os
 import shutil
+import multiprocessing
 
 import six
 
@@ -74,7 +75,7 @@ class Publish(Command):
         machines = {}
         benchmark_names = set()
 
-        log.set_nitems(5 + len(list(util.iter_subclasses(OutputPublisher))))
+        log.set_nitems(6 + len(list(util.iter_subclasses(OutputPublisher))))
 
         if os.path.exists(conf.html_dir):
             util.long_path_rmtree(conf.html_dir)
@@ -165,6 +166,16 @@ class Publish(Command):
                 if 'summary' not in graph.params:
                     if graph.params not in graph_param_list:
                         graph_param_list.append(graph.params)
+
+        log.step()
+        log.info("Detecting steps")
+        with log.indent():
+            n_processes = multiprocessing.cpu_count()
+            pool = multiprocessing.Pool(n_processes)
+            try:
+                graphs.detect_steps(pool, dots=log.dot)
+            finally:
+                pool.terminate()
 
         log.step()
         log.info("Generating graphs")

--- a/asv/config.py
+++ b/asv/config.py
@@ -37,6 +37,7 @@ class Config(object):
         self.install_timeout = 600
         self.dvcs = None
         self.regressions_first_commits = {}
+        self.regressions_thresholds = {}
         self.plugins = []
 
     @classmethod

--- a/asv/plugins/regressions.py
+++ b/asv/plugins/regressions.py
@@ -17,7 +17,7 @@ from six.moves.urllib.parse import urlencode
 from ..results import iter_results
 from ..console import log
 from ..publishing import OutputPublisher
-from ..step_detect import detect_regressions
+from ..step_detect import detect_regressions, detect_steps
 
 from .. import util
 from .. import feed
@@ -40,55 +40,38 @@ class Regressions(OutputPublisher):
         data_filter = _GraphDataFilter(conf, repo, revisions)
 
         all_params = graphs.get_params()
-        last_percentage_time = time.time()
 
-        n_processes = multiprocessing.cpu_count()
-        pool = multiprocessing.Pool(n_processes)
-        try:
-            results = []
-            for j, (file_name, graph) in enumerate(graphs):
-                if 'summary' in graph.params:
-                    continue
+        for j, (file_name, graph) in enumerate(graphs):
+            if 'summary' in graph.params:
+                continue
 
-                # Print progress status
-                log.add('.')
-                if time.time() - last_percentage_time > 5:
-                    log.add('{0:.0f}%'.format(100*j/len(graphs)))
-                    last_percentage_time = time.time()
+            benchmark_name = os.path.basename(file_name)
+            benchmark = benchmarks.get(benchmark_name)
+            if not benchmark:
+                continue
 
-                benchmark_name = os.path.basename(file_name)
-                benchmark = benchmarks.get(benchmark_name)
-                if not benchmark:
-                    continue
+            log.add('.')
 
-                graph_data = data_filter.get_graph_data(graph, benchmark)
-                for data in graph_data:
-                    results.append((pool.apply_async(_analyze_data, (data,), {}), graph))
-
-                while len(results) > n_processes:
-                    r, graph = results.pop(0)
-                    cls._insert_regression(regressions, seen, revision_to_hash, repo, all_params,
-                                           r.get(), graph)
-
-            while results:
-                r, graph = results.pop(0)
-                cls._insert_regression(regressions, seen, revision_to_hash, repo, all_params,
-                                       r.get(), graph)
-        finally:
-            pool.terminate()
+            for graph_data in data_filter.get_graph_data(graph, benchmark):
+                cls._process_regression(regressions, seen, revision_to_hash, repo, all_params,
+                                        graph_data, graph)
 
         cls._save(conf, {'regressions': regressions})
         cls._save_feed(conf, benchmarks, regressions, revisions, revision_to_hash)
 
     @classmethod
-    def _insert_regression(cls, regressions, seen, revision_to_hash, repo, all_params,
-                           result_item, graph):
-        j, entry_name, result = result_item
-        if result is None:
+    def _process_regression(cls, regressions, seen, revision_to_hash, repo, all_params,
+                           graph_data, graph):
+        j, entry_name, steps = graph_data
+
+        v, best_v, jumps = detect_regressions(steps)
+
+        if v is None:
             return
 
+        result = (jumps, v, best_v)
+
         # Check which ranges are a single commit
-        jumps = result[0]
         for k, jump in enumerate(jumps):
             commit_a = revision_to_hash[jump[0]]
             commit_b = revision_to_hash[jump[1]]
@@ -236,46 +219,6 @@ class Regressions(OutputPublisher):
                         address='{0}.asv'.format(conf.project))
 
 
-def _analyze_data(graph_data):
-    """
-    Analyze a single series
-
-    Returns
-    -------
-    jumps : list of (revision_a, revision_b, prev_value, next_value)
-         List of revision pairs, between which there is an upward jump
-         in the value, and the preceding and following values.
-    cur_value : float
-         Most recent value
-    best_value : float
-         Best value
-    """
-    try:
-        j, entry_name, revisions, values = graph_data
-
-        v, jump_pos, best_v = detect_regressions(values)
-        if v is None:
-            return j, entry_name, None
-
-        jumps = []
-        for jump_r in jump_pos:
-            for r in range(jump_r + 1, len(values)):
-                if values[r] is not None:
-                    next_r = r
-                    next_value = values[r]
-                    break
-            else:
-                next_r = jump_r + 1
-                next_value = v
-            prev_value = values[jump_r]
-            jumps.append((revisions[jump_r], revisions[next_r],
-                          prev_value, next_value))
-
-        return j, entry_name, (jumps, v, best_v)
-    except BaseException as exc:
-        raise util.ParallelFailure(str(exc), exc.__class__, traceback.format_exc())
-
-
 class _GraphDataFilter(object):
     """
     Obtain data sets from graphs, following configuration settings.
@@ -285,7 +228,7 @@ class _GraphDataFilter(object):
         self.conf = conf
         self.repo = repo
         self.revisions = revisions
-        self.revision_sets = {}
+        self._start_revisions = {}
 
     def get_graph_data(self, graph, benchmark):
         """
@@ -299,40 +242,41 @@ class _GraphDataFilter(object):
         entry_name
             Name for the data set. If benchmark is non-parameterized, this is the
             benchmark name.
-        revisions
-            List of revisions (ints)
-        values
-            List of benchmark values (floats or Nones)
+        steps
+            Steps to consider in regression detection.
 
         """
-        series = graph.get_data()
-
         if benchmark.get('params'):
-            param_iter = enumerate(itertools.product(*benchmark['params']))
+            param_iter = enumerate(zip(itertools.product(*benchmark['params']),
+                                           graph.get_steps()))
         else:
-            param_iter = [(None, None)]
+            param_iter = [(None, (None, graph.get_steps()))]
 
-        for j, param in param_iter:
+        for j, (param, steps) in param_iter:
             if param is None:
                 entry_name = benchmark['name']
             else:
                 entry_name = benchmark['name'] + '({0})'.format(', '.join(param))
 
-            revision_set = self._get_allowed_revisions(graph, benchmark, entry_name)
+            start_revision = self._get_start_revision(graph, benchmark, entry_name)
 
-            times = [item[0] for item in series if item[0] in revision_set]
-            if param is None:
-                values = [item[1] for item in series if item[0] in revision_set]
-            else:
-                values = [item[1][j] for item in series if item[0] in revision_set]
+            if start_revision is None:
+                # Skip detection
+                continue
 
-            yield j, entry_name, times, values
+            steps = [step for step in steps if step[1] >= start_revision]
 
-    def _get_allowed_revisions(self, graph, benchmark, entry_name):
+            yield j, entry_name, steps
+
+    def _get_start_revision(self, graph, benchmark, entry_name):
         """
-        Compute the set of revisions allowed by asv.conf.json.
+        Compute the first revision allowed by asv.conf.json.
+
+        Revisions correspond to linearized commit history and the
+        regression detection runs on this order --- the starting commit
+        thus corresponds to a specific starting revision.
         """
-        revision_set = set(self.revisions.values())
+        start_revision = min(six.itervalues(self.revisions))
 
         if graph.params.get('branch'):
             branch_suffix = '@' + graph.params.get('branch')
@@ -343,24 +287,28 @@ class _GraphDataFilter(object):
             if re.match(regex, entry_name + branch_suffix):
                 if start_commit is None:
                     # Disable regression detection completely
-                    return set()
+                    return None
 
                 if self.conf.branches == [None]:
                     key = (start_commit, None)
                 else:
                     key = (start_commit, graph.params.get('branch'))
 
-                if key not in self.revision_sets:
-                    revs = set()
+                if key not in self._start_revisions:
                     spec = self.repo.get_new_range_spec(*key)
                     start_hash = self.repo.get_hash_from_name(start_commit)
+
                     for commit in [start_hash] + self.repo.get_hashes_from_range(spec):
                         rev = self.revisions.get(commit)
                         if rev is not None:
-                            revs.add(rev)
-                    self.revision_sets[key] = revs
+                            self._start_revisions[key] = rev
+                            break
+                    else:
+                        # Commit not found in the branch --- warn and ignore.
+                        log.warn(("Commit {0} specified in `regressions_first_commits` "
+                                  "not found in branch").format(start_commit))
+                        self._start_revisions[key] = -1
 
-                revision_set = revision_set.intersection(self.revision_sets[key])
+                start_revision = max(start_revision, self._start_revisions[key] + 1)
 
-        return revision_set
-
+        return start_revision

--- a/asv/step_detect.py
+++ b/asv/step_detect.py
@@ -297,9 +297,9 @@ except ImportError:
 # Detecting regressions
 #
 
-def detect_regressions(y):
+def detect_steps(y):
     """
-    Detect regressions in a (noisy) signal.
+    Detect steps in a (noisy) signal.
 
     Parameters
     ----------
@@ -308,13 +308,13 @@ def detect_regressions(y):
 
     Returns
     -------
-    latest_value
-        Latest value
-    jump_pos : list of integers
-        List of positions after which value increased. The first item corresponds
-        to the last position at which the best value was obtained.
-    best_value
-        Best value
+    steps : list of (left_pos, right_pos, value, err_est)
+        List containing a decomposition of the input data to a piecewise
+        constant function. Each element contains the left (inclusive) and
+        right (exclusive) bounds of a segment, the average value on 
+        the segment and the l1 error estimate, <|Y - avg|>. Missing data
+        points are not necessarily contained in any segment; right_pos-1
+        is the last non-missing data point.
 
     """
 
@@ -328,59 +328,81 @@ def detect_regressions(y):
         y_filtered.append(x)
 
     # Find piecewise segments
-    p = 1
-    right, values, dists, gamma = solve_potts_autogamma(y_filtered, p=p, min_size=5)
+    right, values, dists, gamma = solve_potts_autogamma(y_filtered, p=1, min_size=5)
 
+    # Extract the steps, mapping indices back etc.
+    steps = []
+    l = 0
+    for r, v, d in zip(right, values, dists):
+        steps.append((index_map[l], index_map[r-1] + 1,
+                          v,
+                          min(y_filtered[l:r]),
+                          abs(d/(r - l))))
+        l = r
+    return steps
+
+
+def detect_regressions(steps):
+    """
+    Detect regressions in a (noisy) signal.
+
+    Parameters
+    ----------
+    steps : list of (left, right, value, min, error)
+        List of steps computed by detect_steps, or equivalent
+
+    Returns
+    -------
+    latest_value
+        Latest value
+    best_value
+        Best value
+    regression_pos : list of (before, after, value_before, value_after)
+        List of positions between which the value increased. The first item
+        corresponds to the last position at which the best value was obtained.
+
+    """
     # Find best value and compare to the most recent one
-    best_r = None
     best_v = None
     best_err = None
     cur_err = None
     cur_v = None
 
-    prev_r = 0
     prev_v = None
     prev_err = None
 
-    l = 0
-    jumps = []
-    if values:
-        last_v = values[-1]
+    if steps:
+        last_v = steps[-1][2]
     else:
         last_v = None
 
-    for r, v, d in zip(right, values, dists):
-        if r - prev_r < 3:
-            # disregard too short segments
-            prev_r = r
-            continue
+    regression_pos = []
 
-        cur_v = v
-        cur_min = min(y_filtered[l:r])
-        cur_err = abs(d / (r - prev_r))**(1/p)
+    prev_r = None
+    for l, r, cur_v, cur_min, cur_err in steps:
+        if r - l < 3:
+            # disregard too short segments
+            continue
 
         if best_v is None or cur_min <= best_v + best_err:
             # Found best value (modulo errors)
             best_v = cur_v
             best_err = cur_err
-            jumps = [index_map[r-1]]
-        elif (prev_v is not None and
-              cur_v > prev_v + max(cur_err, prev_err) and
-              prev_v < last_v - max(cur_err, prev_err)):
+            regression_pos = []
+        elif (not regression_pos or (prev_v is not None and
+                cur_v > prev_v + max(cur_err, prev_err) and
+                prev_v < last_v - max(cur_err, prev_err))):
             # Found an upward jump
-            if index_map[prev_r-1] != jumps[-1]:
-                jumps.append(index_map[prev_r-1])
+            regression_pos.append((prev_r - 1, l, prev_v, cur_v))
 
         prev_r = r
         prev_v = cur_v
         prev_err = cur_err
 
-        l = r
-
-    if cur_v is None or best_v is None or cur_v <= best_v + max(cur_err, best_err):
-        return None, None, None
+    if cur_v is None or best_v is None or cur_v <= best_v + max(cur_err, best_err) or not regression_pos:
+        return (None, None, None)
     else:
-        return (cur_v, jumps, best_v)
+        return (cur_v, best_v, regression_pos)
 
 
 #

--- a/asv/step_detect.py
+++ b/asv/step_detect.py
@@ -328,7 +328,7 @@ def detect_steps(y):
         y_filtered.append(x)
 
     # Find piecewise segments
-    right, values, dists, gamma = solve_potts_autogamma(y_filtered, p=1, min_size=5)
+    right, values, dists, gamma = solve_potts_autogamma(y_filtered, p=1)
 
     # Extract the steps, mapping indices back etc.
     steps = []
@@ -380,10 +380,6 @@ def detect_regressions(steps):
 
     prev_r = None
     for l, r, cur_v, cur_min, cur_err in steps:
-        if r - l < 3:
-            # disregard too short segments
-            continue
-
         if best_v is None or cur_min <= best_v + best_err:
             # Found best value (modulo errors)
             best_v = cur_v

--- a/asv/template/asv.conf.json
+++ b/asv/template/asv.conf.json
@@ -127,4 +127,15 @@
     //    "some_benchmark": "352cdf",  // Consider regressions only after this commit
     //    "another_benchmark": null,   // Skip regression detection altogether
     // }
+
+    // The thresholds for relative change in results, after which `asv
+    // publish` starts reporting regressions. Dictionary of the same
+    // form as in ``regressions_first_commits``, with values
+    // indicating the thresholds.  If multiple entries match, the
+    // maximum is taken. If no entry matches, the default is 5%.
+    //
+    // "regressions_thresholds": {
+    //    "some_benchmark": 0.01,     // Threshold of 1%
+    //    "another_benchmark": 0.5,   // Threshold of 50%
+    // }
 }

--- a/docs/source/asv.conf.json.rst
+++ b/docs/source/asv.conf.json.rst
@@ -276,3 +276,23 @@ In this case, regressions are detected only for commits after tag
 detection is further limited to commits after the commit given, and
 for ``benchmark_2``, regression detection is skipped completely in the
 ``master`` branch.
+
+``regressions_thresholds``
+--------------------------
+
+The minimum relative change required before `asv publish` reports a
+regression.
+
+The value is a dictionary, similar to ``regressions_first_commits``.
+If multiple entries match, the largest threshold is taken.  If no
+entry matches, the default threshold is ``0.05`` (iow. 5%).
+
+Example::
+
+    "regressions_thresholds": {
+        ".*": 0.01,
+        "benchmark_1": 0.2,
+    }
+
+In this case, the reporting threshold is 1% for all benchmarks, except
+``benchmark_1`` which uses a threshold of 20%.

--- a/test/test_graph.py
+++ b/test/test_graph.py
@@ -191,5 +191,26 @@ def test_summary_graph_loop():
     assert abs(data[0][1] - 0.1) < 1e-7
 
 
+def test_graph_steps():
+    vals = [(1, 1), (5, 1), (6, 1), (7, 1), (8, 1),
+            (11, 2), (15, 2), (16, 2.001), (17, 2), (18, 2)]
+
+    g = Graph('foo', {})
+    for x, y in vals:
+        g.add_data_point(x, y)
+
+    steps = g.get_steps()
+    lastval = steps[1][4]
+    assert abs(lastval - 0.001/5.0) < 1e-10
+    assert steps == [(1, 8+1, 1.0, 1.0, 0), (11, 18+1, 2.0, 2.0, lastval)]
+
+    multi_g = Graph('foo', {})
+    for x, y in vals:
+        multi_g.add_data_point(x, [y, y, y])
+
+    for s in multi_g.get_steps():
+        assert s == steps
+
+
 def _sgn(x):
     return 1 if x >= 0 else -1

--- a/test/test_publish.py
+++ b/test/test_publish.py
@@ -334,6 +334,26 @@ def test_regression_non_monotonic(dvcs_type, tmpdir):
     assert regressions == expected
 
 
+def test_regression_threshold(generate_result_dir):
+    conf, repo, commits = generate_result_dir(5 * [1.0] + 5 * [1.1] + 5 * [2.0])
+
+    conf.regressions_thresholds = {'.*': 0}
+    tools.run_asv_with_conf(conf, "publish")
+    regressions = util.load_json(join(conf.html_dir, "regressions.json"))
+    expected = {"regressions": [["time_func", _graph_path(repo.dvcs), {}, None, [
+        [[None, 5, 1.0, 1.1], [None, 10, 1.1, 2.0]], 2.0, 1.0,
+    ]]]}
+    assert regressions == expected
+
+    conf.regressions_thresholds = {'.*': 0, 'time_func.*': 0.2}
+    tools.run_asv_with_conf(conf, "publish")
+    regressions = util.load_json(join(conf.html_dir, "regressions.json"))
+    expected = {"regressions": [["time_func", _graph_path(repo.dvcs), {}, None, [
+        [[None, 10, 1.1, 2.0]], 2.0, 1.0,
+    ]]]}
+    assert regressions == expected
+
+
 def test_regression_atom_feed(generate_result_dir):
     conf, repo, commits = generate_result_dir(5 * [1] + 5 * [10] + 5 * [15])
     tools.run_asv_with_conf(conf, "publish")

--- a/test/test_step_detect.py
+++ b/test/test_step_detect.py
@@ -9,7 +9,7 @@ import pytest
 
 from asv.step_detect import (solve_potts, solve_potts_autogamma, solve_potts_approx,
                              detect_regressions, golden_search, median, rolling_median_dev,
-                             L1Dist)
+                             L1Dist, detect_steps)
 from asv import step_detect
 
 
@@ -137,12 +137,31 @@ def test_detect_regressions(use_rangemedian):
         y = y.tolist()
         y[123] = None
         y[1234] = np.nan
-        new_value, jump_pos, best_value = detect_regressions(y)
+        steps = detect_steps(y)
 
-        assert jump_pos == [3233 + (seed % 123), 3499 + (seed % 71)]
+        steps_lr = [(l, r) for l, r, _, _, _ in steps]
+        k = steps[0][1]
+        assert 990 <= k <= 1010
+        assert steps_lr == [(0, k),
+                            (k, 3234 + (seed % 123)),
+                            (3234 + (seed % 123), 3264 + (seed % 53)),
+                            (3264 + (seed % 53), 3350),
+                            (3350, 3500 + (seed % 71)),
+                            (3500 + (seed % 71), 3700),
+                            (3700, 4000)]
+        steps_v = [x[2] for x in steps]
+        assert np.allclose(steps_v, [0.35, 0.05, 2.05, 4.05, 1.15, 4.05, 2.05], rtol=0.3)
+
+        # The expected mean error is 0.7 <|U(0,1) - 1/2|> = 0.7/4
+        steps_err = [x[4] for x in steps]
+        assert np.allclose(steps_err, [0.7/4]*7, rtol=0.3)
+
+        # Check detect_regressions
+        new_value, best_value, regression_pos = detect_regressions(steps)
+        assert regression_pos == [(3233 + (seed % 123), (3233 + (seed % 123) + 1), steps_v[1], steps_v[2]),
+                                  (3499 + (seed % 71), 3499 + (seed % 71) + 1, steps_v[4], steps_v[5])]
         assert np.allclose(best_value, 0.7/2 - 0.3, rtol=0.3, atol=0)
         assert np.allclose(new_value, 0.7/2 - 0.3 + 2, rtol=0.3, atol=0)
-
 
 def test_golden_search():
     def f(x):

--- a/test/test_step_detect.py
+++ b/test/test_step_detect.py
@@ -217,3 +217,29 @@ def test_l1dist(use_rangemedian):
 
                 assert m == m2, (i, j)
                 assert abs(d - d2) < 1e-10, (i, j)
+
+
+def test_regression_threshold():
+    steps = [(0, 1,   1.0, 1.0, 0.0),
+             (1, 2,   1.1, 1.1, 0.0),
+             (2, 3,   2.0, 2.0, 0.0)]
+
+    latest, best, pos = detect_regressions(steps, threshold=0.05)
+    assert latest == 2
+    assert best == 1
+    assert pos == [(0, 1, 1.0, 1.1), (1, 2, 1.1, 2.0)]
+
+    latest, best, pos = detect_regressions(steps, threshold=0.2)
+    assert latest == 2
+    assert best == 1
+    assert pos == [(1, 2, 1.1, 2.0)]
+
+    latest, best, pos = detect_regressions(steps, threshold=0.9)
+    assert latest == 2
+    assert best == 1
+    assert pos == [(1, 2, 1.1, 2.0)]
+
+    latest, best, pos = detect_regressions(steps, threshold=1.1)
+    assert latest == None
+    assert best == None
+    assert pos == None


### PR DESCRIPTION
Add a user-configurable threshold for determining whether `asv publish` should report a regression or not. Change the default threshold from 0% relative change to 5%, in order to make the regression reporting less noisy out-of-the-box.

This contains also same refactoring commits as in gh-437.