### PR TITLE
Rate limit the dots printed by Log.dot

### DIFF
--- a/asv/console.py
+++ b/asv/console.py
@@ -16,6 +16,7 @@ import logging
 import os
 import sys
 import textwrap
+import time
 
 import six
 from six.moves import xrange, input
@@ -250,6 +251,7 @@ class Log(object):
         self._count = 0
         self._logger = logging.getLogger()
         self._needs_newline = False
+        self._last_dot = time.time()
 
     def _stream_formatter(self, record):
         '''
@@ -311,8 +313,10 @@ class Log(object):
 
     def dot(self):
         if isatty(sys.stdout):
-            color_print('.', 'darkgrey', end='')
-            sys.stdout.flush()
+            if time.time() > self._last_dot + 1.0:
+                color_print('.', 'darkgrey', end='')
+                sys.stdout.flush()
+                self._last_dot = time.time()
 
     def set_nitems(self, n):
         """

--- a/asv/plugins/regressions.py
+++ b/asv/plugins/regressions.py
@@ -51,7 +51,7 @@ class Regressions(OutputPublisher):
             if not benchmark:
                 continue
 
-            log.add('.')
+            log.dot()
 
             for graph_data in data_filter.get_graph_data(graph, benchmark):
                 cls._process_regression(regressions, seen, revision_to_hash, repo, all_params,


### PR DESCRIPTION
asv publish spewing lots of dots looks a bit messy, so rate limit them.