### PR TITLE
BUG: Make benchmark number calibration based on wall clock time

### DIFF
--- a/asv/benchmark.py
+++ b/asv/benchmark.py
@@ -447,13 +447,17 @@ class TimeBenchmark(Benchmark):
             number = 1
             while True:
                 self._redo_setup_next = False
+                start = time.time()
                 timing = timer.timeit(number)
-                if timing >= goal_time:
+                wall_time = time.time() - start
+                actual_timing = max(wall_time, timing)
+
+                if actual_timing >= goal_time:
                     if time.time() > start_time + warmup_time:
                         break
                 else:
                     try:
-                        p = min(10.0, max(1.1, goal_time/timing))
+                        p = min(10.0, max(1.1, goal_time/actual_timing))
                     except ZeroDivisionError:
                         p = 10.0
                     number = max(number + 1, int(p * number))

--- a/test/benchmark/time_examples.py
+++ b/test/benchmark/time_examples.py
@@ -84,3 +84,17 @@ class TimeWithRepeatCalibrate(object):
 
     def time_it(self):
         pass
+
+
+class TimeWithBadTimer(object):
+    # Check that calibration of number is robust against bad timers
+    repeat = 1
+    number = 0
+    goal_time = 0.1
+    timeout = 5
+
+    def timer(self):
+        return 0.0
+
+    def time_it(self):
+        pass

--- a/test/test_benchmarks.py
+++ b/test/test_benchmarks.py
@@ -59,7 +59,7 @@ def test_find_benchmarks(tmpdir):
     assert len(b) == 3
 
     b = benchmarks.Benchmarks(conf, repo, envs, regex='example')
-    assert len(b) == 24
+    assert len(b) == 25
 
     b = benchmarks.Benchmarks(conf, repo, envs, regex='time_example_benchmark_1')
     assert len(b) == 2
@@ -72,7 +72,7 @@ def test_find_benchmarks(tmpdir):
     assert sorted(b.keys()) == ['custom.time_function', 'custom.track_method']
 
     b = benchmarks.Benchmarks(conf, repo, envs)
-    assert len(b) == 30
+    assert len(b) == 31
 
     start_timestamp = datetime.datetime.utcnow()
 
@@ -104,6 +104,8 @@ def test_find_benchmarks(tmpdir):
     assert 'stderr' in times[
         'time_examples.time_with_warnings']
     assert times['time_examples.time_with_warnings']['errcode'] != 0
+
+    assert times['time_examples.TimeWithBadTimer.time_it']['result'] == [0.0]
 
     assert times['params_examples.track_param']['params'] == [["<class 'benchmark.params_examples.ClassOne'>",
                                                                "<class 'benchmark.params_examples.ClassTwo'>"]]


### PR DESCRIPTION
Guard against large runtime when the timer used fails to properly
account for the wall-clock duration.

Fixes gh-497