### PR TITLE
chmod html_dir to ensure writability

### DIFF
--- a/asv/commands/publish.py
+++ b/asv/commands/publish.py
@@ -89,9 +89,10 @@ class Publish(Command):
         shutil.copytree(template_dir, conf.html_dir)
 
         # Ensure html_dir is writable even if template_dir is on a read-only FS
-        os.chmod(conf.html_dir, 0755)
-        [[os.chmod(os.path.join(pre, x), 0755) for x in (fs + ds)]
-         for (pre, ds, fs) in os.walk(conf.html_dir)]
+        os.chmod(conf.html_dir, 0o755)
+        for (pre, ds, fs) in os.walk(conf.html_dir):
+            for x in fs + ds:
+                os.chmod(os.path.join(pre, x), 0o755)
 
         log.step()
         log.info("Loading machine info")

--- a/asv/commands/publish.py
+++ b/asv/commands/publish.py
@@ -88,6 +88,11 @@ class Publish(Command):
             os.path.dirname(os.path.abspath(__file__)), '..', 'www')
         shutil.copytree(template_dir, conf.html_dir)
 
+        # Ensure html_dir is writable even if template_dir is on a read-only FS
+        os.chmod(conf.html_dir, 0755)
+        [[os.chmod(os.path.join(pre, x), 0755) for x in (fs + ds)]
+         for (pre, ds, fs) in os.walk(conf.html_dir)]
+
         log.step()
         log.info("Loading machine info")
         with log.indent():


### PR DESCRIPTION
asv's HTML output is made by copying a "template" directory, which lives
alongside asv's code (e.g. in /usr or the like), to the destination, which is
then modified to contain the benchmark data.

If the template is read-only, e.g. due to the filesystem it's stored on, then we
can copy it across, but don't have permission to modify it (e.g. getting OSError
13 "permission denied" when trying to make the graph/ subdir).

This change runs chmod to grant write permission to the owner (the current user)
immediately after the copy, so we avoid such "permission denied" errors.