### PR TITLE
Benchmark result versioning

### DIFF
--- a/asv/commands/continuous.py
+++ b/asv/commands/continuous.py
@@ -101,10 +101,11 @@ class Continuous(Command):
 
                 for name, benchmark in six.iteritems(run_objs['benchmarks']):
                     params = benchmark['params']
+                    version = benchmark['version']
 
                     value = result.get_result_value(name, params)
                     stats = result.get_result_stats(name, params)
-                    yield name, params, value, stats
+                    yield name, params, value, stats, version
 
         status = Compare.print_table(conf, parent, head,
                                      resultset_1=results_iter(parent),

--- a/asv/commands/publish.py
+++ b/asv/commands/publish.py
@@ -132,10 +132,10 @@ class Publish(Command):
             for results in iter_results(conf.results_dir):
                 log.dot()
 
-                for key in results.result_keys:
-                    b = benchmarks.get(key)
+                for key in results.get_result_keys(benchmarks):
+                    b = benchmarks[key]
+                    b_params = b['params']
 
-                    b_params = b['params'] if b else []
                     result = results.get_result_value(key, b_params)
                     if not b_params:
                         result = result[0]

--- a/asv/commands/rm.py
+++ b/asv/commands/rm.py
@@ -86,7 +86,7 @@ class Rm(Command):
 
             if single_benchmark is not None:
                 found = False
-                for benchmark in list(result.result_keys):
+                for benchmark in list(result.get_all_result_keys()):
                     if fnmatchcase(benchmark, single_benchmark):
                         count += 1
                         files_to_remove.add(result)

--- a/asv/commands/run.py
+++ b/asv/commands/run.py
@@ -215,7 +215,7 @@ class Run(Command):
                             skipped_benchmarks.update(benchmarks)
                             break
 
-                        for key in result.result_keys:
+                        for key in result.get_result_keys(benchmarks):
                             if key not in benchmarks:
                                 continue
 
@@ -289,6 +289,7 @@ class Run(Command):
                                 d['samples'] = None
                                 d['number'] = None
 
-                            result.add_result(benchmark_name, d)
+                            benchmark_version = benchmarks[benchmark_name]['version']
+                            result.add_result(benchmark_name, d, benchmark_version)
 
                         result.update_save(conf.results_dir)

--- a/asv/plugins/regressions.py
+++ b/asv/plugins/regressions.py
@@ -130,7 +130,7 @@ class Regressions(OutputPublisher):
                 run_timestamps[key] = timestamp
 
             # Fallback to commit date
-            for benchmark_name in results.result_keys:
+            for benchmark_name in results.get_result_keys(benchmarks):
                 key = (benchmark_name, revision)
                 run_timestamps.setdefault(key, results.date)
 

--- a/docs/source/dev.rst
+++ b/docs/source/dev.rst
@@ -83,6 +83,10 @@ A benchmark suite directory has the following layout.  The
     - ``param_names``: Names for parameters for a parameterized
       benchmark. Must be of the same length as the ``params`` list.
 
+    - ``version``: An arbitrary string identifying the benchmark
+      version. Default value is hash of ``code``, but user can
+      override.
+
     Other keys are specific to the kind of benchmark, and correspond
     to :ref:`benchmark-attributes`.
 
@@ -159,6 +163,12 @@ A benchmark suite directory has the following layout.  The
 
       - ``ended_at``: A dictionary from benchmark names to JavaScript
         time stamps indicating the end time of the benchmark run.
+
+      - ``benchmark_version``: A dictionary from benchmark names to benchmark
+        version identifier (an arbitrary string). Results whose version
+        is not equal to the version of the benchmark are ignored.
+        If the value is missing, no version comparisons are done
+        (backward compatibility).
 
 - ``$html_dir/``: The output of ``asv publish``, that turns the raw
   results in ``$results_dir/`` into something viewable in a web

--- a/docs/source/writing_benchmarks.rst
+++ b/docs/source/writing_benchmarks.rst
@@ -197,6 +197,16 @@ The following attributes are applicable to all benchmark types:
 - ``pretty_name``: If given, used to display the benchmark name instead of the
   benchmark function name.
 
+- ``version``: Used to determine when to invalidate old benchmark
+  results.  Benchmark results produced with a different value of the
+  version than the current value will be ignored.  The value can be
+  any Python string (or other object, ``str()`` will be taken).
+
+  Default (if ``version=None`` or not given): hash of the source code
+  of the benchmark function and setup and setup_cache methods. If the
+  source code of any of these changes, old results become invalidated.
+
+
 Parameterized benchmarks
 ------------------------
 

--- a/test/benchmark/code_extraction.py
+++ b/test/benchmark/code_extraction.py
@@ -1,0 +1,26 @@
+# -*- coding: utf-8 -*-
+
+def setup():
+    # module-level
+    pass
+
+def setup_cache():
+    # module-level
+    pass
+
+def track_test():
+    # module-level 難
+    return 0
+
+class MyClass:
+    def setup(self):
+        # class-level
+        pass
+
+    def setup_cache(self):
+        # class-level
+        pass
+
+    def track_test(self):
+        # class-level 難
+        return 0

--- a/test/example_results/benchmarks.json
+++ b/test/example_results/benchmarks.json
@@ -203,8 +203,161 @@
         "param_names": [], 
         "params": [], 
         "timeout": 60.0, 
-        "type": "track", 
+        "type": "time", 
         "unit": "unit"
-    }, 
+    },
+    "time_AAA_failure": {
+        "code": "foo\n", 
+        "name": "time_AAA_failure", 
+        "param_names": [], 
+        "params": [], 
+        "timeout": 60.0, 
+        "type": "time", 
+        "unit": "unit"
+    },
+    "time_AAA_skip": {
+        "code": "foo\n", 
+        "name": "time_AAA_skip", 
+        "param_names": [], 
+        "params": [], 
+        "timeout": 60.0, 
+        "type": "time", 
+        "unit": "unit"
+    },
+    "time_coordinates.time_latitude": {
+        "code": "foo\n", 
+        "name": "time_coordinates.time_latitude", 
+        "param_names": [], 
+        "params": [], 
+        "timeout": 60.0, 
+        "type": "time", 
+        "unit": "unit"
+    },
+    "time_quantity.time_quantity_array_conversion": {
+        "code": "foo\n", 
+        "name": "time_quantity.time_quantity_array_conversion", 
+        "param_names": [], 
+        "params": [], 
+        "timeout": 60.0, 
+        "type": "time", 
+        "unit": "unit"
+    },
+    "time_quantity.time_quantity_init_array": {
+        "code": "foo\n", 
+        "name": "time_quantity.time_quantity_init_array", 
+        "param_names": [], 
+        "params": [], 
+        "timeout": 60.0, 
+        "type": "time", 
+        "unit": "unit"
+    },
+    "time_quantity.time_quantity_init_scalar": {
+        "code": "foo\n", 
+        "name": "time_quantity.time_quantity_init_scalar", 
+        "param_names": [], 
+        "params": [], 
+        "timeout": 60.0, 
+        "type": "time", 
+        "unit": "unit"
+    },
+    "time_quantity.time_quantity_scalar_conversion": {
+        "code": "foo\n", 
+        "name": "time_quantity.time_quantity_scalar_conversion", 
+        "param_names": [], 
+        "params": [], 
+        "timeout": 60.0, 
+        "type": "time", 
+        "unit": "unit"
+    },
+    "time_quantity.time_quantity_ufunc_sin": {
+        "code": "foo\n", 
+        "name": "time_quantity.time_quantity_ufunc_sin", 
+        "param_names": [], 
+        "params": [], 
+        "timeout": 60.0, 
+        "type": "time", 
+        "unit": "unit"
+    },
+    "time_units.mem_unit": {
+        "code": "foo\n", 
+        "name": "time_units.mem_unit", 
+        "param_names": [], 
+        "params": [], 
+        "timeout": 60.0, 
+        "type": "time", 
+        "unit": "unit"
+    },
+    "time_units.time_simple_unit_parse": {
+        "code": "foo\n", 
+        "name": "time_units.time_simple_unit_parse", 
+        "param_names": [], 
+        "params": [], 
+        "timeout": 60.0, 
+        "type": "time", 
+        "unit": "unit"
+    },
+    "time_units.time_unit_compose": {
+        "code": "foo\n", 
+        "name": "time_units.time_unit_compose", 
+        "param_names": [], 
+        "params": [], 
+        "timeout": 60.0, 
+        "type": "time", 
+        "unit": "unit"
+    },
+    "time_units.time_unit_parse": {
+        "code": "foo\n", 
+        "name": "time_units.time_unit_parse", 
+        "param_names": [], 
+        "params": [], 
+        "timeout": 60.0, 
+        "type": "time", 
+        "unit": "unit"
+    },
+    "time_units.time_unit_to": {
+        "code": "foo\n", 
+        "name": "time_units.time_unit_to", 
+        "param_names": [], 
+        "params": [], 
+        "timeout": 60.0, 
+        "type": "time", 
+        "unit": "unit"
+    },
+    "time_units.time_very_simple_unit_parse": {
+        "code": "foo\n", 
+        "name": "time_units.time_very_simple_unit_parse", 
+        "param_names": [], 
+        "params": [], 
+        "timeout": 60.0, 
+        "type": "time", 
+        "unit": "unit"
+    },
+    "time_other.time_parameterized": {
+        "code": "foo\n", 
+        "name": "time_other.time_parameterized", 
+        "param_names": [], 
+        "params": [], 
+        "timeout": 60.0, 
+        "type": "time", 
+        "unit": "unit"
+    },
+    "time_ci_small": {
+        "code": "foo\n", 
+        "name": "time_ci_small", 
+        "param_names": [], 
+        "params": [], 
+        "timeout": 60.0, 
+        "type": "time", 
+        "unit": "unit"
+    },
+    "time_ci_big": {
+        "code": "foo\n", 
+        "name": "time_ci_big", 
+        "param_names": [], 
+        "params": [], 
+        "timeout": 60.0, 
+        "type": "time", 
+        "unit": "unit"
+    },
     "version": 1
 }

