### PR TITLE
CI: Measure coverage of benchmark.py.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -71,7 +71,7 @@ install:
     if [[ $TRAVIS_PYTHON_VERSION == 2* ]]; then $TRAVIS_PIP install mercurial ; fi;
     if [[ $TRAVIS_PYTHON_VERSION == 2* ]]; then $TRAVIS_PIP install python-hglib ; fi;
     $TRAVIS_PIP install selenium six pytest feedparser;
-    if [[ $COVERAGE != '' ]]; then $TRAVIS_PIP install coverage pytest-coverage coveralls; fi;
+    if [[ $COVERAGE != '' ]]; then $TRAVIS_PIP install pytest-cov coveralls; fi;
 
 script:
   - $TRAVIS_PYTHON setup.py test $COVERAGE

--- a/asv/plugins/virtualenv.py
+++ b/asv/plugins/virtualenv.py
@@ -152,6 +152,12 @@ class Virtualenv(environment.Environment):
         else:
             pip_args = ['install', '-v', 'wheel', 'pip>=8']
 
+        if 'COV_CORE_SOURCE' in os.environ:
+            # To measure coverage of ASV parts run in a subprocess from
+            # a temporary virtual environment an interpreter hook needs
+            # to be installed for that environment.
+            pip_args.append('pytest-cov')
+
         if not WIN:
             self.run_executable('pip', pip_args)
         else:

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ class PyTest(TestCommand):
         if self.pytest_args:
             test_args += self.pytest_args.split()
         if self.coverage:
-            test_args += ['--cov', 'asv']
+            test_args += ['--cov', os.path.abspath('asv')]
         errno = pytest.main(test_args)
         sys.exit(errno)
 


### PR DESCRIPTION
Coverage of `asv/benchmark.py` isn't measured as the script is executed in a subprocess from a virtual environment -- without sitecustomize.py or .pth hook installed. See http://pytest-cov.readthedocs.io/en/latest/readme.html#limitations and https://coverage.readthedocs.io/en/latest/subprocess.html.

[pytest-coverage](https://pypi.python.org/pypi/pytest-coverage) points to [pytest-cover](https://pypi.python.org/pypi/pytest-cover/), which in turn claims to have been merged into  `pytest-cov`.