### PR TITLE
Drop support for end-of-lifed Python versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,10 +8,7 @@ env:
     - COVERAGE=""
 
 python:
-  - 2.6
   - 2.7
-  - 3.2
-  - 3.3
   - 3.4
   - 3.5
   - 3.6
@@ -62,11 +59,7 @@ install:
       chmod +x $HOME/miniconda2/bin/conda;
       if $TRAVIS_PYTHON -c 'import virtualenv'; then echo "ERROR: virtualenv package is installed"; exit 1; fi;
     else
-      if [[ "$TRAVIS_PYTHON_VERSION" == "3.2" ]]; then
-        $TRAVIS_PIP install 'virtualenv<14';
-      else
-        $TRAVIS_PIP install virtualenv;
-      fi
+      $TRAVIS_PIP install virtualenv;
     fi
     $TRAVIS_PIP install selenium six pytest feedparser python-hglib;
     if [[ $COVERAGE != '' ]]; then $TRAVIS_PIP install pytest-cov coveralls; fi;

--- a/setup.py
+++ b/setup.py
@@ -204,6 +204,8 @@ def run_setup(build_binary=False):
             ]
         },
 
+        python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*',
+
         zip_safe=False,
 
         # py.test testing


### PR DESCRIPTION
Python 2.6 and 3.2 are already EOL, and 3.3 will be EOL 2017-09-29.

This doesn't drop support for those versions in the code (those cleanups can be done later if necessary), but just removes testing and sets the python_requires tag appropriately.

Will merge soon (python2.6 appears to be failing on travis due to pip not supporting it).