### PR TITLE
Benchmark statistics

### DIFF
--- a/asv/benchmark.py
+++ b/asv/benchmark.py
@@ -431,9 +431,12 @@ class TimeBenchmark(Benchmark):
 
         start_time = time.time()
 
+        max_time = start_time + min(warmup_time + 1.3 * repeat * goal_time,
+                                    self.timeout - 1.3 * goal_time)
+
         def too_slow():
             # too slow, don't take more samples
-            return time.time() > start_time + warmup_time + 2 * repeat * goal_time
+            return time.time() > max_time
 
         if number == 0:
             # Select number & warmup.

--- a/asv/commands/continuous.py
+++ b/asv/commands/continuous.py
@@ -89,7 +89,11 @@ class Continuous(Command):
                     continue
 
                 for name, benchmark in six.iteritems(run_objs['benchmarks']):
-                    yield name, result.results.get(name, float("nan"))
+                    params = benchmark['params']
+
+                    value = result.get_result_value(name, params)
+                    stats = result.get_result_stats(name, params)
+                    yield name, params, value, stats
 
         status = Compare.print_table(conf, parent, head,
                                      resultset_1=results_iter(parent),

--- a/asv/commands/continuous.py
+++ b/asv/commands/continuous.py
@@ -34,6 +34,15 @@ class Continuous(Command):
         parser.add_argument(
             'branch', default=None,
             help="""The commit/branch to test. By default, the first configured branch.""")
+        parser.add_argument(
+            "--record-samples", action="store_true",
+            help="""Store raw measurement samples, not only statistics""")
+        parser.add_argument(
+            "--quick", "-q", action="store_true",
+            help="""Do a "quick" run, where each benchmark function is
+            run only once.  This is useful to find basic errors in the
+            benchmark functions faster.  The results are unlikely to
+            be useful, and thus are not saved.""")
         common_args.add_factor(parser)
         common_args.add_show_stderr(parser)
         common_args.add_bench(parser)
@@ -48,12 +57,13 @@ class Continuous(Command):
         return cls.run(
             conf=conf, branch=args.branch, base=args.base, factor=args.factor,
             show_stderr=args.show_stderr, bench=args.bench, machine=args.machine,
-            env_spec=args.env_spec, **kwargs
+            env_spec=args.env_spec, record_samples=args.record_samples,
+            quick=args.quick, **kwargs
         )
 
     @classmethod
     def run(cls, conf, branch=None, base=None, factor=None, show_stderr=False, bench=None,
-            machine=None, env_spec=None, _machine_file=None):
+            machine=None, env_spec=None, record_samples=False, quick=False, _machine_file=None):
         repo = get_repo(conf)
         repo.pull()
 
@@ -72,6 +82,7 @@ class Continuous(Command):
         result = Run.run(
             conf, range_spec=commit_hashes, bench=bench,
             show_stderr=show_stderr, machine=machine, env_spec=env_spec,
+            record_samples=record_samples, quick=quick,
             _returns=run_objs, _machine_file=_machine_file)
         if result:
             return result

--- a/asv/commands/find.py
+++ b/asv/commands/find.py
@@ -124,13 +124,6 @@ class Find(Command):
                 env, show_stderr=show_stderr)
             result = list(x.values())[0]['result']
 
-            if isinstance(result, dict):
-                # parameterized results
-                result = result['result']
-            else:
-                # single value
-                result = [result]
-
             results[i] = result
 
             return results[i]

--- a/asv/commands/publish.py
+++ b/asv/commands/publish.py
@@ -16,7 +16,7 @@ from ..console import log
 from ..graph import GraphSet
 from ..machine import iter_machine_files
 from ..repo import get_repo
-from ..results import iter_results, compatible_results
+from ..results import iter_results
 from ..publishing import OutputPublisher
 from .. import environment
 from .. import util
@@ -132,9 +132,13 @@ class Publish(Command):
             for results in iter_results(conf.results_dir):
                 log.dot()
 
-                for key, val in six.iteritems(results.results):
+                for key in results.result_keys:
                     b = benchmarks.get(key)
-                    result = compatible_results(val, b)
+
+                    b_params = b['params'] if b else []
+                    result = results.get_result_value(key, b_params)
+                    if not b_params:
+                        result = result[0]
 
                     benchmark_names.add(key)
 

--- a/asv/commands/rm.py
+++ b/asv/commands/rm.py
@@ -86,15 +86,11 @@ class Rm(Command):
 
             if single_benchmark is not None:
                 found = False
-                for benchmark in list(six.iterkeys(result.results)):
+                for benchmark in list(result.result_keys):
                     if fnmatchcase(benchmark, single_benchmark):
                         count += 1
                         files_to_remove.add(result)
-                        del result.results[benchmark]
-
-                        # Remove run times (may be missing in old files)
-                        result.started_at.pop(benchmark, None)
-                        result.ended_at.pop(benchmark, None)
+                        result.remove_result(benchmark)
             else:
                 files_to_remove.add(result)
 

--- a/asv/commands/run.py
+++ b/asv/commands/run.py
@@ -210,8 +210,14 @@ class Run(Command):
                             skipped_benchmarks.update(benchmarks)
                             break
 
-                        for key, value in six.iteritems(result.results):
-                            failed = value is None or (isinstance(value, dict) and None in value['result'])
+                        for key in result.result_keys:
+                            if key not in benchmarks:
+                                continue
+
+                            value = result.get_result_value(key, benchmarks[key]['params'])
+
+                            failed = value is None or (isinstance(value, list) and None in value)
+
                             if skip_failed and failed:
                                 skipped_benchmarks.add(key)
                             if skip_successful and not failed:

--- a/asv/commands/run.py
+++ b/asv/commands/run.py
@@ -104,6 +104,9 @@ class Run(Command):
             "--skip-existing", "-k", action="store_true",
             help="""Skip running benchmarks that have previous successful
             or failed results""")
+        parser.add_argument(
+            "--record-samples", action="store_true",
+            help="""Store raw measurement samples, not only statistics""")
 
         parser.set_defaults(func=cls.run_from_args)
 
@@ -120,6 +123,7 @@ class Run(Command):
             skip_successful=args.skip_existing_successful or args.skip_existing,
             skip_failed=args.skip_existing_failed or args.skip_existing,
             skip_existing_commits=args.skip_existing_commits,
+            record_samples=args.record_samples,
             **kwargs
         )
 
@@ -127,7 +131,8 @@ class Run(Command):
     def run(cls, conf, range_spec=None, steps=None, bench=None, parallel=1,
             show_stderr=False, quick=False, profile=False, env_spec=None,
             dry_run=False, machine=None, _machine_file=None, skip_successful=False,
-            skip_failed=False, skip_existing_commits=False, _returns={}):
+            skip_failed=False, skip_existing_commits=False, record_samples=False,
+            _returns={}):
         machine_params = Machine.load(
             machine_name=machine,
             _path=_machine_file, interactive=True)
