### PR TITLE
BUG: util.which should also recognize .bat

### DIFF
--- a/asv/util.py
+++ b/asv/util.py
@@ -279,8 +279,14 @@ def which(filename):
     Raises an IOError if no result is found.
     """
     if WIN:
-        if not filename.endswith('.exe'):
-            filename = filename + '.exe'
+        exe_exts = ['.exe', '.bat', '.com']
+        base, ext = os.path.splitext(filename)
+        if ext in exe_exts:
+            filenames = [filename]
+        else:
+            filenames = [base + ext2 for ext2 in exe_exts]
+    else:
+        filenames = [filename]
 
     if os.path.sep in filename:
         locations = ['']
@@ -294,9 +300,10 @@ def which(filename):
 
     candidates = []
     for location in locations:
-        candidate = os.path.join(location, filename)
-        if os.path.isfile(candidate) or os.path.islink(candidate):
-            candidates.append(candidate)
+        for fn in filenames:
+            candidate = os.path.join(location, fn)
+            if os.path.isfile(candidate) or os.path.islink(candidate):
+                candidates.append(candidate)
     if len(candidates) == 0:
         raise IOError("Could not find '{0}' in PATH".format(filename))
     return candidates[0]

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -98,9 +98,11 @@ def test_write_unicode_to_ascii():
 def test_which_path(tmpdir):
     dirname = os.path.abspath(os.path.join(str(tmpdir), 'name with spaces'))
     fn = 'asv_test_exe_1234.exe'
+    fn2 = 'asv_test_exe_4321.bat'
 
     os.makedirs(dirname)
     shutil.copyfile(sys.executable, os.path.join(dirname, fn))
+    shutil.copyfile(sys.executable, os.path.join(dirname, fn2))
 
     old_path = os.environ.get('PATH', '')
     try:
@@ -108,11 +110,15 @@ def test_which_path(tmpdir):
             os.environ['PATH'] = old_path + os.pathsep + '"' + dirname + '"'
             util.which('asv_test_exe_1234')
             util.which('asv_test_exe_1234.exe')
+            util.which('asv_test_exe_4321')
+            util.which('asv_test_exe_4321.bat')
 
         os.environ['PATH'] = old_path + os.pathsep + dirname
         util.which('asv_test_exe_1234.exe')
+        util.which('asv_test_exe_4321.bat')
         if WIN:
             util.which('asv_test_exe_1234')
+            util.which('asv_test_exe_4321')
     finally:
         os.environ['PATH'] = old_path
 


### PR DESCRIPTION
For example conda can in sub-environments become a bat file.