### PR TITLE
[WIP] ENH: Allow asv continuous to use a branch not in JSON `branches`

### DIFF
--- a/asv/benchmarks.py
+++ b/asv/benchmarks.py
@@ -309,7 +309,7 @@ class Benchmarks(dict):
     """
     api_version = 1
 
-    def __init__(self, conf, repo, environments, benchmarks=None, regex=None):
+    def __init__(self, conf, repo, environments, commit_hash, benchmarks=None, regex=None):
         """
         Discover benchmarks in the given `benchmark_dir`.
 
@@ -333,7 +333,7 @@ class Benchmarks(dict):
         self._benchmark_dir = conf.benchmark_dir
 
         if benchmarks is None:
-            benchmarks = self.disc_benchmarks(conf, repo, environments)
+            benchmarks = self.disc_benchmarks(conf, repo, environments, commit_hash)
         else:
             benchmarks = six.itervalues(benchmarks)
 
@@ -349,7 +349,8 @@ class Benchmarks(dict):
                 self[benchmark['name']] = benchmark
 
     @classmethod
-    def disc_benchmarks(cls, conf, repo, environments):
+    def disc_benchmarks(cls, conf, repo, environments,
+                        commit_hash):
         """
         Discover all benchmarks in a directory tree.
         """
@@ -374,7 +375,7 @@ class Benchmarks(dict):
         log.info("Discovering benchmarks")
         with log.indent():
             env.create()
-            env.install_project(conf, repo)
+            env.install_project(conf, repo, commit_hash)
 
             result_file = tempfile.NamedTemporaryFile(delete=False)
             try:

--- a/asv/commands/run.py
+++ b/asv/commands/run.py
@@ -131,14 +131,14 @@ class Run(Command):
     def run(cls, conf, range_spec=None, steps=None, bench=None, parallel=1,
             show_stderr=False, quick=False, profile=False, env_spec=None,
             dry_run=False, machine=None, _machine_file=None, skip_successful=False,
-            skip_failed=False, skip_existing_commits=False, record_samples=False,
+            skip_failed=False, skip_existing_commits=False, record_samples=False, commit_hash=None,
             _returns={}):
         machine_params = Machine.load(
             machine_name=machine,
             _path=_machine_file, interactive=True)
         machine_params.save(conf.results_dir)
 
-        environments = list(environment.get_environments(conf, env_spec))
+        environments = list(environment.get_environments(conf, env_spec, commit_hash))
 
         if environment.is_existing_only(environments):
             # No repository required, so skip using it
@@ -182,7 +182,7 @@ class Run(Command):
                         "No range spec may be specified if benchmarking in "
                         "an existing environment")
 
-        benchmarks = Benchmarks(conf, repo, environments, regex=bench)
+        benchmarks = Benchmarks(conf, repo, environments, commit_hash, regex=bench)
         if len(benchmarks) == 0:
             log.error("No benchmarks selected")
             return 1

--- a/asv/environment.py
+++ b/asv/environment.py
@@ -186,7 +186,7 @@ def get_env_name(tool_name, python, requirements):
     return util.sanitize_filename('-'.join(name))
 
 
-def get_environments(conf, env_specifiers):
+def get_environments(conf, env_specifiers, commit_hash):
     """
     Iterator returning `Environment` objects for all of the
     permutations of the given versions of Python and a matrix of
@@ -255,7 +255,8 @@ def get_environments(conf, env_specifiers):
                 else:
                     cls = get_environment_class(conf, python)
 
-                yield cls(conf, python, requirements)
+                yield cls(conf, python, requirements,
+                          commit_hash)
             except EnvironmentUnavailable as err:
                 log.warn(str(err))
 
@@ -329,7 +330,7 @@ class Environment(object):
     """
     tool_name = None
 
-    def __init__(self, conf, python, requirements):
+    def __init__(self, conf, python, requirements, commit_hash):
         """
         Get an environment for a given requirement matrix and
         Python version specifier.

--- a/asv/plugins/conda.py
+++ b/asv/plugins/conda.py
@@ -29,7 +29,8 @@ class Conda(environment.Environment):
     tool_name = "conda"
     _matches_cache = {}
 
-    def __init__(self, conf, python, requirements):
+    def __init__(self, conf, python, requirements,
+                 commit_hash):
         """
         Parameters
         ----------
@@ -44,7 +45,8 @@ class Conda(environment.Environment):
         """
         self._python = python
         self._requirements = requirements
-        super(Conda, self).__init__(conf, python, requirements)
+        super(Conda, self).__init__(conf, python, requirements,
+                                    commit_hash)
 
     @classmethod
     def matches(cls, python):


### PR DESCRIPTION
### Background / Motivation
For some projects it would be useful to be able to run `asv continuous` between a (commit hash on) standard `master` branch that can be listed in the JSON `branches` parameter (i.e., the branch the project mainly uses on github) and a (commit hash on) new feature branch from a given developer (in i.e., a github PR) from their **new** branch that is **not** included in the `branches` parameter of the JSON file.

If I'm not mistaken, this isn't currently possible if you want to check the performance between i.e., the tip of master and the most recent commit hash of the new feature branch not listed in the JSON file. 

It might be possible to manually edit the JSON file for each new feature branch (add its name), but that seems rather awkward, right?

### Implementation in this PR
I've just hacked something together to support the above functionality based on a few hours of looking at the asv source code, so there is almost certainly a far better way to do this, if there's even general interest in doing this at all.

If there might be interest in supporting this, I'm hoping that I can at least catalyze some criticism / feedback on doing this more appropriately based on this initial hack that seems to work in my early / crude tests.

I currently run a command as below using this 'new feature:'
`asv continuous --bench GROReadBench 175aba4b 3e16993 -e --extrabranch 3e16993`

Where the new `extrabranch` provides a commit hash from the new feature branch that is not listed in the JSON file (ok, even if you like this feature / idea, the API is almost certainly going to need to change).

Suggestions? Even if `asv` itself doesn't want to support this, one project I work on will likely want to maintain a fork that does because of the development workflow, so any suggestions are most welcome.