--- a/test/example_results/benchmarks.json
+++ b/test/example_results/benchmarks.json
@@ -359,5 +359,35 @@
         "type": "time", 
         "unit": "unit"
     },
+    "time_with_version_match": {
+        "code": "foo\n", 
+        "name": "time_with_version", 
+        "param_names": [], 
+        "params": [], 
+        "timeout": 60.0, 
+        "type": "time", 
+        "unit": "unit",
+        "version": "1"
+    },
+    "time_with_version_mismatch_bench": {
+        "code": "foo\n", 
+        "name": "time_with_version_mismatch_bench", 
+        "param_names": [], 
+        "params": [], 
+        "timeout": 60.0, 
+        "type": "time", 
+        "unit": "unit",
+        "version": "2"
+    },
+    "time_with_version_mismatch_other": {
+        "code": "foo\n", 
+        "name": "time_with_version_mismatch_other", 
+        "param_names": [], 
+        "params": [], 
+        "timeout": 60.0, 
+        "type": "time", 
+        "unit": "unit",
+        "version": "1"
+    },
     "version": 1
 }

--- a/test/example_results/cheetah/22b920c6-py2.7-Cython-numpy1.8.json
+++ b/test/example_results/cheetah/22b920c6-py2.7-Cython-numpy1.8.json
@@ -34,7 +34,15 @@
 	    "result": [1, 2, 3]
 	},
 	"time_ci_small": {"result": 1, "stats": [{"ci_99": [0.9, 1.1], "q_25": 1, "q_75": 1}]},
