### PR TITLE
Sanitize filenames in graph parameters

### DIFF
--- a/asv/environment.py
+++ b/asv/environment.py
@@ -183,7 +183,7 @@ def get_env_name(tool_name, python, requirements):
             name.append(''.join([key, val]))
         else:
             name.append(key)
-    return '-'.join(name)
+    return util.sanitize_filename('-'.join(name))
 
 
 def get_environments(conf, env_specifiers):

--- a/asv/graph.py
+++ b/asv/graph.py
@@ -117,19 +117,21 @@ class Graph(object):
         """
         Get a file path understood by the JS frontend, corresponding
         on the given parameters and benchmark_name.
+
+        The implementation must match asv.js:graph_to_path
         """
-        # TODO: Make filename safe
         parts = ['graphs']
         l = list(six.iteritems(params))
         l.sort()
         for key, val in l:
             if val is None:
-                parts.append('{0}-null'.format(key))
+                part = '{0}-null'.format(key)
             elif val:
-                parts.append('{0}-{1}'.format(key, val))
+                part = '{0}-{1}'.format(key, val)
             else:
-                parts.append('{0}'.format(key))
-        parts.append(benchmark_name)
+                part = '{0}'.format(key)
+            parts.append(util.sanitize_filename(part))
+        parts.append(util.sanitize_filename(benchmark_name))
         return os.path.join(*parts)
 
     def add_data_point(self, revision, value):

--- a/asv/util.py
+++ b/asv/util.py
@@ -12,6 +12,7 @@ import datetime
 import json
 import math
 import os
+import re
 import select
 import signal
 import subprocess
@@ -882,3 +883,28 @@ else:
         shutil.rmtree(long_path(path),
                       ignore_errors=ignore_errors,
                       onerror=onerror)
+
+
+def sanitize_filename(filename):
+    """
+    Replace characters to make a string safe to use in file names.
+
+    This is not a 1-to-1 mapping.
+
+    The implementation needs to match www/asv.js:escape_graph_parameter
+    """
+    if not isinstance(filename, six.text_type):
+        filename = filename.decode(sys.getfilesystemencoding())
+
+    # ntfs & ext3
+    filename = re.sub('[<>:"/\\^|?*\x00-\x1f]', '_', filename)
+
+    # ntfs
+    forbidden = ["CON", "PRN", "AUX", "NUL", "COM1", "COM2", "COM3",
+                 "COM4", "COM5", "COM6", "COM7", "COM8", "COM9", "LPT1",
+                 "LPT2", "LPT3", "LPT4", "LPT5", "LPT6", "LPT7", "LPT8",
+                 "LPT9"]
+    if filename.upper() in forbidden:
+        filename = filename + "_"
+
+    return filename

