### PR TITLE
Change the default --factor to 1.1

### DIFF
--- a/asv/commands/common_args.py
+++ b/asv/commands/common_args.py
@@ -36,11 +36,11 @@ def add_global_arguments(parser, suppress_defaults=True):
 
 def add_factor(parser):
     parser.add_argument(
-        '--factor', "-f", type=float, default=2.0,
+        '--factor', "-f", type=float, default=1.1,
         help="""The factor above or below which a result is considered
-        problematic.  For example, with a factor of 2, if a benchmark
-        gets twice as slow or twice as fast, it will be displayed in
-        the results list.""")
+        problematic.  For example, with a factor of 1.1 (the default
+        value), if a benchmark gets 10%% slower or faster, it will
+        be displayed in the results list.""")
 
 
 def add_show_stderr(parser):

--- a/asv/commands/compare.py
+++ b/asv/commands/compare.py
@@ -96,7 +96,7 @@ class Compare(Command):
                        machine=args.machine)
 
     @classmethod
-    def run(cls, conf, hash_1, hash_2, factor=2, split=False, machine=None):
+    def run(cls, conf, hash_1, hash_2, factor=None, split=False, machine=None):
 
         machines = []
         for path in iter_machine_files(conf.results_dir):

--- a/asv/commands/continuous.py
+++ b/asv/commands/continuous.py
@@ -52,7 +52,7 @@ class Continuous(Command):
         )
 
     @classmethod
-    def run(cls, conf, branch=None, base=None, factor=2.0, show_stderr=False, bench=None,
+    def run(cls, conf, branch=None, base=None, factor=None, show_stderr=False, bench=None,
             machine=None, env_spec=None, _machine_file=None):
         repo = get_repo(conf)
         repo.pull()


### PR DESCRIPTION
The default behavior of reporting only benchmarks changed by 2x is probably somewhat misleading (it prints "not changed significantly"), I think the threshold should be smaller.