-	"time_ci_big": {"result": 1, "stats": [{"ci_99": [0.5, 2.5], "q_25": 0.5, "q_75": 2.5}]}
-    }, 
+	"time_ci_big": {"result": 1, "stats": [{"ci_99": [0.5, 2.5], "q_25": 0.5, "q_75": 2.5}]},
+	"time_with_version_match": 1,
+	"time_with_version_mismatch_bench": 1,
+	"time_with_version_mismatch_other": 1
+    },
+    "benchmark_version": {
+    	"time_with_version_match": "1",
+    	"time_with_version_mismatch_bench": "1",
+    	"time_with_version_mismatch_other": "1"
+    },
     "version": 1
 }

--- a/test/example_results/cheetah/fcf8c079-py2.7-Cython-numpy1.8.json
+++ b/test/example_results/cheetah/fcf8c079-py2.7-Cython-numpy1.8.json
@@ -37,7 +37,15 @@
 	},
 	"params_examples.ParamSuite.track_value": null,
 	"time_ci_small": {"result": 3, "stats": [{"ci_99": [3.9, 3.1], "q_25": 3, "q_75": 3}]},
-	"time_ci_big": {"result": 3, "stats": [{"ci_99": [1.5, 3.5], "q_25": 1.5, "q_75": 3.5}]}
+	"time_ci_big": {"result": 3, "stats": [{"ci_99": [1.5, 3.5], "q_25": 1.5, "q_75": 3.5}]},
+	"time_with_version_match": 3,
+	"time_with_version_mismatch_bench": 3,
+	"time_with_version_mismatch_other": 3
+    },
+    "benchmark_version": {
+    	"time_with_version_match": "1",
+    	"time_with_version_mismatch_bench": "1",
+    	"time_with_version_mismatch_other": "2"
     }, 
     "version": 1
 }

