### PR TITLE
Replace forward slash with underscore in env name.

### DIFF
--- a/asv/environment.py
+++ b/asv/environment.py
@@ -179,12 +179,11 @@ def get_env_name(tool_name, python, requirements):
     reqs = list(six.iteritems(requirements))
     reqs.sort()
     for key, val in reqs:
-        key = key.replace('/', '_')
         if val:
             name.append(''.join([key, val]))
         else:
             name.append(key)
-    return '-'.join(name)
+    return '-'.join(name).replace('/', '_')
 
 
 def get_environments(conf, env_specifiers):

--- a/asv/environment.py
+++ b/asv/environment.py
@@ -179,6 +179,7 @@ def get_env_name(tool_name, python, requirements):
     reqs = list(six.iteritems(requirements))
     reqs.sort()
     for key, val in reqs:
+        key = key.replace('/', '_')
         if val:
             name.append(''.join([key, val]))
         else:

--- a/test/test_environment.py
+++ b/test/test_environment.py
@@ -447,7 +447,7 @@ def test_environment_name():
     # Check autodetect
     environments = list(environment.get_environments(conf))
     assert len(environments) == 1
-    assert environments[0].name = "foo"
+    assert environments[0].name == "foo"
 
 
 def test_matrix_empty():

--- a/test/test_environment.py
+++ b/test/test_environment.py
@@ -445,7 +445,7 @@ def test_environment_name():
     }
 
     # Check autodetect
-    environments = list(environment.get_environments(conf))
+    environments = list(environment.get_environments(conf, []))
     assert len(environments) == 1
     assert environments[0].name == "foo"
 

--- a/test/test_environment.py
+++ b/test/test_environment.py
@@ -436,6 +436,20 @@ def test_environment_select_autodetect():
     assert len(environments) == 1
 
 
+def test_environment_name():
+    conf = config.Config()
+    conf.environment_type = "conda"
+    conf.pythons = ["3.4"]
+    conf.matrix = {
+        "six": ["1.4"],
+    }
+
+    # Check autodetect
+    environments = list(environment.get_environments(conf))
+    assert len(environments) == 1
+    assert environments[0].name = "foo"
+
+
 def test_matrix_empty():
     conf = config.Config()
     conf.environment_type = ""

--- a/test/test_environment.py
+++ b/test/test_environment.py
@@ -447,7 +447,7 @@ def test_environment_name():
     # Check autodetect
     environments = list(environment.get_environments(conf, []))
     assert len(environments) == 1
-    assert environments[0].name == "foo"
+    assert environments[0].name == "conda-py3.4-six1.4"
 
 
 def test_matrix_empty():


### PR DESCRIPTION
Replace forward slash in env name to prevent subdirectories getting created.

Resolves #494 