### PR TITLE
In web regression listing, show the date of the last (not first) regression

### DIFF
--- a/asv/www/asv.js
+++ b/asv/www/asv.js
@@ -48,6 +48,26 @@ $(document).ready(function() {
         return 'inf';
     }
 
+    function pad_left(s, c, num) {
+        s = '' + s;
+        while (s.length < num) {
+            s = c + s;
+        }
+        return s;
+    }
+
+    function format_date_yyyymmdd(date) {
+        return (pad_left(date.getFullYear(), '0', 4)
+                + '-' + pad_left(date.getMonth() + 1, '0', 2)
+                + '-' + pad_left(date.getDate(), '0', 2));
+    }
+
+    function format_date_yyyymmdd_hhmm(date) {
+        return (format_date_yyyymmdd(date) + ' '
+                + pad_left(date.getHours(), '0', 2)
+                + ':' + pad_left(date.getMinutes(), '0', 2));
+    }
+
     /* Convert a flat index to permutation to the corresponding value */
     function param_selection_from_flat_idx(params, idx) {
         var selection = [];
@@ -431,6 +451,8 @@ $(document).ready(function() {
 
     this.master_json = master_json; /* Updated after index.json loads */
 
+    this.format_date_yyyymmdd = format_date_yyyymmdd;
+    this.format_date_yyyymmdd_hhmm = format_date_yyyymmdd_hhmm;
     this.pretty_second = pretty_second;
     this.time_units = time_units;
 

--- a/asv/www/regressions.css
+++ b/asv/www/regressions.css
@@ -31,3 +31,7 @@
 #regressions-body .feed-div {
     float: right;
 }
+
+#regressions-body table tbody td.date {
+    white-space: nowrap;
+}

--- a/asv/www/regressions.js
+++ b/asv/www/regressions.js
@@ -173,7 +173,8 @@ $(document).ready(function() {
             var old_value = regression[2];
 
             var factor = new_value / old_value;
-            var date_fmt = new Date($.asv.master_json.revision_to_date[revisions[0][1]]);
+            var last_revision = revisions[revisions.length - 1];
+            var date_fmt = new Date($.asv.master_json.revision_to_date[last_revision[1]]);
 
             var row = $('<tr/>');
 
@@ -215,7 +216,7 @@ $(document).ready(function() {
 
             var benchmark_link = $('<a/>').attr('href', benchmark_url).text(benchmark_name);
             row.append($('<td/>').append(benchmark_link));
-            row.append($('<td/>').text(date_fmt.toISOString()));
+            row.append($('<td class="date"/>').text($.asv.format_date_yyyymmdd_hhmm(date_fmt)));
 
             var commit_td = $('<td/>');
             $.each(revisions, function(i, revs) {

--- a/asv/www/summarylist.js
+++ b/asv/www/summarylist.js
@@ -206,20 +206,6 @@ $(document).ready(function() {
         $.asv.ui.reflow_value_selector_panels();
     }
 
-    function pad_left(s, c, num) {
-        s = '' + s;
-        while (s.length < num) {
-            s = c + s;
-        }
-        return s;
-    }
-
-    function format_date_yyyymmdd(date) {
-        return (pad_left(date.getFullYear(), '0', 4)
-                + '-' + pad_left(date.getMonth() + 1, '0', 2)
-                + '-' + pad_left(date.getDay() + 1, '0', 2));
-    }
-
     function construct_benchmark_table(data) {
         var index = $.asv.master_json;
 
@@ -394,7 +380,7 @@ $(document).ready(function() {
                     commit_a.attr('href', $.asv.master_json.show_commit_url + commit_2);
                     commit_a.text(commit_2);
                 }
-                span.text(format_date_yyyymmdd(date) + ' ');
+                span.text($.asv.format_date_yyyymmdd(date) + ' ');
                 span.append(commit_a);
                 changed_at_td.append(span);
             }

--- a/test/test_web.py
+++ b/test/test_web.py
@@ -181,8 +181,8 @@ def test_web_regressions(browser, basic_html):
         assert cols1[0] == 'params_examples.track_find_test(1)'
         assert cols2[0] == 'params_examples.track_find_test(2)'
 
-        assert re.match(r'^\d\d\d\d-\d\d-\d\dT\d\d:\d\d:\d\d.\d+Z$', cols1[1])
-        assert re.match(r'^\d\d\d\d-\d\d-\d\dT\d\d:\d\d:\d\d.\d+Z$', cols2[1])
+        assert re.match(r'^\d\d\d\d-\d\d-\d\d \d\d:\d\d$', cols1[1])
+        assert re.match(r'^\d\d\d\d-\d\d-\d\d \d\d:\d\d$', cols2[1])
 
         assert cols1[2:] == [bad_commit_hash[:8], '2.00x', '1.00', '2.00', 'Ignore']
         assert cols2[2:] == [bad_commit_hash[:8], '2.00x', '1.00', '2.00', 'Ignore']


### PR DESCRIPTION
Ordering by most recent regression is likely the most sensible one.
This also makes the date ordering of items displayed on web more closely match the RSS feed.

Also fix a bug producing completely incorrect date formatting (Date.getDay vs Date.getDate...).
