### PR TITLE
ENH: enable specifying custom conda channels + create env via environment.yml

### DIFF
--- a/asv/config.py
+++ b/asv/config.py
@@ -39,6 +39,7 @@ class Config(object):
         self.regressions_first_commits = {}
         self.regressions_thresholds = {}
         self.plugins = []
+        self.conda_channels = []
 
     @classmethod
     def load(cls, path=None):

--- a/asv/environment.py
+++ b/asv/environment.py
@@ -415,10 +415,9 @@ class Environment(object):
             return False
 
         for executable in ['pip', 'python']:
-            exe = self.find_executable(executable)
-            # do not count a system install of pip or python
-            # as evidence of an installed env
-            if not os.path.isfile(exe) or (self._path not in os.path.dirname(exe)):
+            try:
+                self.find_executable(executable)
+            except IOError:
                 return False
 
         try:
@@ -535,18 +534,19 @@ class Environment(object):
     def find_executable(self, executable):
         """
         Find an executable (eg. python, pip) in the environment.
+
+        If not found, raises IOError
         """
 
         # Assume standard virtualenv/Conda layout
-        # account for known posix / Windows subfolders
-        paths = [self._path]
-        possible_subfolders = ['Scripts', 'bin']
-        for subfolder in possible_subfolders:
-            paths.append(os.path.join(self._path, subfolder))
+        if WIN:
+            paths = [self._path,
+                     os.path.join(self._path, 'Scripts'),
+                     os.path.join(self._path, 'bin')]
+        else:
+            paths = [os.path.join(self._path, 'bin')]
 
