### PR TITLE
[WIP] ENH: Initial changes needed to get asv working with package/setup.py

### DIFF
--- a/asv/environment.py
+++ b/asv/environment.py
@@ -498,7 +498,8 @@ class Environment(object):
     def build_project(self, repo, commit_hash):
         self.checkout_project(repo, commit_hash)
         log.info("Building for {0}".format(self.name))
-        self.run(['setup.py', 'build'], cwd=self._build_root)
+        cwd = os.path.join(self._build_root, 'package')
+        self.run(['setup.py', 'build'], cwd=cwd)
         return self._build_root
 
     def install_project(self, conf, repo, commit_hash=None):

--- a/asv/wheel_cache.py
+++ b/asv/wheel_cache.py
@@ -83,6 +83,8 @@ class WheelCache(object):
 
         build_root = env.build_project(repo, commit_hash)
         cache_path = self._create_wheel_cache_path(commit_hash)
+        if 'mdanalysis' in build_root:
+            build_root = os.path.join(build_root, 'package')
 
         try:
             env.run_executable(


### PR DESCRIPTION
I managed to make a minimal set of hacks to `asv` that allow for benchmarking with `asv continuous`  when the project `setup.py` is in a subdirectory instead of the project root. This is obviously a work in progress based on a hack for a single project with a single specified / hard-coded subdirectory for the (conda) build.

Perhaps over time & with some guidance I can help make this more general so that it may be suitable for `asv` itself and not just our custom fork.