### PR TITLE
Allow users to control setup_cache timeout

### DIFF
--- a/asv/benchmark.py
+++ b/asv/benchmark.py
@@ -272,6 +272,7 @@ class Benchmark(object):
         self._teardowns = list(_get_all_attrs(attr_sources, 'teardown', True))
         self._setup_cache = _get_first_attr(attr_sources, 'setup_cache', None)
         self.setup_cache_key = get_setup_cache_key(self._setup_cache)
+        self.setup_cache_timeout = _get_first_attr([self._setup_cache], "timeout", None)
         self.timeout = _get_first_attr(attr_sources, "timeout", 60.0)
         self.code = textwrap.dedent(inspect.getsource(self.func))
         self.type = "base"

--- a/docs/source/writing_benchmarks.rst
+++ b/docs/source/writing_benchmarks.rst
@@ -159,6 +159,10 @@ As another example, explicitly saving data in a file::
         def track_numbers(self):
             return len(self.data)
 
+The ``setup_cache`` timeout can be specified by setting the
+``.timeout`` attribute of the ``setup_cache`` function. The default
+value is the maximum of the timeouts of the benchmarks using it.
+
 .. _benchmark-attributes:
 
 Benchmark attributes

--- a/test/benchmark/cache_examples.py
+++ b/test/benchmark/cache_examples.py
@@ -4,6 +4,7 @@
 from __future__ import absolute_import, division, unicode_literals, print_function
 
 import os
+import time
 
 
 class ClassLevelSetup:
@@ -53,3 +54,26 @@ class ClassLevelSetupFail:
 
     def track_fail(self):
         return -1
+
+
+class ClassLevelCacheTimeout:
+    def setup_cache(self):
+        time.sleep(2.0)
+
+    setup_cache.timeout = 0.1
+
+    def track_fail(self):
+        return 0
+
+
+class ClassLevelCacheTimeoutSuccess:
+    timeout = 1.0
+
+    def setup_cache(self):
+        time.sleep(2.0)
+
+    setup_cache.timeout = 5.0
+
+    def track_success(self):
+        return 0
+

--- a/test/test_benchmarks.py
+++ b/test/test_benchmarks.py
@@ -59,7 +59,7 @@ def test_find_benchmarks(tmpdir):
     assert len(b) == 3
 
     b = benchmarks.Benchmarks(conf, repo, envs, regex='example')
-    assert len(b) == 22
+    assert len(b) == 24
 
     b = benchmarks.Benchmarks(conf, repo, envs, regex='time_example_benchmark_1')
     assert len(b) == 2
@@ -69,7 +69,7 @@ def test_find_benchmarks(tmpdir):
     assert len(b) == 2
 
     b = benchmarks.Benchmarks(conf, repo, envs)
-    assert len(b) == 26
+    assert len(b) == 28
 
     start_timestamp = datetime.datetime.utcnow()
 
@@ -126,6 +126,9 @@ def test_find_benchmarks(tmpdir):
 
     assert times['cache_examples.ClassLevelSetupFail.track_fail']['result'] == None
     assert 'raise RuntimeError()' in times['cache_examples.ClassLevelSetupFail.track_fail']['stderr']
+
+    assert times['cache_examples.ClassLevelCacheTimeout.track_fail']['result'] == None
+    assert times['cache_examples.ClassLevelCacheTimeoutSuccess.track_success']['result'] == 0
 
     profile_path = join(tmpdir, 'test.profile')
     with open(profile_path, 'wb') as fd:


### PR DESCRIPTION
The timeout for `setup_cache` cannot currently be controlled by the user. Make this possible.

The cache setup timeout is taken from the .timeout attribute of the `setup_cache` function. If not specified, the default value is taken the maximum of the timeouts of the benchmarks.