-        executable = util.which(executable, paths)
-
-        return executable
+        return util.which(executable, paths)
 
     def run_executable(self, executable, args, **kwargs):
         """

--- a/asv/template/asv.conf.json
+++ b/asv/template/asv.conf.json
@@ -42,6 +42,10 @@
     // to the current version of Python used to run `asv`.
     // "pythons": ["2.7", "3.3"],
 
+    // The list of conda channel names to be searched for benchmark
+    // dependency packages in the specified order
+    // "conda_channels": ["conda-forge", "defaults"]
+
     // The matrix of dependencies to test.  Each key is the name of a
     // package (in PyPI) and the values are version numbers.  An empty
     // list or empty string indicates to just test against the default

--- a/docs/source/asv.conf.json.rst
+++ b/docs/source/asv.conf.json.rst
@@ -78,7 +78,8 @@ following:
 - a Python version string, e.g. ``"2.7"``, in which case:
 
   - if ``conda`` is found, ``conda`` will be used to create an
-    environment for that version of Python
+    environment for that version of Python via a temporary
+    environment.yml file
 
   - if ``virtualenv`` is installed, ``asv`` will search for that
     version of Python on the ``PATH`` and create a new virtual
@@ -93,6 +94,17 @@ following:
   fully loaded and read-only.  Thus, the benchmarked project must
   already be installed, and it will not be possible to benchmark
   multiple revisions of the project.
+
+``conda_channels``
+------------------
+A list of ``conda`` channel names (strings) to use in the provided
+order as the source channels for the dependencies. For example::
+
+    "conda_channels": ["conda-forge", "defaults"]
+
+The channels will be parsed by ``asv`` to populate the ``channels``
+section of a temporary environment.yml file used to build the
+benchmarking environment.
 
 ``matrix``
 ----------

--- a/test/test_environment.py
+++ b/test/test_environment.py
@@ -8,6 +8,7 @@ import os
 import sys
 import six
 import pytest
+import json
 
 from asv import config
 from asv import environment
@@ -106,6 +107,9 @@ def test_large_environment_matrix(tmpdir):
         # this test run a long time, we only set up the environment,
         # but don't actually install dependencies into it.  This is
         # enough to trigger the bug in #169.
+        env._get_requirements = lambda *a: None
+        # pip / virtualenv setup still uses
+        # _install_requirements
         env._install_requirements = lambda *a: None
         env.create()
 
@@ -459,6 +463,55 @@ def test_matrix_existing():
     items = [(env.tool_name, tuple(env.requirements.keys())) for env in environments]
     assert items == [('existing', ())]
 
+# environment.yml should respect the specified order
+# of channels when adding packages
+@pytest.mark.skipif((not HAS_CONDA),
+                    reason="Requires conda")
+@pytest.mark.parametrize("channel_list,expected_channel", [
+    (["defaults", "conda-forge"], "defaults"),
+    (["conda-forge", "defaults"], "conda-forge"),
+    ])
+def test_conda_channel_addition(tmpdir,
+                                channel_list,
+                                expected_channel):
+    # test that we can add conda channels to environments
+    # and that we respect the specified priority order
+    # of channels
+    conf = config.Config()
+    conf.env_dir = six.text_type(tmpdir.join("env"))
+    conf.environment_type = "conda"
+    conf.pythons = ["2.7", "3.6"]
+    conf.matrix = {}
+    # these have to be valid channels
+    # available for online access
+    conf.conda_channels = channel_list
+    environments = list(environment.get_environments(conf, None))
+
+    # should have one environment per Python version
+    assert len(environments) == 2
+
+    # create the two environments
+    for env in environments:
+        env.create()
+        # generate JSON output from conda list
+        # and parse to verify added channels
+        # for current env
+        # (conda info would be more direct, but
+        # seems to reflect contents of condarc file,
+        # which we are intentionally trying not to modify)
+        conda = os.path.normpath(env.find_executable('conda'))
+        print("\n**conda being used:", conda)
+        out_str = six.text_type(util.check_output([conda,
+                                                    'list',
+                                                    '-p',
+                                                    os.path.normpath(env._path),
+                                                    '--json']))
+        json_package_list = json.loads(out_str)
+        for installed_package in json_package_list:
+            # ignore default-only package
+            if installed_package['name'] == 'vs2008_runtime':
+                continue
+            assert installed_package['channel'] == expected_channel
 
 @pytest.mark.skipif(not (HAS_PYPY and HAS_VIRTUALENV), reason="Requires pypy and virtualenv")
 def test_pypy_virtualenv(tmpdir):

--- a/test/test_environment.py
+++ b/test/test_environment.py
@@ -107,7 +107,7 @@ def test_large_environment_matrix(tmpdir):
         # this test run a long time, we only set up the environment,
         # but don't actually install dependencies into it.  This is
         # enough to trigger the bug in #169.
-        env._get_requirements = lambda *a: None
+        env._get_requirements = lambda *a: ([], [])
         # pip / virtualenv setup still uses
         # _install_requirements
         env._install_requirements = lambda *a: None
@@ -324,6 +324,7 @@ def test_conda_pip_install(tmpdir):
 
     conf.env_dir = six.text_type(tmpdir.join("env"))
 
+    conf.environment_type = "conda"
     conf.pythons = ["3.4"]
     conf.matrix = {
         "pip+colorama": ["0.3.6"]

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -99,9 +99,11 @@ def test_write_unicode_to_ascii():
 def test_which_path(tmpdir):
     dirname = os.path.abspath(os.path.join(str(tmpdir), 'name with spaces'))
     fn = 'asv_test_exe_1234.exe'
+    fn2 = 'asv_test_exe_4321.bat'
 
     os.makedirs(dirname)
     shutil.copyfile(sys.executable, os.path.join(dirname, fn))
+    shutil.copyfile(sys.executable, os.path.join(dirname, fn2))
 
     old_path = os.environ.get('PATH', '')
     try:
@@ -109,11 +111,23 @@ def test_which_path(tmpdir):
             os.environ['PATH'] = old_path + os.pathsep + '"' + dirname + '"'
             util.which('asv_test_exe_1234')
             util.which('asv_test_exe_1234.exe')
+            util.which('asv_test_exe_4321')
+            util.which('asv_test_exe_4321.bat')
 
         os.environ['PATH'] = old_path + os.pathsep + dirname
         util.which('asv_test_exe_1234.exe')
+        util.which('asv_test_exe_4321.bat')
         if WIN:
             util.which('asv_test_exe_1234')
+            util.which('asv_test_exe_4321')
+
+        # Check the paths= argument
+        util.which('asv_test_exe_1234.exe', paths=[dirname])
+        util.which('asv_test_exe_4321.bat', paths=[dirname])
+
+        # Check non-existent files
+        with pytest.raises(IOError):
+            util.which('nonexistent.exe', paths=[dirname])
     finally:
         os.environ['PATH'] = old_path
 


### PR DESCRIPTION
- This PR adds the basic functionality to specify a list of custom conda channels using a new key in the JSON config file; the associated feature request issue is #405 
- This actually looks fairly clean to me (and works for me), but there are probably some things that the core devs will know that I haven't thought of
- I suspect the way the channels are added may need slight modification -- installing packages is done in a single call to conda for performance reasons, and we may wish to do the same for adding channels (I currently loop over the input channels as you can see)
- need for tests? -- make sure this works when adding a single vs. multiple custom channels? mock the call to those channels? how much of a pain would this be to do? Maybe there's something simpler that can be done test-wise.