### PR TITLE
BUG: make Conda set PYTHONNOUSERSITE=True to match virtualenv behavior

### DIFF
--- a/asv/plugins/conda.py
+++ b/asv/plugins/conda.py
@@ -156,3 +156,9 @@ class Conda(environment.Environment):
     def run(self, args, **kwargs):
         log.debug("Running '{0}' in {1}".format(' '.join(args), self.name))
         return self.run_executable('python', args, **kwargs)
+
+    def run_executable(self, executable, args, **kwargs):
+        # Conda doesn't guarantee that user site directories are excluded
+        kwargs["env"] = dict(kwargs.pop("env", os.environ),
+                             PYTHONNOUSERSITE=str("True"))
+        return super(Conda, self).run_executable(executable, args, **kwargs)

--- a/test/test_environment.py
+++ b/test/test_environment.py
@@ -568,3 +568,8 @@ def test_environment_environ_path(environment_type, tmpdir):
     output = env.run(['-c', 'import os; print(os.environ["PATH"])'])
     paths = output.strip().split(os.pathsep)
     assert os.path.commonprefix([paths[0], conf.env_dir]) == conf.env_dir
+
+    # Check user-site directory is not in sys.path
+    output = env.run(['-c', 'import site; print(site.ENABLE_USER_SITE)'])
+    usersite_in_syspath = output.strip()
+    assert usersite_in_syspath == "False"


### PR DESCRIPTION
Make the Conda environment more self-contained by disabling user-site
directories.  Virtualenv does this by itself.