### PR TITLE
CI: bump appveyor py3.4->py3.5, travis pypy3.2->pypy3.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,8 @@ python:
   - 3.4
   - 3.5
   - pypy
-  - pypy3
+  - "pypy3.3-5.2-alpha1"
+  # - pypy3
 
 matrix:
   include:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,15 +10,15 @@ environment:
 
   matrix:
 
+      - PYTHON_VERSION: "3.5"
+        platform: x64
+        PYTHON_ARCH: "64"
       - PYTHON_VERSION: "2.7"
         platform: x64
         PYTHON_ARCH: "64"
       - PYTHON_VERSION: "2.7"
         platform: x86
         PYTHON_ARCH: "32"
-      - PYTHON_VERSION: "3.4"
-        platform: x64
-        PYTHON_ARCH: "64"
 
 install:
     # Install miniconda using a powershell script.
@@ -41,4 +41,4 @@ install:
 build: false
 
 test_script:
-  - "%CMD_IN_ENV% python setup.py test -a --tb=native"
+  - "%CMD_IN_ENV% python setup.py test -a --tb=native -a --basetemp=%APPVEYOR_BUILD_FOLDER%\\tmp"


### PR DESCRIPTION
Python 3.4 + conda + appveyor fails to create some environments.
Pypy3 on travis is currently too old to support current pip and the installed virtualenv version.