### PR TITLE
Add the possibility for asv machine to use defaults

### DIFF
--- a/asv/commands/machine.py
+++ b/asv/commands/machine.py
@@ -28,6 +28,9 @@ class Machine(Command):
                 '--' + name, default=defaults[name],
                 help=description)
 
+        parser.add_argument('--yes', default=False, action='store_true',
+                            help="Accept all questions")
+
         parser.set_defaults(func=cls.run_from_args)
 
         return parser
@@ -44,5 +47,8 @@ class Machine(Command):
             if kwargs.get(key) != val:
                 different[key] = kwargs.get(key)
 
+        use_defaults = kwargs['yes']
+
         machine.Machine.load(
-            force_interactive=(len(different) == 0), **different)
+            force_interactive=(len(different) == 0),
+            use_defaults=use_defaults, **different)

--- a/asv/console.py
+++ b/asv/console.py
@@ -230,8 +230,12 @@ def color_print(*args, **kwargs):
         write(end)
 
 
-def get_answer_default(prompt, default):
+def get_answer_default(prompt, default, use_defaults=False):
     color_print("{0} [{1}]: ".format(prompt, default), end='')
+
+    if use_defaults:
+        return default
+
     x = input()
     if x.strip() == '':
         return default

--- a/asv/machine.py
+++ b/asv/machine.py
@@ -147,8 +147,8 @@ class Machine(object):
             }
 
     @staticmethod
-    def generate_machine_file():
-        if not sys.stdout.isatty():
+    def generate_machine_file(use_defaults=False):
+        if not sys.stdout.isatty() and not use_defaults:
             raise util.UserError(
                 "Run asv at the console the first time to generate "
                 "one.")
@@ -167,13 +167,14 @@ class Machine(object):
                     '{0}. {1}: {2}'.format(
                         i+1, name, textwrap.dedent(description)),
                     subsequent_indent='   '))
-            values[name] = console.get_answer_default(name, defaults[name])
+            values[name] = console.get_answer_default(name, defaults[name],
+                                                      use_defaults=use_defaults)
 
         return values
 
     @classmethod
     def load(cls, interactive=False, force_interactive=False, _path=None,
-             machine_name=None, **kwargs):
+             machine_name=None, use_defaults=False, **kwargs):
         self = Machine()
 
         if machine_name is None:
@@ -185,7 +186,7 @@ class Machine(object):
             d = {}
         d.update(kwargs)
         if (not len(d) and interactive) or force_interactive:
-            d.update(self.generate_machine_file())
+            d.update(self.generate_machine_file(use_defaults=use_defaults))
 
         machine_name = d['machine']
 

--- a/test/test_machine.py
+++ b/test/test_machine.py
@@ -31,3 +31,14 @@ def test_machine(tmpdir):
     assert m.arch == 'MIPS'
     assert m.cpu == '10 MHz'
     assert m.ram == '640k'
+
+
+def test_machine_defaults(tmpdir):
+    tmpdir = six.text_type(tmpdir)
+
+    m = machine.Machine.load(
+        interactive=True,
+        use_defaults=True,
+        _path=join(tmpdir, 'asv-machine.json'))
+
+    assert m.__dict__ == m.get_defaults()


### PR DESCRIPTION
Using asv in a full-automated way is difficult because asv run needs asv
machine to run first. Make asv machine accept a '--yes' that accept the
default value. This way automated scripts can put 'asv machine --yes' before
running 'asv run'.