--- a/test/test_compare.py
+++ b/test/test_compare.py
@@ -45,6 +45,9 @@ All benchmarks:
 +           372μs           11.5ms    30.81  time_units.time_unit_parse
 -          69.1μs           18.3μs     0.27  time_units.time_unit_to
            11.9μs           13.1μs     1.10  time_units.time_very_simple_unit_parse
++           1.00s            3.00s     3.00  time_with_version_match
++           1.00s            3.00s     3.00  time_with_version_mismatch_bench
+x           1.00s            3.00s     3.00  time_with_version_mismatch_other
 """
 
 REFERENCE_SPLIT = """
@@ -82,6 +85,14 @@ Benchmarks that have got worse:
 +          1.31ms           7.75ms     5.91  time_quantity.time_quantity_ufunc_sin
 +           125μs           3.81ms    30.42  time_units.time_simple_unit_parse
 +           372μs           11.5ms    30.81  time_units.time_unit_parse
++           1.00s            3.00s     3.00  time_with_version_match
++           1.00s            3.00s     3.00  time_with_version_mismatch_bench
+
+Benchmarks that are not comparable:
+
+       before           after         ratio
+     [22b920c6]       [fcf8c079]
+x           1.00s            3.00s     3.00  time_with_version_mismatch_other
 """
 
 REFERENCE_ONLY_CHANGED = """
@@ -96,6 +107,8 @@ REFERENCE_ONLY_CHANGED = """
 +           125μs           3.81ms    30.42  time_units.time_simple_unit_parse
 +          1.31ms           7.75ms     5.91  time_quantity.time_quantity_ufunc_sin
 +         1.00±0s          3.00±0s     3.00  time_ci_small
++           1.00s            3.00s     3.00  time_with_version_match
++           1.00s            3.00s     3.00  time_with_version_mismatch_bench
 -          69.1μs           18.3μs     0.27  time_units.time_unit_to
 """
 

--- a/test/test_results.py
+++ b/test/test_results.py
@@ -34,17 +34,21 @@ def test_results(tmpdir):
 
         values = {
             'suite1.benchmark1': {'result': [float(i * 0.001)], 'stats': [{'foo': 1}],
-                                  'samples': [[1,2]], 'number': [6], 'params': [['a']]},
+                                  'samples': [[1,2]], 'number': [6], 'params': [['a']],
+                                  'version': "1"},
             'suite1.benchmark2': {'result': [float(i * i * 0.001)], 'stats': [{'foo': 2}],
-                                  'samples': [[3,4]], 'number': [7], 'params': []},
+                                  'samples': [[3,4]], 'number': [7], 'params': [],
+                                  'version': "1"},
             'suite2.benchmark1': {'result': [float((i + 1) ** -1)], 'stats': [{'foo': 3}],
-                                  'samples': [[5,6]], 'number': [8], 'params': [['c']]}
+                                  'samples': [[5,6]], 'number': [8], 'params': [['c']],
+                                  'version': None}
         }
 
         for key, val in values.items():
+            val = dict(val)
             val['started_at'] = timestamp1
             val['ended_at'] = timestamp2
-            r.add_result(key, val, "some version")
+            r.add_result(key, val, val.pop("version"))
 
         # Save / add_existing_results roundtrip
         r.save(resultsdir)
@@ -64,6 +68,7 @@ def test_results(tmpdir):
             assert rr._samples == r._samples
             assert rr.started_at == r._started_at
             assert rr.ended_at == r._ended_at
