### PR TITLE
Allow to overwrite 'html_dir' and to filter commits considered in 'publish'

### DIFF
--- a/asv/commands/preview.py
+++ b/asv/commands/preview.py
@@ -68,6 +68,10 @@ class Preview(Command):
                             help="Port to run webserver on.  [8080]")
         parser.add_argument("--browser", "-b", action="store_true",
                             help="Open in webbrowser")
+        parser.add_argument(
+            '--html-dir', '-o', default=None, help=(
+                "Optional output directory. Default is 'html_dir' "
+                "from asv config"))
 
         parser.set_defaults(func=cls.run_from_args)
 
@@ -75,6 +79,8 @@ class Preview(Command):
 
     @classmethod
     def run_from_conf_args(cls, conf, args):
+        if args.html_dir:
+            conf.html_dir = args.html_dir
         return cls.run(conf=conf, port=args.port,
                        browser=args.browser)
 

--- a/asv/commands/publish.py
+++ b/asv/commands/publish.py
@@ -60,6 +60,10 @@ class Publish(Command):
         parser.add_argument(
             'range', nargs='?', default=None,
             help="""Optional commit range to consider""")
+        parser.add_argument(
+            '--html-dir', '-o', default=None, help=(
+                "Optional output directory. Default is 'html_dir' "
+                "from asv config"))
 
         common_args.add_environment(parser)
 
@@ -69,6 +73,8 @@ class Publish(Command):
 
     @classmethod
     def run_from_conf_args(cls, conf, args):
+        if args.html_dir is not None:
+            conf.html_dir = args.html_dir
         return cls.run(conf=conf, env_spec=args.env_spec,
                        range_spec=args.range)
 

--- a/asv/plugins/regressions.py
+++ b/asv/plugins/regressions.py
@@ -121,6 +121,10 @@ class Regressions(OutputPublisher):
         run_timestamps = {}
         revision_timestamps = {}
         for results in iter_results(conf.results_dir):
+            if results.commit_hash not in revisions:
+                # revisions could be filtered when specifying a range
+                # in 'asv publish'
+                continue
             revision = revisions[results.commit_hash]
             revision_timestamps[revision] = results.date
 

--- a/test/test_publish.py
+++ b/test/test_publish.py
@@ -178,6 +178,19 @@ def _graph_path(dvcs_type):
         master = "default"
     return join("graphs", "branch-{0}".format(master), "machine-tarzan", "time_func.json")
 
+
+def test_publish_range_spec(generate_result_dir):
+    conf, repo, commits = generate_result_dir(5 * [1])
+    for range_spec, expected in (
+        ([commits[0], commits[-1]], set([commits[0], commits[-1]])),
+        ('HEAD~2..HEAD' if repo.dvcs == 'git' else '.~1:',
+            set(commits[-2:])),
+    ):
+        tools.run_asv_with_conf(conf, "publish", range_spec)
+        data = util.load_json(join(conf.html_dir, 'index.json'))
+        assert set(data['revision_to_hash'].values()) == expected
+
+
 def test_regression_simple(generate_result_dir):
     conf, repo, commits = generate_result_dir(5 * [1] + 5 * [10])
     tools.run_asv_with_conf(conf, "publish")


### PR DESCRIPTION
Our usecase is to have multiple website giving multiple views of our workflow development. Eg. One website for published commits and one for WIP, also having a limited website that only show tagged commits.