### PR TITLE
TST: bump colorama versions in tests to match conda

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ matrix:
         - USE_CONDA=true
         - COVERAGE=--cov asv
 
-    - python: 3.5
+    - python: 3.6
       env: USE_CONDA=true
 
     - python: 2.7

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,7 +13,7 @@ environment:
       - PYTHON_VERSION: "2.7"
         platform: x64
         PYTHON_ARCH: "64"
-      - PYTHON_VERSION: "3.5"
+      - PYTHON_VERSION: "3.6"
         platform: x64
         PYTHON_ARCH: "64"
       - PYTHON_VERSION: "2.7"

--- a/test/test_environment.py
+++ b/test/test_environment.py
@@ -64,7 +64,7 @@ def test_matrix_environments(tmpdir):
     conf.pythons = ["2.7", "3.4"]
     conf.matrix = {
         "six": ["1.10", None],
-        "colorama": ["0.3.6", "0.3.7"]
+        "colorama": ["0.3.7", "0.3.9"]
     }
     environments = list(environment.get_environments(conf, None))
 
@@ -327,7 +327,7 @@ def test_conda_pip_install(tmpdir):
     conf.environment_type = "conda"
     conf.pythons = ["3.4"]
     conf.matrix = {
-        "pip+colorama": ["0.3.6"]
+        "pip+colorama": ["0.3.9"]
     }
     environments = list(environment.get_environments(conf, None))
 

--- a/test/test_workflow.py
+++ b/test/test_workflow.py
@@ -73,7 +73,7 @@ def basic_conf(tmpdir):
         'project': 'asv',
         'matrix': {
             "six": [""],
-            "colorama": ["0.3.6", "0.3.7"]
+            "colorama": ["0.3.7", "0.3.9"]
         }
     })
 
@@ -105,7 +105,7 @@ def test_run_publish(capfd, basic_conf):
 
     # Check parameterized test json data format
     filename = glob.glob(join(tmpdir, 'html', 'graphs', 'arch-x86_64', 'branch-master',
-                              'colorama-0.3.7',  'cpu-Blazingly fast', 'machine-orangutan',
+                              'colorama-0.3.9',  'cpu-Blazingly fast', 'machine-orangutan',
                               'os-GNU_Linux', 'python-*', 'ram-128GB',
                               'six', 'params_examples.time_skip.json'))[0]
     with open(filename, 'r') as fp:
@@ -231,7 +231,7 @@ def test_run_spec(basic_conf):
 
         expected = set(['machine.json'])
         for commit in expected_commits:
-            for psver in ['0.3.6', '0.3.7']:
+            for psver in ['0.3.7', '0.3.9']:
                 expected.add('{0}-{1}-py{2}-colorama{3}-six.json'.format(
                     commit[:8], tool_name, pyver, psver))
 


### PR DESCRIPTION
Bump package version in tests so that they work on conda + py3.6