### PR TITLE
CI: fix pytest usage + pypy versions

### DIFF
--- a/.continuous-integration/appveyor/windows_sdk.cmd
+++ b/.continuous-integration/appveyor/windows_sdk.cmd
@@ -1,4 +1,7 @@
-:: To build extensions for 64 bit Python 3, we need to configure environment
+:: To build extensions for 64 bit Python 3.5 or later no special environment needs
+:: to be configured.
+::
+:: To build extensions for 64 bit Python 3.4 or earlier, we need to configure environment
 :: variables to use the MSVC 2010 C++ compilers from GRMSDKX_EN_DVD.iso of:
 :: MS Windows SDK for Windows 7 and .NET Framework 4 (SDK v7.1)
 ::
@@ -13,33 +16,49 @@
 ::
 :: More details at:
 :: https://github.com/cython/cython/wiki/64BitCythonExtensionsOnWindows
-:: http://stackoverflow.com/a/13751649/163740
+:: https://stackoverflow.com/a/13751649/163740
 ::
-:: Author: Olivier Grisel
-:: License: CC0 1.0 Universal: http://creativecommons.org/publicdomain/zero/1.0/
+:: Original Author: Olivier Grisel
+:: License: CC0 1.0 Universal: https://creativecommons.org/publicdomain/zero/1.0/
+:: This version based on updates for python 3.5 by Phil Elson at:
+::     https://github.com/pelson/Obvious-CI/tree/master/scripts
+
 @ECHO OFF
 
 SET COMMAND_TO_RUN=%*
 SET WIN_SDK_ROOT=C:\Program Files\Microsoft SDKs\Windows
 
 SET MAJOR_PYTHON_VERSION="%PYTHON_VERSION:~0,1%"
