### PR TITLE
Use abspath for gh-pages html fetch

### DIFF
--- a/asv/plugins/github.py
+++ b/asv/plugins/github.py
@@ -57,7 +57,7 @@ class GithubPages(Command):
             util.check_call([git, 'commit', '-m', 'Generated from sources'], cwd=conf.html_dir)
 
             # Fetch branch here
-            util.check_call([git, 'fetch', conf.html_dir])
+            util.check_call([git, 'fetch', os.path.abspath(conf.html_dir)])
             util.check_call([git, 'branch', '-f', 'gh-pages', 'FETCH_HEAD'])
         finally:
             # Cleanup the child repo under html


### PR DESCRIPTION
I haven't investigated this deeply, but `asv gh-pages` failed for me on the panadas repo.
The issue seems to be related to having the benchmarks inside the project directory, like pandas does.

```
git clone pandas
cd pandas/asv_bench
asv gh-pages --no-push
[ 11.11%] · Loading machine info
[ 22.22%] · Getting params, commits, tags and branches
[ 33.33%] · Loading results
[ 44.44%] · Detecting steps
[ 55.56%] · Generating graphs
[ 66.67%] · Generating output for SummaryGrid
[ 77.78%] · Generating output for SummaryList.
[ 88.89%] · Generating output for Regressions
[100.00%] · Writing index
[100.00%] · Updating gh-pages branch
[100.00%] · Error running /usr/local/bin/git fetch html
            STDOUT -------->

            STDERR -------->
            fatal: 'html' does not appear to be a git repository
            fatal: Could not read from remote repository.

            Please make sure you have the correct access rights
            and the repository exists.
Traceback (most recent call last):
  File "/Users/taugspurger/miniconda3/envs/asv/bin/asv", line 11, in <module>
    load_entry_point('asv', 'console_scripts', 'asv')()
  File "/Users/taugspurger/sandbox/asv/asv/main.py", line 38, in main
    result = args.func(args)
  File "/Users/taugspurger/sandbox/asv/asv/commands/__init__.py", line 48, in run_from_args
    return cls.run_from_conf_args(conf, args)
  File "/Users/taugspurger/sandbox/asv/asv/plugins/github.py", line 36, in run_from_conf_args
    return cls.run(conf=conf, no_push=args.no_push)
  File "/Users/taugspurger/sandbox/asv/asv/plugins/github.py", line 60, in run
    util.check_call([git, 'fetch', conf.html_dir])
  File "/Users/taugspurger/sandbox/asv/asv/util.py", line 344, in check_call
    cwd=cwd)
  File "/Users/taugspurger/sandbox/asv/asv/util.py", line 571, in check_output
    raise ProcessError(args, retcode, stdout, stderr)
asv.util.ProcessError: Command '/usr/local/bin/git fetch html' returned non-zero exit status 128
```

I've manually tested this and it worked. Haven't had a chance to write up a regression test, but can do that later if you want.