### PR TITLE
Fix usability issues in environment selection

### DIFF
--- a/asv/environment.py
+++ b/asv/environment.py
@@ -239,7 +239,14 @@ def get_environments(conf, env_specifiers):
             else:
                 pythons = conf.pythons
 
-        for requirements in iter_requirement_matrix(env_type, pythons, conf, explicit_selection):
+        if env_type != "existing":
+            requirements_iter = iter_requirement_matrix(env_type, pythons, conf,
+                                                        explicit_selection)
+        else:
+            # Ignore requirement matrix
+            requirements_iter = [dict(python=python) for python in pythons]
+
+        for requirements in requirements_iter:
             python = requirements.pop('python')
 
             try:

--- a/asv/environment.py
+++ b/asv/environment.py
@@ -39,7 +39,8 @@ def iter_requirement_matrix(environment_type, pythons, conf,
     def get_env_type(python):
         env_type = env_classes.get(python)
         if env_type is None:
-            env_type = get_environment_class(conf, python)
+            cls = get_environment_class(conf, python)
+            env_type = cls.tool_name
             env_classes[python] = env_type
         return env_type
 

--- a/test/test_environment.py
+++ b/test/test_environment.py
@@ -396,6 +396,15 @@ def test_environment_select():
     assert environments[0].tool_name == "conda"
     assert environments[0].requirements == {'six': '1.4'}
 
+    # Check interaction with exclude
+    conf.exclude = [{'environment_type': "conda"}]
+    environments = list(environment.get_environments(conf, ["conda-py2.7-six1.4"]))
+    assert len(environments) == 0
+
+    conf.exclude = [{'environment_type': 'matches nothing'}]
+    environments = list(environment.get_environments(conf, ["conda-py2.7-six1.4"]))
+    assert len(environments) == 1
+
 
 @pytest.mark.skipif(not ((HAS_PYTHON_27 and HAS_VIRTUALENV) or HAS_CONDA),
                     reason="Requires Python 2.7")
@@ -412,6 +421,19 @@ def test_environment_select_autodetect():
     assert len(environments) == 1
     assert environments[0].python == "2.7"
     assert environments[0].tool_name in ("virtualenv", "conda")
+
+    # Check interaction with exclude
+    conf.exclude = [{'environment_type': 'matches nothing'}]
+    environments = list(environment.get_environments(conf, [":2.7"]))
+    assert len(environments) == 1
+
+    conf.exclude = [{'environment_type': 'virtualenv|conda'}]
+    environments = list(environment.get_environments(conf, [":2.7"]))
+    assert len(environments) == 0
+
+    conf.exclude = [{'environment_type': 'conda'}]
+    environments = list(environment.get_environments(conf, ["conda:2.7"]))
+    assert len(environments) == 0
 
 
 @pytest.mark.skipif(not (HAS_PYPY and HAS_VIRTUALENV), reason="Requires pypy and virtualenv")

--- a/test/test_environment.py
+++ b/test/test_environment.py
@@ -429,11 +429,23 @@ def test_environment_select_autodetect():
 
     conf.exclude = [{'environment_type': 'virtualenv|conda'}]
     environments = list(environment.get_environments(conf, [":2.7"]))
-    assert len(environments) == 0
+    assert len(environments) == 1
 
     conf.exclude = [{'environment_type': 'conda'}]
     environments = list(environment.get_environments(conf, ["conda:2.7"]))
-    assert len(environments) == 0
+    assert len(environments) == 1
+
+
+def test_matrix_empty():
+    conf = config.Config()
+    conf.environment_type = ""
+    conf.pythons = ["2.7"]
+    conf.matrix = {}
+
+    # Check default environment config
+    environments = list(environment.get_environments(conf, None))
+    items = set(env.python for env in environments)
+    assert items == set(['2.7'])
 
 
 @pytest.mark.skipif(not (HAS_PYPY and HAS_VIRTUALENV), reason="Requires pypy and virtualenv")


### PR DESCRIPTION
- Fix bug in environment exclude rules with autodetected environment_type
- When the user explicitly selects an environment (e.g. on command line), use the specified environment/python combination even if exclude rules result to an empty requirement matrix.
-  	Make ExistingEnvironment ignore the requirements matrix. This ensures -E existing or --python=same results to only one environment.

Fixes gh-459