+            assert rr.benchmark_version == r._benchmark_version
 
         # Check the get_* methods
         assert sorted(r2.get_all_result_keys()) == sorted(values.keys())
@@ -81,6 +86,15 @@ def test_results(tmpdir):
             assert r2.get_result_value(bench, bad_params) == [None, None]
             assert r2.get_result_stats(bench, bad_params) == [None, None]
             assert r2.get_result_samples(bench, bad_params) == ([None, None], [None, None])
+
+        # Check get_result_keys
+        mock_benchmarks = {
+            'suite1.benchmark1': {'version': '1'},
+            'suite1.benchmark2': {'version': '2'},
+            'suite2.benchmark1': {'version': '2'},
+        }
+        assert sorted(r2.get_result_keys(mock_benchmarks)) == ['suite1.benchmark1',
+                                                               'suite2.benchmark1']
 
 
 def test_get_result_hash_from_prefix(tmpdir):

--- a/test/test_results.py
+++ b/test/test_results.py
@@ -44,7 +44,7 @@ def test_results(tmpdir):
         for key, val in values.items():
             val['started_at'] = timestamp1
             val['ended_at'] = timestamp2
-            r.add_result(key, val)
+            r.add_result(key, val, "some version")
 
         # Save / add_existing_results roundtrip
         r.save(resultsdir)
@@ -66,8 +66,8 @@ def test_results(tmpdir):
             assert rr.ended_at == r._ended_at
 
         # Check the get_* methods
-        assert sorted(r2.result_keys) == sorted(values.keys())
-        for bench in r2.result_keys:
+        assert sorted(r2.get_all_result_keys()) == sorted(values.keys())
+        for bench in r2.get_all_result_keys():
             # Get with same parameters as stored
             params = r2.get_result_params(bench)
             assert params == values[bench]['params']
@@ -136,7 +136,7 @@ def test_json_timestamp(tmpdir):
         'started_at': stamp1,
         'ended_at': stamp2
     }
-    r.add_result('some_benchmark', value)
+    r.add_result('some_benchmark', value, "some version")
     r.save(tmpdir)
 
     r = util.load_json(join(tmpdir, 'mach', 'aaaa-env.json'))

--- a/test/test_rm.py
+++ b/test/test_rm.py
@@ -31,7 +31,7 @@ def test_rm(tmpdir):
 
     results_a = list(results.iter_results(tmpdir))
     for result in results_a:
-        for key in result.result_keys:
+        for key in result.get_all_result_keys():
             assert not key.startswith('time_quantity')
         for key in six.iterkeys(result.started_at):
             assert not key.startswith('time_quantity')

--- a/test/tools.py
+++ b/test/tools.py
@@ -18,6 +18,7 @@ import sys
 from os.path import abspath, join, dirname, relpath, isdir
 from contextlib import contextmanager
 from distutils.spawn import find_executable
+from hashlib import sha256
 from six.moves import SimpleHTTPServer
 
 import pytest
@@ -368,6 +369,8 @@ def generate_result_dir(tmpdir, dvcs, values, branches=None):
 
     timestamp = datetime.datetime.utcnow()
 
+    benchmark_version = sha256(os.urandom(16)).hexdigest()
+
     params = None
     for commit, value in values.items():
         if isinstance(value, dict):
@@ -381,9 +384,9 @@ def generate_result_dir(tmpdir, dvcs, values, branches=None):
             'ended_at': timestamp,
             'stats': None,
             'samples': None,
-            'number': None
+            'number': None,
         }
-        result.add_result("time_func", value)
+        result.add_result("time_func", value, benchmark_version)
         result.save(result_dir)
 
     util.write_json(join(result_dir, "benchmarks.json"), {
@@ -391,6 +394,7 @@ def generate_result_dir(tmpdir, dvcs, values, branches=None):
             "name": "time_func",
             "params": params or [],
             "param_names": params or [],
+            "version": benchmark_version,
         }
     }, api_version=1)
     return conf


### PR DESCRIPTION
Add a version attribute to benchmarks, and when benchmarks are run,
tag the results produced with it. The default value is based on hash of
source code lines, but can be overridden by user.

In run, consider results with different benchmark version as missing.
In compare, mark incompatible results.
In publish, ignore results with different benchmark versions.