--- a/asv/www/asv.js
+++ b/asv/www/asv.js
@@ -175,22 +175,41 @@ $(document).ready(function() {
         return filter_graph_data(raw_series, x_axis, flat_selection, params);
     }
 
+    /* Escape special characters in graph item file names.
+       The implementation must match asv.util.sanitize_filename */
+    function sanitize_filename(name) {
+        var bad_re = /[<>:"\/\\^|?*\x00-\x1f]/g;
+        var bad_names = ["CON", "PRN", "AUX", "NUL", "COM1", "COM2", "COM3",
+                         "COM4", "COM5", "COM6", "COM7", "COM8", "COM9", "LPT1",
+                         "LPT2", "LPT3", "LPT4", "LPT5", "LPT6", "LPT7", "LPT8",
+                         "LPT9"];
+        name = name.replace(bad_re, "_");
+        if (bad_names.indexOf(name.toUpperCase()) != -1) {
+            name = name + "_";
+        }
+        return name;
+    }
+
     /* Given a specific group of parameters, generate the URL to
-       use to load that graph. */
+       use to load that graph.
+       The implementation must match asv.graph.Graph.get_file_path
+     */
     function graph_to_path(benchmark_name, state) {
         var parts = [];
         $.each(state, function(key, value) {
+            var part;
             if (value === null) {
-                parts.push(key + "-null");
+                part = key + "-null";
             } else if (value) {
-                parts.push(key + "-" + value);
+                part = key + "-" + value;
             } else {
-                parts.push(key);
+                part = key;
             }
+            parts.push(sanitize_filename('' + part));
         });
         parts.sort();
         parts.splice(0, 0, "graphs");
-        parts.push(benchmark_name);
+        parts.push(sanitize_filename(benchmark_name));
         return parts.join('/') + ".json";
     }
 

--- a/test/test_environment.py
+++ b/test/test_environment.py
@@ -483,3 +483,17 @@ def test_pypy_virtualenv(tmpdir):
         env.create()
         output = env.run(['-c', 'import sys; print(sys.pypy_version_info)'])
         assert output.startswith(six.text_type("(major="))
+
+
+def test_environment_name_sanitization():
+    conf = config.Config()
+    conf.environment_type = "conda"
+    conf.pythons = ["3.4"]
+    conf.matrix = {
+        "pip+git+http://github.com/space-telescope/asv.git": [],
+    }
+
+    # Check name sanitization
+    environments = list(environment.get_environments(conf, []))
+    assert len(environments) == 1
+    assert environments[0].name == "conda-py3.4-pip+git+http___github.com_space-telescope_asv.git"

--- a/test/test_environment.py
+++ b/test/test_environment.py
@@ -62,7 +62,7 @@ def test_matrix_environments(tmpdir):
 
     conf.pythons = ["2.7", "3.4"]
     conf.matrix = {
-        "six": ["1.4", None],
+        "six": ["1.10", None],
         "colorama": ["0.3.6", "0.3.7"]
     }
     environments = list(environment.get_environments(conf, None))
@@ -346,7 +346,7 @@ def test_environment_select():
     conf.environment_type = "conda"
     conf.pythons = ["2.7", "3.4"]
     conf.matrix = {
-        "six": ["1.4"],
+        "six": ["1.10"],
     }
     conf.include = [
         {'environment_type': 'conda', 'python': '1.9'}
@@ -390,19 +390,19 @@ def test_environment_select():
         assert os.path.normcase(os.path.abspath(env._executable)) == os.path.normcase(os.path.abspath(sys.executable))
 
     # Select by environment name
-    environments = list(environment.get_environments(conf, ["conda-py2.7-six1.4"]))
+    environments = list(environment.get_environments(conf, ["conda-py2.7-six1.10"]))
     assert len(environments) == 1
     assert environments[0].python == "2.7"
     assert environments[0].tool_name == "conda"
-    assert environments[0].requirements == {'six': '1.4'}
+    assert environments[0].requirements == {'six': '1.10'}
 
     # Check interaction with exclude
     conf.exclude = [{'environment_type': "conda"}]
-    environments = list(environment.get_environments(conf, ["conda-py2.7-six1.4"]))
+    environments = list(environment.get_environments(conf, ["conda-py2.7-six1.10"]))
     assert len(environments) == 0
 
     conf.exclude = [{'environment_type': 'matches nothing'}]
-    environments = list(environment.get_environments(conf, ["conda-py2.7-six1.4"]))
+    environments = list(environment.get_environments(conf, ["conda-py2.7-six1.10"]))
     assert len(environments) == 1
 
 
@@ -413,7 +413,7 @@ def test_environment_select_autodetect():
     conf.environment_type = "conda"
     conf.pythons = ["3.4"]
     conf.matrix = {
-        "six": ["1.4"],
+        "six": ["1.10"],
     }
 
     # Check autodetect

--- a/test/test_graph.py
+++ b/test/test_graph.py
@@ -1,3 +1,11 @@
+# -*- coding: utf-8 -*-
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+
+from __future__ import (absolute_import, division, print_function,
+                        unicode_literals)
+
+import os
+
 from asv.graph import Graph, RESAMPLED_POINTS, make_summary_graph
 
 
@@ -210,6 +218,11 @@ def test_graph_steps():
 
     for s in multi_g.get_steps():
         assert s == steps
+
+
+def test_graph_filename_sanitization():
+    g = Graph('hello:world', {'a/a': 'b>b', 'c*c': 'd\0\0d'})
+    assert g.path == os.path.join('graphs', 'a_a-b_b', 'c_c-d__d', 'hello_world')
 
 
 def _sgn(x):

--- a/test/test_web.py
+++ b/test/test_web.py
@@ -88,8 +88,12 @@ def basic_html(request):
 
         # Swap CPU info and obtain some results
         info = util.load_json(machine_file, api_version=1)
-        info['orangutan']['cpu'] = 'Not really fast'
-        info['orangutan']['ram'] = 'Not much ram'
+
+        # Put in parameter values that need quoting in file names
+        info['orangutan']['cpu'] = 'Not /really/ <fast>'
+        info['orangutan']['ram'] = '?'
+        info['orangutan']['NUL'] = ''
+
         util.write_json(machine_file, info, api_version=1)
 
         tools.run_asv_with_conf(conf, 'run', 'master~10..', '--steps=3',
@@ -268,7 +272,8 @@ def test_web_summarylist(browser, basic_html):
         # Check link
         base_href, qs = splitquery(base_link.get_attribute('href'))
         base_url, tag = splittag(base_href)
-        assert parse_qs(qs) == {'ram': ['128GB'], 'cpu': ['Blazingly fast']}
+        assert parse_qs(qs) == {'ram': ['128GB'], 'cpu': ['Blazingly fast'],
+                                'NUL': ['[none]']}
         assert tag == 'params_examples.track_find_test'
 
         # Change table sort (sorting is async, so needs waits)
@@ -279,7 +284,7 @@ def test_web_summarylist(browser, basic_html):
                                               'params_examples.track_find_test'))
 
         # Try to click cpu selector link in the panel
-        cpu_select = browser.find_element_by_link_text('Not really fast')
+        cpu_select = browser.find_element_by_link_text('Not /really/ <fast>')
         cpu_select.click()
 
         # For the other CPU, there is no recent change recorded, only

--- a/test/test_workflow.py
+++ b/test/test_workflow.py
@@ -106,7 +106,7 @@ def test_run_publish(capfd, basic_conf):
     # Check parameterized test json data format
     filename = glob.glob(join(tmpdir, 'html', 'graphs', 'arch-x86_64', 'branch-master',
                               'colorama-0.3.7',  'cpu-Blazingly fast', 'machine-orangutan',
-                              'os-GNU', 'Linux', 'python-*', 'ram-128GB',
+                              'os-GNU_Linux', 'python-*', 'ram-128GB',
                               'six', 'params_examples.time_skip.json'))[0]
     with open(filename, 'r') as fp:
         data = json.load(fp)


### PR DESCRIPTION
The graph parameter keys and values are used in file names, and need to
be quoted appropriately.

Also sanitize environment names, as they are used in result file names.

Fixes #494