+SET MINOR_PYTHON_VERSION=%PYTHON_VERSION:~2,1%
 IF %MAJOR_PYTHON_VERSION% == "2" (
     SET WINDOWS_SDK_VERSION="v7.0"
+    SET SET_SDK_64=Y
 ) ELSE IF %MAJOR_PYTHON_VERSION% == "3" (
     SET WINDOWS_SDK_VERSION="v7.1"
+    IF %MINOR_PYTHON_VERSION% LEQ 4 (
+        SET SET_SDK_64=Y
+    ) ELSE (
+        SET SET_SDK_64=N
+    )
 ) ELSE (
     ECHO Unsupported Python version: "%MAJOR_PYTHON_VERSION%"
     EXIT 1
 )
 
 IF "%PYTHON_ARCH%"=="64" (
-    ECHO Configuring Windows SDK %WINDOWS_SDK_VERSION% for Python %MAJOR_PYTHON_VERSION% on a 64 bit architecture
-    SET DISTUTILS_USE_SDK=1
-    SET MSSdk=1
-    "%WIN_SDK_ROOT%\%WINDOWS_SDK_VERSION%\Setup\WindowsSdkVer.exe" -q -version:%WINDOWS_SDK_VERSION%
-    "%WIN_SDK_ROOT%\%WINDOWS_SDK_VERSION%\Bin\SetEnv.cmd" /x64 /release
-    ECHO Executing: %COMMAND_TO_RUN%
-    call %COMMAND_TO_RUN% || EXIT 1
+    IF %SET_SDK_64% == Y (
+        ECHO Configuring Windows SDK %WINDOWS_SDK_VERSION% for Python %MAJOR_PYTHON_VERSION% on a 64 bit architecture
+        SET DISTUTILS_USE_SDK=1
+        SET MSSdk=1
+        "%WIN_SDK_ROOT%\%WINDOWS_SDK_VERSION%\Setup\WindowsSdkVer.exe" -q -version:%WINDOWS_SDK_VERSION%
+        "%WIN_SDK_ROOT%\%WINDOWS_SDK_VERSION%\Bin\SetEnv.cmd" /x64 /release
+        ECHO Executing: %COMMAND_TO_RUN%
+        call %COMMAND_TO_RUN% || EXIT 1
+    )  ELSE (
+        ECHO Using default MSVC build environment for 64 bit architecture
+        ECHO Executing: %COMMAND_TO_RUN%
+        call %COMMAND_TO_RUN% || EXIT 1
+    )
 ) ELSE (
     ECHO Using default MSVC build environment for 32 bit architecture
     ECHO Executing: %COMMAND_TO_RUN%

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,8 +14,8 @@ python:
   - 3.3
   - 3.4
   - 3.5
+  - 3.6
   - pypy
-  - "pypy3.3-5.2-alpha1"
   # - pypy3
 
 matrix:
@@ -23,7 +23,7 @@ matrix:
     - python: 2.7
       env:
         - USE_CONDA=true
-        - COVERAGE=--coverage
+        - COVERAGE=--cov asv
 
     - python: 3.5
       env: USE_CONDA=true
@@ -70,9 +70,10 @@ install:
     fi
     $TRAVIS_PIP install selenium six pytest feedparser python-hglib;
     if [[ $COVERAGE != '' ]]; then $TRAVIS_PIP install pytest-cov coveralls; fi;
+  - $TRAVIS_PYTHON setup.py build_ext -i
 
 script:
-  - $TRAVIS_PYTHON setup.py test $COVERAGE
+  - $TRAVIS_PYTHON -m pytest $COVERAGE test
 
 after_success:
   - if [[ $COVERAGE != '' ]]; then coveralls; fi

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,10 +10,10 @@ environment:
 
   matrix:
 
-      - PYTHON_VERSION: "3.5"
+      - PYTHON_VERSION: "2.7"
         platform: x64
         PYTHON_ARCH: "64"
-      - PYTHON_VERSION: "2.7"
+      - PYTHON_VERSION: "3.5"
         platform: x64
         PYTHON_ARCH: "64"
       - PYTHON_VERSION: "2.7"
@@ -21,12 +21,22 @@ environment:
         PYTHON_ARCH: "32"
 
 install:
+    # Clear tmpdir (sometimes left behind by appveyor?)
+    - rmdir /s /q %APPVEYOR_BUILD_FOLDER%\\tmp & exit /b 0
+
     # Install miniconda using a powershell script.
     - "powershell .continuous-integration/appveyor/install-miniconda.ps1"
     - "SET PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%"
 
     # Install the build and runtime dependencies of the project.
     - "conda update -q --yes conda"
+
+    # Tell conda to not use hardlinks: on Windows it's not possible
+    # to delete hard links to files in use, which causes problem when
+    # trying to cleanup environments during the tests
+    - "conda config --set always_copy True"
+    - "conda config --set allow_softlinks False"
+
     # Create a conda environment
     - "conda create -q --yes -n test python=%PYTHON_VERSION%"
     - "activate test"
@@ -37,8 +47,11 @@ install:
     # Install specified version of dependencies
     - "conda install -q --yes six pytest numpy"
 
+    # In-place build
+    - "%CMD_IN_ENV% python setup.py build_ext -i"
+
 # Not a .NET project
 build: false
 
 test_script:
-  - "%CMD_IN_ENV% python setup.py test -a --tb=native -a --basetemp=%APPVEYOR_BUILD_FOLDER%\\tmp"
+    - "python -m pytest --tb=native --basetemp=%APPVEYOR_BUILD_FOLDER%\\tmp test"

--- a/test/test_environment.py
+++ b/test/test_environment.py
@@ -112,11 +112,6 @@ def test_large_environment_matrix(tmpdir):
 
 @pytest.mark.skipif(not (HAS_PYTHON_27 or HAS_CONDA),
                     reason="Requires Python 2.7")
-@pytest.mark.xfail(WIN,
-                   reason=("Fails on some Windows installations; the Python DLLs "
-                           "in the created environments are apparently not unloaded "
-                           "properly so that removing the environments fails. This is "
-                           "likely not a very common occurrence in real use cases."))
 def test_presence_checks(tmpdir):
     conf = config.Config()
 


### PR DESCRIPTION
Use pytest directly rather than via setup.py; avoids long tracebacks on
appveyor. Also, we are using the in-place import pytest setup, so make
that explicit.