### PR TITLE
CI: use pytest-timeout

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -61,12 +61,12 @@ install:
     else
       $TRAVIS_PIP install virtualenv;
     fi
-    $TRAVIS_PIP install selenium six pytest feedparser python-hglib;
+    $TRAVIS_PIP install selenium six pytest pytest-timeout feedparser python-hglib;
     if [[ $COVERAGE != '' ]]; then $TRAVIS_PIP install pytest-cov coveralls; fi;
   - $TRAVIS_PYTHON setup.py build_ext -i
 
 script:
-  - $TRAVIS_PYTHON -m pytest $COVERAGE test
+  - $TRAVIS_PYTHON -m pytest --timeout=360 -l $COVERAGE test
 
 after_success:
   - if [[ $COVERAGE != '' ]]; then coveralls; fi

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -45,7 +45,7 @@ install:
     - "python --version"
 
     # Install specified version of dependencies
-    - "conda install -q --yes six pytest numpy"
+    - "conda install -q --yes six pip pytest pytest-timeout numpy"
 
     # In-place build
     - "%CMD_IN_ENV% python setup.py build_ext -i"
@@ -54,4 +54,4 @@ install:
 build: false
 
 test_script:
-    - "python -m pytest --tb=native --basetemp=%APPVEYOR_BUILD_FOLDER%\\tmp test"
+    - "python -m pytest --timeout=360 -l --basetemp=%APPVEYOR_BUILD_FOLDER%\\tmp test"

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -38,6 +38,7 @@ def _multiprocessing_raise_usererror(arg):
         raise util.ParallelFailure(str(exc), exc.__class__, traceback.format_exc())
 
 
+@pytest.mark.timeout(30)
 def test_parallelfailure():
     # Check the workaround for https://bugs.python.org/issue9400 works
 


### PR DESCRIPTION
Try to avoid appveyor hanging, by limiting test runtime.