### PR TITLE
Move current version information in __init__.py + fix import w/o setup.py

### DIFF
--- a/asv/__init__.py
+++ b/asv/__init__.py
@@ -7,13 +7,26 @@ from __future__ import (absolute_import, division, print_function,
 import os
 import sys
 
+# This __version__ assignment is parsed by setup.py; keep it in this form.
+# Development versions end with ".dev" (suffix is added below).
+__version__ = "0.3.dev"
+__release__ = not __version__.endswith(".dev")
+
+try:
+    from ._version import __githash__, __suffix__
+except ImportError:
+    __githash__ = None
+    __suffix__ = "0"
+if not __release__:
+    __version__ += __suffix__
+del __suffix__
+
+
 if sys.version_info >= (3, 3):
     # OS X framework builds of Python 3.3 can not call other 3.3
     # virtualenvs as a subprocess because `__PYENV_LAUNCHER__` is
     # inherited.
     if os.environ.get('__PYVENV_LAUNCHER__'):
         os.unsetenv('__PYVENV_LAUNCHER__')
-
-from ._version import __version__, __githash__, __release__
 
 from . import plugin_manager

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[zest.releaser]
+python-file-with-version = asv/__init__.py

--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,7 @@ import os
 import re
 import subprocess
 import sys
+import ast
 
 
 # A py.test test command
@@ -50,6 +51,32 @@ class PyTest(TestCommand):
 basedir = os.path.abspath(os.path.dirname(__file__))
 
 
+def get_version():
+    """Parse current version number from __init__.py"""
+    # Grab the first assignment to __version__
+    version = None
+    init_py = os.path.join(os.path.dirname(__file__),
+                           'asv', '__init__.py')
+    with open(init_py, 'r') as f:
+        source = f.read()
+    tree = ast.parse(source)
+    for statement in tree.body:
+        if (isinstance(statement, ast.Assign) and
+            len(statement.targets) == 1 and
+            statement.targets[0].id == '__version__'):
+            version = statement.value.s
+            break
+
+    if not version:
+        raise RuntimeError("Failed to parse version from {}".format(init_py))
+
+    if 'dev' in version and not version.endswith('.dev'):
+        raise RuntimeError("Dev version string in {} doesn't end in .dev".format(
+            init_py))
+
+    return version
+
+
 def get_git_hash():
     """
     Get version from asv/__init__.py and generate asv/_version.py
@@ -71,7 +98,7 @@ def get_git_hash():
 
 def get_git_revision():
     """
-    Get the number of revisions since the last tag.
+    Get the number of revisions since the beginning.
     """
     revision = "0"
     if os.path.isdir(os.path.join(basedir, '.git')):
@@ -87,36 +114,24 @@ def get_git_revision():
     return revision
 
 
-def write_version_file(filename, version, revision):
+def write_version_file(filename, suffix, githash):
     # Write revision file (only if it needs to be changed)
-    content = '''
-__version__ = "{0}"
-__githash__ = "{1}"
-__release__ = {2}
-    '''.format(version, revision, 'dev' not in version)
+    content = ('__suffix__ = "{0}"\n'
+               '__githash__ = "{1}"\n'.format(suffix, githash))
+
+    if not githash.strip():
+        # Not in git repository; probably in sdist, so keep old
+        # version file
+        return
 
     old_content = None
     if os.path.isfile(filename):
         with open(filename, 'r') as f:
             old_content = f.read()
 
-        if 'dev' in version and not revision.strip():
-            # Dev version and Git revision not available. Probably
-            # running from an sdist, so assume the version file is up
-            # to date.
-            m = re.search(r'__version__ = "([0-9a-z+.-]*)"', old_content)
-            if m:
-                old_version = m.group(1)
-                prefix = version[:version.find('dev')]
-                if old_version.startswith(prefix):
-                    version = old_version
-                    content = old_content
-
     if content != old_content:
         with open(filename, 'w') as f:
             f.write(content)
-
-    return version
 
 
 class BuildFailed(Exception):
@@ -139,19 +154,17 @@ class optional_build_ext(build_ext):
 
 
 def run_setup(build_binary=False):
-    version = '0.3.dev'
-
+    version = get_version()
     git_hash = get_git_hash()
 
-    # Indicates if this version is a release version
-    release = 'dev' not in version
+    if version.endswith('.dev'):
+        suffix = '{0}+{1}'.format(get_git_revision(), git_hash[:8])
+        version += suffix
+    else:
+        suffix = ''
 
-    if not release:
-        version = '{0}{1}+{2}'.format(
-            version, get_git_revision(), git_hash[:8])
-
-    version = write_version_file(
-        os.path.join(basedir, 'asv', '_version.py'), version, git_hash)
+    write_version_file(os.path.join(basedir, 'asv', '_version.py'),
+                       suffix, git_hash)
 
     # Install entry points for making releases with zest.releaser
     entry_points = {}


### PR DESCRIPTION
Make the asv in the git repository importable without running setup.py,
and keep the master version number in __init__.py. Store only git
revision information in _version.py.