@@ -280,6 +285,10 @@ class Run(Command):
                             env.name)
 
                         for benchmark_name, d in six.iteritems(results):
+                            if not record_samples:
+                                d['samples'] = None
+                                d['number'] = None
+
                             result.add_result(benchmark_name, d)
 
                         result.update_save(conf.results_dir)

--- a/asv/commands/run.py
+++ b/asv/commands/run.py
@@ -274,11 +274,6 @@ class Run(Command):
                             env.name)
 
                         for benchmark_name, d in six.iteritems(results):
-                            result.add_result(benchmark_name, d['result'],
-                                              d['started_at'], d['ended_at'])
-                            if 'profile' in d:
-                                result.add_profile(
-                                    benchmark_name,
-                                    d['profile'])
+                            result.add_result(benchmark_name, d)
 
                         result.update_save(conf.results_dir)

--- a/asv/console.py
+++ b/asv/console.py
@@ -113,7 +113,8 @@ def _color_text(text, color):
 
 _unicode_translations = {
     ord('μ'): 'u',
-    ord('·'): '-'
+    ord('·'): '-',
+    ord('±'): '~'
 }
 
 

--- a/asv/plugins/regressions.py
+++ b/asv/plugins/regressions.py
@@ -130,7 +130,7 @@ class Regressions(OutputPublisher):
                 run_timestamps[key] = timestamp
 
             # Fallback to commit date
-            for benchmark_name in six.iterkeys(results.results):
+            for benchmark_name in results.result_keys:
                 key = (benchmark_name, revision)
                 run_timestamps.setdefault(key, results.date)
 

