### PR TITLE
ENH: Terminate process group on timeout under Windows.

### DIFF
--- a/test/test_subprocess.py
+++ b/test/test_subprocess.py
@@ -4,7 +4,6 @@
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
-import os
 import sys
 import time
 
@@ -27,11 +26,8 @@ sys.stderr.write("Stderr after waiting\n")
     """)
 
     # Another example, where timeout is due to a hanging sub-subprocess
-    if getattr(os, 'setpgid', None):
-        # only on posix
-        timeout_codes.append(r"""
+    timeout_codes.append(r"""
 import sys
-import time
 import subprocess
 
 sys.stdout.write("Stdout before waiting\n")
@@ -42,7 +38,7 @@ subprocess.call([sys.executable, "-c",
     "import sys, subprocess; subprocess.call([sys.executable, '-c', 'import time; time.sleep(60)'])"])
 sys.stdout.write("Stdout after waiting\n")
 sys.stderr.write("Stderr after waiting\n")
-        """)
+    """)
 
     for timeout_code in timeout_codes:
         t = time.time()


### PR DESCRIPTION
Consider a subsubprocess created within a benchmark that times out. The current behavior is:
* POSIX: the benchmark subprocess group is terminated (including the subsubprocess);
* Windows: just the benchmark subprocess is terminated.

Under Windows this can lead to the main process hanging on [`stderr_reader.join()`](https://github.com/spacetelescope/asv/blob/a14d8dc70442faef6e8b4eacb60ffc9c3d488fa6/asv/util.py#L413) (as the subsubprocess may inherit file descriptors).

This change should ensure that subsubprocesses are terminated on timeout also under Windows. The implementation uses console events as that seems to be more reliable than `taskkill` or `psutil.children()` based solutions. This is a bit specific, so some additional testing under Windows would be appreciated.

Some references:
* a nice write-up on [Python and signals in Windows](https://bugs.python.org/issue26350#msg260201);
* MSDN on [`CREATE_NEW_PROCESS_GROUP`](https://msdn.microsoft.com/pl-pl/library/windows/desktop/ms684863(v=vs.85).aspx#CREATE_NEW_PROCESS_GROUP) and [`CTRL_BREAK_EVENT`](https://msdn.microsoft.com/en-us/library/windows/desktop/ms682541(v=vs.85).aspx);
* [the commit](https://github.com/spacetelescope/asv/commit/32db52d954bb06921ba171aee60f900d9914ab88) in which the POSIX counterpart was introduced;
* the AppVeyor failure in #487 is most likely due to this issue.