--- a/asv/statistics.py
+++ b/asv/statistics.py
@@ -1,0 +1,240 @@
+# -*- coding: utf-8 -*-
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+
+# Author: Pauli Virtanen, 2016
+
+from __future__ import (absolute_import, division, print_function,
+                        unicode_literals)
+
+import math
+
+from .step_detect import solve_potts_approx
+
+
+def compute_stats(samples):
+    """
+    Statistical analysis of measured samples.
+
+    Parameters
+    ----------
+    samples : list of float
+        List of total times (y) of benchmarks.
+
+    Returns
+    -------
+    beta_hat : float
+        Estimated time per iteration
+    stats : dict
+        Information on statistics of the estimator.
+
+    """
+
+    if len(samples) < 1:
+        return None, None
+    elif len(samples) == 1:
+        return samples[0], None
+
+    Y = list(samples)
+
+    # Median and quantiles
+    y_50, ci_50 = quantile_ci(Y, 0.5, alpha_min=0.99)
+    y_25 = quantile(Y, 0.25)
+    y_75 = quantile(Y, 0.75)
+
+    # Look for big shifts in the time series
+    min_size = max(5, len(Y)//5)
+    gamma = quantile([abs(yp - y_50) for yp in Y], 0.5) * min_size
+    if min_size <= len(Y):
+        step_right, step_mu, _ = solve_potts_approx(Y, gamma=gamma, p=1, min_size=min_size)
+    else:
+        step_mu = [y_50]
+
+    # Broaden the confidence interval by the detected steps
+    ci_a, ci_b = ci_50
+    ci_a -= y_50 - min(step_mu)
+    ci_b += max(step_mu) - y_50
+
+    # Produce results
+    mean = sum(Y) / len(Y)
+    var = sum((yp - mean)**2 for yp in Y) / len(Y)   # mle
+    std = math.sqrt(var)
+
+    result = y_50
+
+    stats = {'ci_99': [ci_a, ci_b],
+             'q_25': y_25,
+             'q_75': y_75,
+             'min': min(Y),
+             'max': max(Y),
+             'mean': mean,
+             'std': std,
+             'n': len(Y),
+             'systematic': max(step_mu) - min(step_mu)}
+
+    return result, stats
+
+
+def get_err(result, stats):
+    """
+    Return an 'error measure' suitable for informing the user
+    about the spread of the measurement results.
+    """
+    a, b = stats['q_25'], stats['q_75']
+    return (b - a)/2
+
+
+def is_different(stats_a, stats_b):
+    """
+    Check whether the samples are statistically different.
+
+    This is a pessimistic check, and not statistically fully rigorous.
+    The false negative rate is probably relatively high if the distributions 
+    overlap significantly.
+
+    Parameters
+    ----------
+    samples_a, samples_b
+        Input samples
+    p : float, optional
+        Threshold p-value
+
+    """
+
+    # If confidence intervals overlap, reject
+    ci_a = stats_a['ci_99']
+    ci_b = stats_b['ci_99']
+
+    if ci_a[1] >= ci_b[0] and ci_a[0] <= ci_b[1]:
+        return False
+
+    return True
+
+
+def quantile_ci(x, q, alpha_min=0.99):
+    """
+    Compute a quantile and a confidence interval.
+
+    Assumes independence, but otherwise nonparametric.
+
+    Parameters
+    ----------
+    x : list of float
+        Samples
+    q : float
+        Quantile to compute, in [0,1].
+    alpha_min : float, optional
+        Lower bound for the coverage.
+
+    Returns
+    -------
+    m : float
+        Quantile of x
+    ci : tuple of floats
+        Confidence interval (a, b), of coverage >= alpha_min.
+
+    """
+
+    y = sorted(x)
+    n = len(y)
+
+    cdf = 0
+
+    alpha_min = min(alpha_min, 1 - alpha_min)
+    pa = alpha_min / 2
+    pb = 1 - pa
+
+    a = y[0]
+    b = y[-1]
+
+    for k, yp in enumerate(y):
+        cdf += binom_pmf(n, k, q)
+
+        if cdf <= pa:
+            if k < len(y) - 1:
+                a = 0.5*(yp + y[k+1])
+            else:
+                a = yp
+
+        if cdf >= pb:
+            if k > 0:
+                b = 0.5*(yp + y[k-1])
+            else:
+                b = yp
+            break
+
+    m = quantile(y, q)
+    return m, (a, b)
+
+
+def quantile(x, q):
+    """
+    Compute quantile/percentile of the data
+
+    Parameters
+    ----------
+    x : list of float
+        Data set
+    q : float
+        Quantile to compute, 0 <= q <= 1
+
+    """
+    if not 0 <= q <= 1:
+        raise ValueError("Invalid quantile")
+
+    y = sorted(x)
+    n = len(y)
+
+    z = (n - 1) * q
+    j = int(math.floor(z))
+    z -= j
+
+    if j == n - 1:
+        m = y[-1]
+    else:
+        m = (1 - z)*y[j] + z*y[j+1]
+
+    return m
+
+
+def binom_pmf(n, k, p):
+    """Binomial pmf = (n choose k) p**k (1 - p)**(n - k)"""
+    if not (0 <= k <= n):
+        return 0
+    if p == 0:
+        return 1.0 * (k == 0)
+    elif p == 1.0:
+        return 1.0 * (k == n)
+
+    logp = math.log(p)
+    log1mp = math.log(1 - p)
+    return math.exp(lgamma(1 + n) - lgamma(1 + n - k) - lgamma(1 + k)
+                        + k*logp + (n - k)*log1mp)
+
+
+_BERNOULLI = [1.0, -0.5, 0.166666666667, 0.0, -0.0333333333333, 0.0, 0.0238095238095]
+
+
+def lgamma(x):
+    """
+    Log gamma function. Only implemented at integers.
+    """
+
+    if x <= 0:
+        raise ValueError("Domain error")
+
+    if x > 100:
+        # DLMF 5.11.1
+        r = 0.5 * math.log(2*math.pi) + (x - 0.5) * math.log(x) - x
+        for k in range(1, len(_BERNOULLI)//2 + 1):
+            r += _BERNOULLI[2*k] / (2*k*(2*k - 1) * x**(2*k - 1))
+        return r
+
+    # Fall back to math.factorial
+    int_x = int(x)
+    err_int = abs(x - int_x)
+
+    if err_int < 1e-12 * abs(x):
+        return math.log(math.factorial(int_x - 1))
+
+    # Would need full implementation
+    return float("nan")

--- a/asv/step_detect.py
+++ b/asv/step_detect.py
@@ -638,7 +638,7 @@ def solve_potts_autogamma(y, beta=None, **kw):
     return best_r[0], best_v[0], best_d[0], best_gamma[0]
 
 
-def solve_potts_approx(y, gamma=None, p=2, **kw):
+def solve_potts_approx(y, gamma=None, p=2, min_size=2, **kw):
     """
     Fit penalized stepwise constant function (Potts model) to data
     approximatively, in linear time.
@@ -661,8 +661,14 @@ def solve_potts_approx(y, gamma=None, p=2, **kw):
         mu, dist = mu_dist.mu, mu_dist.dist
         gamma = 3 * dist(0,n-1) * math.log(n) / n
 
-    right, values, dists = solve_potts(y, gamma, p=p, max_size=20, **kw)
-    return merge_pieces(gamma, right, values, dists, mu_dist, max_size=20)
+    if min_size < 10:
+        max_size = 20
+    else:
+        max_size = min_size + 50
+
+    right, values, dists = solve_potts(y, gamma, p=p, min_size=min_size, max_size=max_size,
+                                       **kw)
+    return merge_pieces(gamma, right, values, dists, mu_dist, max_size=max_size)
 
 
 def merge_pieces(gamma, right, values, dists, mu_dist, max_size):

--- a/asv/util.py
+++ b/asv/util.py
@@ -31,6 +31,8 @@ from .console import log
 from .extern import minify_json
 
 
+nan = float('nan')
+
 WIN = (os.name == 'nt')
 
 if not WIN:
@@ -912,6 +914,43 @@ def is_nan(x):
     if isinstance(x, float):
         return x != x
     return False
+
+
+def is_na(value):
+    """
+    Return True if value is None or NaN
+    """
+    return value is None or is_nan(value)
+
+
+def mean_na(values):
+    """
+    Take a mean, with the understanding that None and NaN stand for
+    missing data.
+    """
+    values = [x for x in values if not is_na(x)]
+    if values:
+        return sum(values) / len(values)
+    else:
+        return None
+
+
+def geom_mean_na(values):
+    """
+    Compute geometric mean, with the understanding that None and NaN
+    stand for missing data.
+    """
+    values = [x for x in values if not is_na(x)]
+    if values:
+        exponent = 1/len(values)
+        prod = 1.0
+        acc = 0
+        for x in values:
+            prod *= abs(x)**exponent
+            acc += x
+        return prod if acc >= 0 else -prod
+    else:
+        return None
 
 
 if not WIN:

--- a/docs/source/dev.rst
+++ b/docs/source/dev.rst
@@ -106,14 +106,23 @@ A benchmark suite directory has the following layout.  The
         run on.
 
       - ``results``: A dictionary from benchmark names to benchmark
-        results.
+        results. The item can also be directly the float/list of result
+        values instead of a dictionary.
 
-        - If non-parameterized benchmark, the result is a single value.
+        The dictionary form can have the following keys:
 
-        - For parameterized benchmarks, the result is a dictionary
-          with keys ``params`` and ``result``. The ``params`` value
-          contains a copy of the parameter values of the benchmark, as
-          described above. If the user has modified the benchmark
+        - ``result``: contains the summarized result value(s) of
+          the benchmark. For a non-parameterized benchmark, the value is
+          the result: float, NaN or null. For parameterized
+          benchmarks, it is a list of such values (see ``params`` below).
+
+          The values are either numbers indicating result from
+          successful run, ``null`` indicating a failed benchmark,
+          or ``NaN`` indicating a benchmark explicitly skipped by the
+          benchmark suite.
+
+        - ``params``: contains a copy of the parameter values of the
+          benchmark, as described above. If the user has modified the benchmark
           after the benchmark was run, these may differ from the
           current values. The ``result`` value is a list of
           results. Each entry corresponds to one combination of the
@@ -122,9 +131,28 @@ A benchmark suite directory has the following layout.  The
           i.e., the results appear in cartesian product order, with
           the last parameters varying fastest.
 
-        - In the results, ``null`` indicates a failed benchmark,
-          including failures in installing the project version. ``NaN``
-          indicates a benchmark explicitly skipped by the benchmark suite.
+          This key is omitted if the benchmark is not parameterized.
+
+        - ``samples``: contains the raw data samples produced.
+          For a non-parameterized benchmark, the result is a single
+          list of float values. For parameterized benchmarks,
+          it is a list of such lists (see below).
+          The samples are in the order they were measured in.
+
+          This key is omitted if there are no samples recorded.
+
+        - ``number``: contains the repeat count(s) associated with the
+          measured samples. Same format as for ``result``.
+
+          This key is omitted if there are no samples recorded.
+
+        - ``stats``: dictionary containing results of statistical
+          analysis. Contains keys ``ci_99`` (confidence interval
+          estimate for the result), ``q_25``, ``q_75`` (percentiles),
+          ``min``, ``max``, ``mean``, ``std``, ``n``, and
+          ``systematic`` (estimate of systematic error).
+
+          This key is omitted if there is no statistical analysis.
 
       - ``started_at``: A dictionary from benchmark names to JavaScript
         time stamps indicating the start time of the benchmark run.

--- a/docs/source/using.rst
+++ b/docs/source/using.rst
@@ -249,21 +249,28 @@ Finally, the benchmarks are run::
     [  0.00%] ··· Installing project into py2.7.
     [  0.00%] ·· Benchmarking py2.7
     [ 10.00%] ··· Running benchmarks.MemSuite.mem_list                               2.4k
-    [ 20.00%] ··· Running benchmarks.TimeSuite.time_iterkeys                       9.27μs
-    [ 30.00%] ··· Running benchmarks.TimeSuite.time_keys                          10.74μs
-    [ 40.00%] ··· Running benchmarks.TimeSuite.time_range                         42.20μs
-    [ 50.00%] ··· Running benchmarks.TimeSuite.time_xrange                        32.94μs
+    [ 20.00%] ··· Running benchmarks.TimeSuite.time_iterkeys                  9.27±0.01μs
+    [ 30.00%] ··· Running benchmarks.TimeSuite.time_keys                      10.74±0.1μs
+    [ 40.00%] ··· Running benchmarks.TimeSuite.time_range                    42.20±0.05μs
+    [ 50.00%] ··· Running benchmarks.TimeSuite.time_xrange                   32.94±0.09μs
     [ 50.00%] ·· Building for py3.4
     [ 50.00%] ··· Uninstalling project from py3.4
     [ 50.00%] ··· Installing project into py3.4..
     [ 50.00%] ·· Benchmarking py3.4
     [ 60.00%] ··· Running benchmarks.MemSuite.mem_list                               2.4k
-    [ 70.00%] ··· Running benchmarks.TimeSuite.time_iterkeys                     failed
-    [ 80.00%] ··· Running benchmarks.TimeSuite.time_keys                           7.29μs
-    [ 90.00%] ··· Running benchmarks.TimeSuite.time_range                         30.41μs
-    [100.00%] ··· Running benchmarks.TimeSuite.time_xrange                       failed
+    [ 70.00%] ··· Running benchmarks.TimeSuite.time_iterkeys                       failed
+    [ 80.00%] ··· Running benchmarks.TimeSuite.time_keys                      7.29±0.07μs
+    [ 90.00%] ··· Running benchmarks.TimeSuite.time_range                    30.41±0.04μs
+    [100.00%] ··· Running benchmarks.TimeSuite.time_xrange                         failed
 
 To improve reproducibility, each benchmark is run in its own process.
+
+The results of each benchmark are displayed in the output and also
+recorded on disk.  For timing benchmarks, the median and interquartile
+range of collected measurements are displayed.  Note that the results
+may vary on slow time scales due to CPU frequency scaling, heat
+management, and system load, and this variability is not necessarily
+captured by a single run.
 
 The killer feature of **airspeed velocity** is that it can track the
 benchmark performance of your project over time.  The ``range``

--- a/docs/source/writing_benchmarks.rst
+++ b/docs/source/writing_benchmarks.rst
@@ -301,9 +301,14 @@ by the ``number`` and ``repeat`` attributes, as explained below.
 **Attributes**:
 
 - ``goal_time``: ``asv`` will automatically select the number of
-  iterations to run the benchmark so that it takes between
-  ``goal_time / 10`` and ``goal_time`` seconds each time.  If not
-  specified, ``goal_time`` defaults to 2 seconds.
+  iterations to run the benchmark so that it takes at least ``goal_time``
+  seconds each time.  If not specified, ``goal_time`` defaults to 0.1
+  seconds.
+
+- ``warmup_time``: ``asv`` will spend this time (in seconds) in calling
+  the benchmarked function repeatedly, before starting to run the actual
+  benchmark. If not specified, ``warmup_time`` defaults to 0.1 seconds
+  (on PyPy, the default is 1.0 sec).
 
 - ``number``: Manually choose the number of iterations.  If ``number``
   is specified, ``goal_time`` is ignored.
@@ -314,8 +319,7 @@ by the ``number`` and ``repeat`` attributes, as explained below.
 - ``repeat``: The number of times to repeat the benchmark, with each
   repetition running the benchmark ``number`` of times.  The minimum
   time from all of these repetitions is used as the final result.
-  When not provided, defaults to ``timeit.default_repeat`` (3).
-  Setup and teardown are run on each repeat.
+  When not provided, defaults to 10. Setup and teardown are run on each repeat.
 
 - ``timer``: The timing function to use, which can be any source of
   monotonically increasing numbers, such as `time.clock`, `time.time`

--- a/docs/source/writing_benchmarks.rst
+++ b/docs/source/writing_benchmarks.rst
@@ -317,7 +317,7 @@ by the ``number`` and ``repeat`` attributes, as explained below.
   and after that ``teardown`` runs.
 
 - ``repeat``: The number of times to repeat the benchmark, with each
-  repetition running the benchmark ``number`` of times.  The minimum
+  repetition running the benchmark ``number`` of times.  The median
   time from all of these repetitions is used as the final result.
   When not provided, defaults to 10. Setup and teardown are run on each repeat.
 

--- a/test/benchmark/params_examples.py
+++ b/test/benchmark/params_examples.py
@@ -46,6 +46,7 @@ class TuningTest:
     counter = [0]
     number = 10
     repeat = 10
+    warmup_time = 0
 
     def setup(self, n):
         self.number = 1

--- a/test/benchmark/time_examples.py
+++ b/test/benchmark/time_examples.py
@@ -55,6 +55,7 @@ class TimeWithRepeat(object):
     number = 1
     repeat = 10
     count = 0
+    warmup_time = 0
 
     def setup(self):
         assert self.called is None

--- a/test/example_results/cheetah/22b920c6-py2.7-Cython-numpy1.8.json
+++ b/test/example_results/cheetah/22b920c6-py2.7-Cython-numpy1.8.json
@@ -33,8 +33,8 @@
 	    "params": [["1", "2", "3"]],
 	    "result": [1, 2, 3]
 	},
-	"time_ci_small": {"result": 1, "stats": [{"scale": 0.5, "df": 5, "systematic": 0}], "samples": [[[0,0],[1,1],[2,2],[3,3],[4,3]]]},
-	"time_ci_big": {"result": 1, "stats": [{"scale": 2, "df": 5, "systematic": 0}], "samples": [[[0,0],[1,9],[2,0],[3,9],[4,4]]]}
+	"time_ci_small": {"result": 1, "stats": [{"ci_99": [0.9, 1.1], "q_25": 1, "q_75": 1}]},
+	"time_ci_big": {"result": 1, "stats": [{"ci_99": [0.5, 2.5], "q_25": 0.5, "q_75": 2.5}]}
     }, 
     "version": 1
 }

--- a/test/example_results/cheetah/22b920c6-py2.7-Cython-numpy1.8.json
+++ b/test/example_results/cheetah/22b920c6-py2.7-Cython-numpy1.8.json
@@ -32,7 +32,9 @@
 	"time_other.time_parameterized": {
 	    "params": [["1", "2", "3"]],
 	    "result": [1, 2, 3]
-	}
+	},
+	"time_ci_small": {"result": 1, "stats": [{"scale": 0.5, "df": 5, "systematic": 0}], "samples": [[[0,0],[1,1],[2,2],[3,3],[4,3]]]},
+	"time_ci_big": {"result": 1, "stats": [{"scale": 2, "df": 5, "systematic": 0}], "samples": [[[0,0],[1,9],[2,0],[3,9],[4,4]]]}
     }, 
     "version": 1
 }

--- a/test/example_results/cheetah/fcf8c079-py2.7-Cython-numpy1.8.json
+++ b/test/example_results/cheetah/fcf8c079-py2.7-Cython-numpy1.8.json
@@ -36,8 +36,8 @@
 	    "result": [1, 4, null]
 	},
 	"params_examples.ParamSuite.track_value": null,
-	"time_ci_small": {"result": [3], "stats": [{"scale": 0.5, "df": 5, "systematic": 0}], "samples": [[[0,0],[1,3],[2,6],[3,9],[4,12.5]]]},
-	"time_ci_big": {"result": [3], "stats": [{"scale": 2.0, "df": 5, "systematic": 0}], "samples": [[[0,0],[1,9],[2,6],[3,9],[4,12]]]}
+	"time_ci_small": {"result": 3, "stats": [{"ci_99": [3.9, 3.1], "q_25": 3, "q_75": 3}]},
+	"time_ci_big": {"result": 3, "stats": [{"ci_99": [1.5, 3.5], "q_25": 1.5, "q_75": 3.5}]}
     }, 
     "version": 1
 }

--- a/test/example_results/cheetah/fcf8c079-py2.7-Cython-numpy1.8.json
+++ b/test/example_results/cheetah/fcf8c079-py2.7-Cython-numpy1.8.json
@@ -35,7 +35,9 @@
 	    "params": [["1", "2", "3"]],
 	    "result": [1, 4, null]
 	},
-	"params_examples.ParamSuite.track_value": null
+	"params_examples.ParamSuite.track_value": null,
+	"time_ci_small": {"result": [3], "stats": [{"scale": 0.5, "df": 5, "systematic": 0}], "samples": [[[0,0],[1,3],[2,6],[3,9],[4,12.5]]]},
+	"time_ci_big": {"result": [3], "stats": [{"scale": 2.0, "df": 5, "systematic": 0}], "samples": [[[0,0],[1,9],[2,6],[3,9],[4,12]]]}
     }, 
     "version": 1
 }

--- a/test/test_benchmarks.py
+++ b/test/test_benchmarks.py
@@ -85,7 +85,8 @@ def test_find_benchmarks(tmpdir):
     assert times[
         'time_examples.TimeSuite.time_example_benchmark_1']['result'] != [None]
     assert isinstance(times['time_examples.TimeSuite.time_example_benchmark_1']['stats'][0]['std'], float)
-    assert len(times['time_examples.TimeSuite.time_example_benchmark_1']['samples'][0]) == 10
+    # The exact number of samples may vary if the calibration is not fully accurate
+    assert len(times['time_examples.TimeSuite.time_example_benchmark_1']['samples'][0]) in (8, 9, 10)
     # Benchmarks that raise exceptions should have a time of "None"
     assert times[
         'time_secondary.TimeSecondary.time_exception']['result'] == [None]

--- a/test/test_benchmarks.py
+++ b/test/test_benchmarks.py
@@ -83,55 +83,57 @@ def test_find_benchmarks(tmpdir):
 
     assert len(times) == len(b)
     assert times[
-        'time_examples.TimeSuite.time_example_benchmark_1']['result'] is not None
+        'time_examples.TimeSuite.time_example_benchmark_1']['result'] != [None]
+    assert isinstance(times['time_examples.TimeSuite.time_example_benchmark_1']['stats'][0]['std'], float)
+    assert len(times['time_examples.TimeSuite.time_example_benchmark_1']['samples'][0]) == 10
     # Benchmarks that raise exceptions should have a time of "None"
     assert times[
-        'time_secondary.TimeSecondary.time_exception']['result'] is None
+        'time_secondary.TimeSecondary.time_exception']['result'] == [None]
     assert times[
-        'subdir.time_subdir.time_foo']['result'] is not None
+        'subdir.time_subdir.time_foo']['result'] != [None]
     if not ON_PYPY:
         # XXX: the memory benchmarks don't work on Pypy, since asizeof
         # is CPython-only
         assert times[
-            'mem_examples.mem_list']['result'] > 1000
+            'mem_examples.mem_list']['result'][0] > 1000
     assert times[
-        'time_secondary.track_value']['result'] == 42.0
+        'time_secondary.track_value']['result'] == [42.0]
     assert 'profile' in times[
         'time_secondary.track_value']
     assert 'stderr' in times[
         'time_examples.time_with_warnings']
     assert times['time_examples.time_with_warnings']['errcode'] != 0
 
-    assert times['params_examples.track_param']['result']['params'] == [["<class 'benchmark.params_examples.ClassOne'>",
-                                                                         "<class 'benchmark.params_examples.ClassTwo'>"]]
-    assert times['params_examples.track_param']['result']['result'] == [42, 42]
+    assert times['params_examples.track_param']['params'] == [["<class 'benchmark.params_examples.ClassOne'>",
+                                                               "<class 'benchmark.params_examples.ClassTwo'>"]]
+    assert times['params_examples.track_param']['result'] == [42, 42]
 
-    assert times['params_examples.mem_param']['result']['params'] == [['10', '20'], ['2', '3']]
-    assert len(times['params_examples.mem_param']['result']['result']) == 2*2
+    assert times['params_examples.mem_param']['params'] == [['10', '20'], ['2', '3']]
+    assert len(times['params_examples.mem_param']['result']) == 2*2
 
-    assert times['params_examples.ParamSuite.track_value']['result']['params'] == [["'a'", "'b'", "'c'"]]
-    assert times['params_examples.ParamSuite.track_value']['result']['result'] == [1+0, 2+0, 3+0]
+    assert times['params_examples.ParamSuite.track_value']['params'] == [["'a'", "'b'", "'c'"]]
+    assert times['params_examples.ParamSuite.track_value']['result'] == [1+0, 2+0, 3+0]
 
-    assert isinstance(times['params_examples.TuningTest.time_it']['result']['result'][0], float)
+    assert isinstance(times['params_examples.TuningTest.time_it']['result'][0], float)
 
-    assert isinstance(times['params_examples.time_skip']['result']['result'][0], float)
-    assert isinstance(times['params_examples.time_skip']['result']['result'][1], float)
-    assert util.is_nan(times['params_examples.time_skip']['result']['result'][2])
+    assert isinstance(times['params_examples.time_skip']['result'][0], float)
+    assert isinstance(times['params_examples.time_skip']['result'][1], float)
+    assert util.is_nan(times['params_examples.time_skip']['result'][2])
 
-    assert times['peakmem_examples.peakmem_list']['result'] >= 4 * 2**20
+    assert times['peakmem_examples.peakmem_list']['result'][0] >= 4 * 2**20
 
-    assert times['cache_examples.ClassLevelSetup.track_example']['result'] == 500
-    assert times['cache_examples.ClassLevelSetup.track_example2']['result'] == 500
+    assert times['cache_examples.ClassLevelSetup.track_example']['result'] == [500]
+    assert times['cache_examples.ClassLevelSetup.track_example2']['result'] == [500]
 
-    assert times['cache_examples.track_cache_foo']['result'] == 42
-    assert times['cache_examples.track_cache_bar']['result'] == 12
-    assert times['cache_examples.track_my_cache_foo']['result'] == 0
+    assert times['cache_examples.track_cache_foo']['result'] == [42]
+    assert times['cache_examples.track_cache_bar']['result'] == [12]
+    assert times['cache_examples.track_my_cache_foo']['result'] == [0]
 
     assert times['cache_examples.ClassLevelSetupFail.track_fail']['result'] == None
     assert 'raise RuntimeError()' in times['cache_examples.ClassLevelSetupFail.track_fail']['stderr']
 
     assert times['cache_examples.ClassLevelCacheTimeout.track_fail']['result'] == None
-    assert times['cache_examples.ClassLevelCacheTimeoutSuccess.track_success']['result'] == 0
+    assert times['cache_examples.ClassLevelCacheTimeoutSuccess.track_success']['result'] == [0]
 
     profile_path = join(tmpdir, 'test.profile')
     with open(profile_path, 'wb') as fd:
@@ -144,7 +146,7 @@ def test_find_benchmarks(tmpdir):
     assert times['time_examples.TimeWithRepeat.time_it']['stderr'].split() == expected
 
     # Calibration of iterations should not rerun setup
-    expected = ['setup']*2
+    expected = ['setup']*3
     assert times['time_examples.TimeWithRepeatCalibrate.time_it']['stderr'].split() == expected
 
     # Check run time timestamps
@@ -179,19 +181,19 @@ def test_table_formatting():
     assert benchmarks._format_benchmark_result(result, benchmark) == expected
 
     benchmark = {'params': [['a', 'b', 'c']], 'param_names': ['param1'], "unit": "seconds"}
-    result = [1e-6, 2e-6, 3e-6]
-    expected = ("======== ========\n"
-                " param1          \n"
-                "-------- --------\n"
-                "   a      1.00\u03bcs \n"
-                "   b      2.00\u03bcs \n"
-                "   c      3.00\u03bcs \n"
-                "======== ========")
+    result = list(zip([1e-6, 2e-6, 3e-6], [3e-6, 2e-6, 1e-6]))
+    expected = ("======== ==========\n"
+                " param1            \n"
+                "-------- ----------\n"
+                "   a      1.00\u00b13\u03bcs \n"
+                "   b      2.00\u00b12\u03bcs \n"
+                "   c      3.00\u00b11\u03bcs \n"
+                "======== ==========")
     table = "\n".join(benchmarks._format_benchmark_result(result, benchmark, max_width=80))
     assert table == expected
 
     benchmark = {'params': [["'a'", "'b'", "'c'"], ["[1]", "[2]"]], 'param_names': ['param1', 'param2'], "unit": "seconds"}
-    result = [1, 2, None, 4, 5, float('nan')]
+    result = list(zip([1, 2, None, 4, 5, float('nan')], [None]*6))
     expected = ("======== ======== =======\n"
                 "--            param2     \n"
                 "-------- ----------------\n"

--- a/test/test_benchmarks.py
+++ b/test/test_benchmarks.py
@@ -146,8 +146,8 @@ def test_find_benchmarks(tmpdir):
     assert times['time_examples.TimeWithRepeat.time_it']['stderr'].split() == expected
 
     # Calibration of iterations should not rerun setup
-    expected = ['setup']*3
-    assert times['time_examples.TimeWithRepeatCalibrate.time_it']['stderr'].split() == expected
+    expected = (['setup']*2, ['setup']*3)
+    assert times['time_examples.TimeWithRepeatCalibrate.time_it']['stderr'].split() in expected
 
     # Check run time timestamps
     for name, result in times.items():

--- a/test/test_compare.py
+++ b/test/test_compare.py
@@ -23,40 +23,80 @@ MACHINE_FILE = abspath(join(dirname(__file__), 'asv-machine.json'))
 REFERENCE = """
 All benchmarks:
 
-    before     after       ratio
-  [22b920c6] [fcf8c079]
-!       n/a     failed       n/a  params_examples.ParamSuite.track_value
-     failed     failed       n/a  time_AAA_failure
-        n/a        n/a       n/a  time_AAA_skip
-!  454.03μs     failed       n/a  time_coordinates.time_latitude
-      1.00s      1.00s      1.00  time_other.time_parameterized(1)
-      2.00s      4.00s      2.00  time_other.time_parameterized(2)
-!     3.00s     failed       n/a  time_other.time_parameterized(3)
-+    1.75ms   152.84ms     87.28  time_quantity.time_quantity_array_conversion
-+  933.71μs   108.22ms    115.90  time_quantity.time_quantity_init_array
-    83.65μs    55.38μs      0.66  time_quantity.time_quantity_init_scalar
-   281.71μs   146.88μs      0.52  time_quantity.time_quantity_scalar_conversion
-+    1.31ms     7.75ms      5.91  time_quantity.time_quantity_ufunc_sin
-      5.73m      5.73m      1.00  time_units.mem_unit
-+  125.11μs     3.81ms     30.42  time_units.time_simple_unit_parse
-     1.64ms     1.53ms      0.93  time_units.time_unit_compose
-+  372.11μs    11.47ms     30.81  time_units.time_unit_parse
--   69.09μs    18.32μs      0.27  time_units.time_unit_to
-    11.87μs    13.10μs      1.10  time_units.time_very_simple_unit_parse
+       before           after         ratio
+     [22b920c6]       [fcf8c079]
+!             n/a           failed      n/a  params_examples.ParamSuite.track_value
+           failed           failed      n/a  time_AAA_failure
+              n/a              n/a      n/a  time_AAA_skip
+          1.00±1s          3.00±1s    ~3.00  time_ci_big
++         1.00±0s          3.00±0s     3.00  time_ci_small
+!           454μs           failed      n/a  time_coordinates.time_latitude
+            1.00s            1.00s     1.00  time_other.time_parameterized(1)
+            2.00s            4.00s     2.00  time_other.time_parameterized(2)
+!           3.00s           failed      n/a  time_other.time_parameterized(3)
++          1.75ms            153ms    87.28  time_quantity.time_quantity_array_conversion
++           934μs            108ms   115.90  time_quantity.time_quantity_init_array
+           83.6μs           55.4μs     0.66  time_quantity.time_quantity_init_scalar
+            282μs            147μs     0.52  time_quantity.time_quantity_scalar_conversion
++          1.31ms           7.75ms     5.91  time_quantity.time_quantity_ufunc_sin
+            5.73m            5.73m     1.00  time_units.mem_unit
++           125μs           3.81ms    30.42  time_units.time_simple_unit_parse
+           1.64ms           1.53ms     0.93  time_units.time_unit_compose
++           372μs           11.5ms    30.81  time_units.time_unit_parse
+-          69.1μs           18.3μs     0.27  time_units.time_unit_to
+           11.9μs           13.1μs     1.10  time_units.time_very_simple_unit_parse
+"""
+
+REFERENCE_SPLIT = """
+Benchmarks that have improved:
+
+       before           after         ratio
+     [22b920c6]       [fcf8c079]
+-          69.1μs           18.3μs     0.27  time_units.time_unit_to
+
+Benchmarks that have stayed the same:
+
+       before           after         ratio
+     [22b920c6]       [fcf8c079]
+              n/a              n/a      n/a  time_AAA_skip
+          1.00±1s          3.00±1s    ~3.00  time_ci_big
+            1.00s            1.00s     1.00  time_other.time_parameterized(1)
+            2.00s            4.00s     2.00  time_other.time_parameterized(2)
+           83.6μs           55.4μs     0.66  time_quantity.time_quantity_init_scalar
+            282μs            147μs     0.52  time_quantity.time_quantity_scalar_conversion
+            5.73m            5.73m     1.00  time_units.mem_unit
+           1.64ms           1.53ms     0.93  time_units.time_unit_compose
+           11.9μs           13.1μs     1.10  time_units.time_very_simple_unit_parse
+
+Benchmarks that have got worse:
+
+       before           after         ratio
+     [22b920c6]       [fcf8c079]
+!             n/a           failed      n/a  params_examples.ParamSuite.track_value
+           failed           failed      n/a  time_AAA_failure
++         1.00±0s          3.00±0s     3.00  time_ci_small
+!           454μs           failed      n/a  time_coordinates.time_latitude
+!           3.00s           failed      n/a  time_other.time_parameterized(3)
++          1.75ms            153ms    87.28  time_quantity.time_quantity_array_conversion
++           934μs            108ms   115.90  time_quantity.time_quantity_init_array
++          1.31ms           7.75ms     5.91  time_quantity.time_quantity_ufunc_sin
++           125μs           3.81ms    30.42  time_units.time_simple_unit_parse
++           372μs           11.5ms    30.81  time_units.time_unit_parse
 """
 
 REFERENCE_ONLY_CHANGED = """
-    before     after       ratio
-  [22b920c6] [fcf8c079]
-!       n/a     failed       n/a  params_examples.ParamSuite.track_value
-!  454.03μs     failed       n/a  time_coordinates.time_latitude
-!     3.00s     failed       n/a  time_other.time_parameterized(3)
-+  933.71μs   108.22ms    115.90  time_quantity.time_quantity_init_array
-+    1.75ms   152.84ms     87.28  time_quantity.time_quantity_array_conversion
-+  372.11μs    11.47ms     30.81  time_units.time_unit_parse
-+  125.11μs     3.81ms     30.42  time_units.time_simple_unit_parse
-+    1.31ms     7.75ms      5.91  time_quantity.time_quantity_ufunc_sin
--   69.09μs    18.32μs      0.27  time_units.time_unit_to
+       before           after         ratio
+     [22b920c6]       [fcf8c079]
+!             n/a           failed      n/a  params_examples.ParamSuite.track_value
+!           454μs           failed      n/a  time_coordinates.time_latitude
+!           3.00s           failed      n/a  time_other.time_parameterized(3)
++           934μs            108ms   115.90  time_quantity.time_quantity_init_array
++          1.75ms            153ms    87.28  time_quantity.time_quantity_array_conversion
++           372μs           11.5ms    30.81  time_units.time_unit_parse
++           125μs           3.81ms    30.42  time_units.time_simple_unit_parse
++          1.31ms           7.75ms     5.91  time_quantity.time_quantity_ufunc_sin
++         1.00±0s          3.00±0s     3.00  time_ci_small
+-          69.1μs           18.3μs     0.27  time_units.time_unit_to
 """
 
 def test_compare(capsys, tmpdir):
@@ -74,6 +114,12 @@ def test_compare(capsys, tmpdir):
 
     text, err = capsys.readouterr()
     assert text.strip() == REFERENCE.strip()
+
+    tools.run_asv_with_conf(conf, 'compare', '22b920c6', 'fcf8c079', '--machine=cheetah',
+                            '--factor=2', '--split')
+
+    text, err = capsys.readouterr()
+    assert text.strip() == REFERENCE_SPLIT.strip()
 
     # Check print_table output as called from Continuous
     status = Compare.print_table(conf, '22b920c6', 'fcf8c079', factor=2, machine='cheetah',

--- a/test/test_console.py
+++ b/test/test_console.py
@@ -72,8 +72,8 @@ def test_write_with_fallback(tmpdir, capfd):
     #   - Try to print in latin1
     #   - Try to print in ascii, replacing all non-ascii characters
     encodings = ['utf-8', 'latin1', 'ascii', 'euc-jp']
-    strings = ["helloμ", "hello·", "hello難", "helloä"]
-    repmap = {"helloμ": "hellou", "hello·": "hello-"}
+    strings = ["helloμ", "hello·", "hello難", "helloä", "hello±"]
+    repmap = {"helloμ": "hellou", "hello·": "hello-", "hello±": "hello~"}
 
     for pref_enc, stream_enc, s in itertools.product(encodings, encodings, strings):
         expected = None

--- a/test/test_rm.py
+++ b/test/test_rm.py
@@ -31,7 +31,7 @@ def test_rm(tmpdir):
 
     results_a = list(results.iter_results(tmpdir))
     for result in results_a:
-        for key in six.iterkeys(result.results):
+        for key in result.result_keys:
             assert not key.startswith('time_quantity')
         for key in six.iterkeys(result.started_at):
             assert not key.startswith('time_quantity')

--- a/test/test_statistics.py
+++ b/test/test_statistics.py
@@ -1,0 +1,145 @@
+# -*- coding: utf-8 -*-
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+
+from __future__ import (absolute_import, division, print_function,
+                        unicode_literals)
+
+from itertools import product
+import pytest
+
+import asv.statistics as statistics
+
+
+try:
+    import numpy as np
+    HAS_NUMPY = True
+except ImportError:
+    HAS_NUMPY = False
+
+
+try:
+    from scipy import special, stats
+    HAS_SCIPY = True
+except ImportError:
+    HAS_SCIPY = False
+
+
+@pytest.mark.skipif(not HAS_NUMPY, reason="Requires numpy")
+def test_compute_stats():
+    np.random.seed(1)
+
+    assert statistics.compute_stats([]) == (None, None)
+    assert statistics.compute_stats([15.0]) == (15.0, None)
+
+    for nsamples, true_mean in product([10, 50, 250], [0, 0.3, 0.6]):
+        samples = np.random.randn(nsamples) + true_mean
+        result, stats = statistics.compute_stats(samples)
+
+        assert np.allclose(stats['systematic'], 0)
+        assert np.allclose(stats['n'], len(samples))
+        assert np.allclose(stats['mean'], np.mean(samples))
+        assert np.allclose(stats['q_25'], np.percentile(samples, 25))
+        assert np.allclose(stats['q_75'], np.percentile(samples, 75))
+        assert np.allclose(stats['min'], np.min(samples))
+        assert np.allclose(stats['max'], np.max(samples))
+        assert np.allclose(stats['std'], np.std(samples, ddof=0))
+        assert np.allclose(result, np.median(samples))
+
+        ci = stats['ci_99']
+        assert ci[0] <= true_mean <= ci[1]
+        w = 12.0 * np.std(samples) / np.sqrt(len(samples))
+        assert ci[1] - ci[0] < w
+
+        err = statistics.get_err(result, stats)
+        iqr = np.percentile(samples, 75) - np.percentile(samples, 25)
+        assert np.allclose(err, iqr/2)
+
+
+@pytest.mark.skipif(not HAS_NUMPY, reason="Requires numpy")
+def test_is_different():
+    np.random.seed(1)
+
+    # Smoke test is_different
+    for true_mean, n, significant in [(0.05, 10, False), (0.05, 100, True), (0.1, 10, True)]:
+        samples_a = 0 + 0.1 * np.random.rand(n)
+        samples_b = true_mean + 0.1 * np.random.rand(n)
+        result_a, stats_a = statistics.compute_stats(samples_a)
+        result_b, stats_b = statistics.compute_stats(samples_b)
+        assert statistics.is_different(stats_a, stats_b) == significant
+
+
+@pytest.mark.skipif(not HAS_NUMPY, reason="Requires numpy")
+def test_quantile_ci():
+    # Test the confidence intervals
+
+    def get_z_exp(loc, scale, size):
+        z = np.random.exponential(scale, size=size)
+        z *= 2 * np.random.randint(0, 2, size=len(z)) - 1
+        return loc + z
+
+    def get_z_normal(loc, scale, size):
+        z = np.random.normal(loc, scale, size=size)
+        return z
+
+    loc = 2.5
+    scale = 2.5
+
+    np.random.seed(1)
+
+    for alpha_min in [0.5, 0.9, 0.99, 0.999]:
+        for sampler in [get_z_exp, get_z_normal]:
+            for size in [10, 30]:
+                samples = []
+                for k in range(300):
+                    z = sampler(loc, scale, size)
+                    m, ci = statistics.quantile_ci(z, 0.5, alpha_min)
+                    assert np.allclose(m, np.median(z))
+                    a, b = ci
+                    samples.append(a <= loc <= b)
+
+                alpha = sum(samples) / len(samples)
+
+                # Order of magnitude should match
+                assert 1 - alpha <= 5 * (1 - alpha_min), (alpha_min, sampler, size)
+
+
+def test_quantile_ci_small():
+    # Small samples should give min/max ci
+    for n in range(1, 7):
+        sample = list(range(n))
+        m, ci = statistics.quantile_ci(sample, 0.5, 0.99)
+        assert ci[0] == min(sample)
+        assert ci[1] == max(sample)
+
+
+@pytest.mark.skipif(not HAS_NUMPY, reason="Requires numpy")
+def test_quantile():
+    np.random.seed(1)
+    x = np.random.randn(50)
+    for q in np.linspace(0, 1, 300):
+        expected = np.percentile(x, 100 * q)
+        got = statistics.quantile(x.tolist(), q)
+        assert np.allclose(got, expected), q
+
+
+@pytest.mark.skipif(not HAS_SCIPY, reason="Requires scipy")
+def test_lgamma():
+    x = np.arange(1, 5000)
+
+    expected = special.gammaln(x)
+    got = np.vectorize(statistics.lgamma)(x)
+
+    assert np.allclose(got, expected, rtol=1e-12, atol=0)
+    assert np.isnan(statistics.lgamma(1.2))
+
+
+@pytest.mark.skipif(not HAS_SCIPY, reason="Requires scipy")
+def test_binom_pmf():
+    p = np.linspace(0, 1, 7)
+    k = np.arange(0, 40, 5)[:,None]
+    n = np.arange(0, 40, 5)[:,None,None]
+
+    expected = stats.binom.pmf(k, n, p)
+    got = np.vectorize(statistics.binom_pmf)(n, k, p)
+
+    assert np.allclose(got, expected, rtol=1e-12, atol=0)

--- a/test/test_workflow.py
+++ b/test/test_workflow.py
@@ -160,7 +160,7 @@ def test_continuous(capfd, basic_conf):
 
     text, err = capfd.readouterr()
     assert "SOME BENCHMARKS HAVE CHANGED SIGNIFICANTLY" in text
-    assert "+     1.00s      6.00s      6.00  params_examples.track_find_test(2)" in text
+    assert "+           1.00s            6.00s     6.00  params_examples.track_find_test(2)" in text
     assert "params_examples.ClassOne" in text
 
 

--- a/test/tools.py
+++ b/test/tools.py
@@ -368,7 +368,16 @@ def generate_result_dir(tmpdir, dvcs, values, branches=None):
             params = value["params"]
         result = Results({"machine": "tarzan"}, {}, commit,
                          repo.get_date_from_name(commit), "2.7", None)
-        result.add_result("time_func", value, timestamp, timestamp)
+        value = {
+            'result': [value],
+            'params': [],
+            'started_at': timestamp,
+            'ended_at': timestamp,
+            'stats': None,
+            'samples': None,
+            'number': None
+        }
+        result.add_result("time_func", value)
         result.save(result_dir)
 
     util.write_json(join(result_dir, "benchmarks.json"), {


### PR DESCRIPTION
Record more benchmark samples, and compute, display, and use statistics based on them.

- Change default settings to record more (but shorter) samples. <s>Changes meaning of `goal_time`</s> Makes determination of `goal_time` more accurate; however, no big changes to methodology --- there's room to improve here.
- Do warmup before benchmark --- this seems to matter also on CPython (although possibly not due to CPython itself but some OS/CPU effects)
- Display spread of measurements (median +/- half of interquartile range)
- Estimate confidence interval and use that to decide what is not significant in `asv compare`.
- Optionally, save samples to the json files.
- <s>Switch to gzipped files.</s>

The statistical confidence estimates are a somewhat tricky point, because timing samples usually have strong autocorrelation (multimodality, stepwise changes in location, etc.), which makes simple stuff often misleading. There's some alleviation for this currently there in that it tries to regress the timing sample time series looking for steps, and adds those to the CI. Not rigorous, but probably better than nothing.

The problem is that there's low-frequency noise in the measurement, so measuring for a couple of second does not give a good idea of the full distribution.

todo:

- [x] more tests, e.g. printing and formatting is mostly untested
- [x] do we really need to gzip?
- [x] update documentation
- [x] tuning for pypy